### PR TITLE
fix(ytmusic): Multiple authors/artists

### DIFF
--- a/lib/parser/ytmusic/search/SongResultItem.js
+++ b/lib/parser/ytmusic/search/SongResultItem.js
@@ -7,15 +7,23 @@ class SongResultItem {
 
   static parseItem(item) {
     const list_item = item.musicResponsiveListItemRenderer;
-    if (list_item.playlistItemData) return {
-      id: list_item.playlistItemData.videoId,
-      title: list_item.flexColumns[0]?.musicResponsiveListItemFlexColumnRenderer.text.runs[0]?.text,
-      artist: list_item.flexColumns[1]?.musicResponsiveListItemFlexColumnRenderer.text.runs[2]?.text,
-      album: list_item.flexColumns[1]?.musicResponsiveListItemFlexColumnRenderer.text.runs[4]?.text,
-      duration: list_item.flexColumns[1]?.musicResponsiveListItemFlexColumnRenderer.text.runs
-      .find((run) => /^\d+$/.test(run.text.replace(/:/g, ''))).text,
-      thumbnails: list_item.thumbnail.musicThumbnailRenderer.thumbnail.thumbnails,
-    };
+    if (list_item.playlistItemData) {
+      let artists = list_item.flexColumns[1]?.musicResponsiveListItemFlexColumnRenderer.text.runs;
+      // Remove parts of array that just includes information that the item is a song
+      artists.splice(0,2);
+      // Remove parts of array that contains data like album and duration
+      const meta = artists.splice(artists.length - 4, 4);
+      // Keep only even parts of array, the odd ones are just a delimiter between artists (&)
+      artists = artists.filter((artist, index) => !(index % 2));
+      return {
+        id: list_item.playlistItemData.videoId,
+        title: list_item.flexColumns[0]?.musicResponsiveListItemFlexColumnRenderer.text.runs[0]?.text,
+        artist: artists.map((artist) => artist.text),
+        album: meta[1]?.text,
+        duration: meta[3]?.text,
+        thumbnails: list_item.thumbnail.musicThumbnailRenderer.thumbnail.thumbnails,
+      };
+    }
   }
 }
 

--- a/lib/parser/ytmusic/search/VideoResultItem.js
+++ b/lib/parser/ytmusic/search/VideoResultItem.js
@@ -7,15 +7,23 @@ class VideoResultItem {
   
   static parseItem(item) {
     const list_item = item.musicResponsiveListItemRenderer;
-    if (list_item.playlistItemData) return {
-      id: list_item.playlistItemData.videoId,
-      title: list_item.flexColumns[0]?.musicResponsiveListItemFlexColumnRenderer.text.runs[0]?.text,
-      author: list_item.flexColumns[1]?.musicResponsiveListItemFlexColumnRenderer.text.runs[2]?.text,
-      views: list_item.flexColumns[1]?.musicResponsiveListItemFlexColumnRenderer.text.runs[4]?.text,
-      duration: list_item.flexColumns[1]?.musicResponsiveListItemFlexColumnRenderer.text.runs
-      .find((run) => /^\d+$/.test(run.text.replace(/:/g, ''))).text,
-      thumbnails: list_item?.thumbnail.musicThumbnailRenderer.thumbnail.thumbnails,
-    };
+    if (list_item.playlistItemData) {
+      let authors = list_item.flexColumns[1]?.musicResponsiveListItemFlexColumnRenderer.text.runs;
+      // Remove parts of array that just includes information that the item is a video
+      authors.splice(0,2);
+      // Remove parts of array that contains data like number of views and duration
+      const meta = authors.splice(authors.length - 4, 4);
+      // Keep only even parts of array, the odd ones are just a delimiter between authors (&)
+      authors = authors.filter((author, index) => !(index % 2));
+      return {
+        id: list_item.playlistItemData.videoId,
+        title: list_item.flexColumns[0]?.musicResponsiveListItemFlexColumnRenderer.text.runs[0]?.text,
+        author: authors.map((author) => author.text),
+        views: meta[1]?.text,
+        duration: meta[3]?.text,
+        thumbnails: list_item?.thumbnail.musicThumbnailRenderer.thumbnail.thumbnails,
+      };
+    }
   }
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

When searching on YTMUSIC client, songs and videos are returned, but it's common that they can have more than one artist or author. For that reason, albums (or views) may show the second artist as their value.
I've fixed the code so artists/authors are returned as array of strings and albums/views are returned correctly.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings