### PR TITLE
feat(contents): Multiple video authors

### DIFF
--- a/lib/parser/contents/classes/MusicResponsiveListItem.js
+++ b/lib/parser/contents/classes/MusicResponsiveListItem.js
@@ -104,13 +104,13 @@ class MusicResponsiveListItem {
     this.views = this.#flex_columns[1].title.runs
       .find((run) => run.text.match(/(.*?) views/)).text;
           
-    const author = this.#flex_columns[1].title.runs.find((run) => run.endpoint.browse?.id.startsWith('UC'));
+    const authors = this.#flex_columns[1].title.runs?.filter((run) => run.endpoint.browse?.id.startsWith('UC'));
 
-    author && (this.author = {
+    authors && (this.authors = authors.map((author) => ({
       name: author.text,
       channel_id: author.endpoint.browse.id,
       endpoint: author.endpoint
-    });
+    }))) && (this.author = this.authors[0]);
     
     const duration_text = this.#flex_columns[1].title.runs
       .find((run) => /^\d+$/.test(run.text.replace(/:/g, '')))?.text;

--- a/typings/lib/parser/contents/classes/MusicResponsiveListItem.d.ts
+++ b/typings/lib/parser/contents/classes/MusicResponsiveListItem.d.ts
@@ -37,6 +37,11 @@ declare class MusicResponsiveListItem {
         channel_id: any;
         endpoint: any;
     };
+    authors: {
+        name: any;
+        channel_id: any;
+        endpoint: any;
+    }[];
     name: any;
     subscribers: any;
     year: any;


### PR DESCRIPTION
# Pull Request Template

## Description

I've extended my previous PR (#82) to the new parser. YT Music videos can also have multiple authors, so I added the `authors` key. However, I'm unsure about removing `author` - I kept it there, returning the first item of `authors`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings