### PR TITLE
Include available video qualities to metadata

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -141,7 +141,7 @@ module.exports = {
       metadata.publish_date = data.microformat.playerMicroformatRenderer.publishDate || 'N/A';
       metadata.upload_date = data.microformat.playerMicroformatRenderer.uploadDate || 'N/A';
       metadata.keywords = data.videoDetails.keywords || [];
-      metadata.available_qualities = [...new Set(data[2].playerResponse.streamingData.adaptiveFormats.filter(v => v.qualityLabel).map(v => v.qualityLabel).sort((a, b) => +a.replace(/\D/gi, "") - +b.replace(/\D/gi, "")))]
+      metadata.available_qualities = [...new Set(data.streamingData.adaptiveFormats.filter(v => v.qualityLabel).map(v => v.qualityLabel).sort((a, b) => +a.replace(/\D/gi, "") - +b.replace(/\D/gi, "")))]
 
       video_details.id = data.videoDetails.videoId;
       video_details.title = data.videoDetails.title;

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -141,6 +141,7 @@ module.exports = {
       metadata.publish_date = data.microformat.playerMicroformatRenderer.publishDate || 'N/A';
       metadata.upload_date = data.microformat.playerMicroformatRenderer.uploadDate || 'N/A';
       metadata.keywords = data.videoDetails.keywords || [];
+      metadata.available_qualities = [...new Set(data[2].playerResponse.streamingData.adaptiveFormats.filter(v => v.qualityLabel).map(v => v.qualityLabel).sort((a, b) => +a.replace(/\D/gi, "") - +b.replace(/\D/gi, "")))]
 
       video_details.id = data.videoDetails.videoId;
       video_details.title = data.videoDetails.title;
@@ -169,6 +170,7 @@ module.exports = {
       metadata.publish_date = data[2].playerResponse.microformat.playerMicroformatRenderer.publishDate;
       metadata.upload_date = data[2].playerResponse.microformat.playerMicroformatRenderer.uploadDate;
       metadata.keywords = data[2].playerResponse.videoDetails.keywords;
+      metadata.available_qualities = [...new Set(data[2].playerResponse.streamingData.adaptiveFormats.filter(v => v.qualityLabel).map(v => v.qualityLabel).sort((a, b) => +a.replace(/\D/gi, "") - +b.replace(/\D/gi, "")))]
 
       video_details.id = data[2].playerResponse.videoDetails.videoId;
       video_details.title = data[2].playerResponse.videoDetails.title;


### PR DESCRIPTION
The playerResponse streamingData adaptiveFormats are filtered to include only those which
include a qualityLabel. This array is then mapped to an array of qualityLabels and sorted
from lowest to highest quality. A Set is created then spread syntax is used to remove duplicates.