### PR TITLE
 fix(VideoInfo): Fix the problem that chooseFormat still returns empty, even though there are videos to adapt

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -82,7 +82,7 @@ async function start() {
   });
 
   stream.on('info', (info) => {
-    console.info('[DOWNLOADER]', `Downloading ${info.video_details.title} by ${info.video_details.metadata.channel_name}`);
+    console.info('[DOWNLOADER]', `Downloading ${info.title} by ${info.basic_info.channel.name}`);
   });
 
   stream.on('end', () => {

--- a/lib/parser/youtube/VideoInfo.js
+++ b/lib/parser/youtube/VideoInfo.js
@@ -266,8 +266,6 @@ class VideoInfo {
     const is_best = ['best','bestefficiency'].includes(options.quality);
     const use_most_efficient = options.quality !== 'best';
     let candidates = formats.filter(format => {
-      if (best_width < format.width) 
-        best_width = format.width;
       if (requires_audio && !format.has_audio) 
         return false;
       if (requires_video && !format.has_video) 
@@ -276,6 +274,8 @@ class VideoInfo {
         return false;
       if (!is_best && format.quality_label !== options.quality) 
         return false;
+      if (best_width < format.width) 
+        best_width = format.width;
       return true;
     });
 


### PR DESCRIPTION
# Pull Request Template

## Description

This commit is mainly to fix the best video format selection problem, when a video exists in 2160p format, it may not be in mp4 format, which causes the best_width to hit 4096, but this video format does not enter candidates.

Finally chooseFormat will return an undefined.

You can use the following video id to recreate the situation
``` javascript
// Downloading videos:
const stream = youtube.download("p--VpPCwp9Q", {
  format: 'mp4', // Optional, ignored when type is set to audio and defaults to mp4, and I recommend to leave it as it is
  quality: 'best', // if a video doesn't have a specific quality it'll fall back to 360p, this is ignored when type is set to audio
  type: 'video' // can be “video”, “audio” and “videoandaudio”
});
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings