### PR TITLE
feat: allow users to cache OAuth credentials

### DIFF
--- a/src/core/OAuth.ts
+++ b/src/core/OAuth.ts
@@ -48,9 +48,8 @@ class OAuth {
         credentials: this.#credentials,
         status: 'SUCCESS'
       });
-    }
-    else if (!(await this.#loadCachedCredentials())) {
-        await this.#getUserCode();
+    } else if (!(await this.#loadCachedCredentials())) {
+      await this.#getUserCode();
     }
   }
 
@@ -75,7 +74,7 @@ class OAuth {
       access_token: credentials.access_token,
       refresh_token: credentials.refresh_token,
       expires: new Date(credentials.expires)
-    }
+    };
     this.#session.emit('auth', {
       credentials: this.#credentials,
       status: 'SUCCESS'

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -64,8 +64,9 @@ export default class Session extends EventEmitterLike {
   http;
   logged_in;
   actions;
+  cache;
 
-  constructor(context: Context, api_key: string, api_version: string, player: Player, cookie?: string, fetch?: FetchFunction) {
+  constructor(context: Context, api_key: string, api_version: string, player: Player, cookie?: string, fetch?: FetchFunction, cache?: UniversalCache) {
     super();
     this.#context = context;
     this.#key = api_key;
@@ -75,6 +76,7 @@ export default class Session extends EventEmitterLike {
     this.actions = new Actions(this);
     this.oauth = new OAuth(this);
     this.logged_in = !!cookie;
+    this.cache = cache;
   }
 
   on(type: 'auth', listener: OAuthAuthEventHandler): void;
@@ -139,7 +141,7 @@ export default class Session extends EventEmitterLike {
 
   static async create(options: SessionOptions = {}) {
     const { context, api_key, api_version } = await Session.getSessionData(options.lang, options.device_category, options.client_type, options.timezone, options.fetch);
-    return new Session(context, api_key, api_version, await Player.create(options.cache, options.fetch), options.cookie, options.fetch);
+    return new Session(context, api_key, api_version, await Player.create(options.cache, options.fetch), options.cookie, options.fetch, options.cache);
   }
 
   static async getSessionData(


### PR DESCRIPTION
Use `UniversalCache` instance to cache user credentials

Opt-in via `OAuth#cacheCredentials()`. `OAuth#init()` will check the cache before starting the OAuth flow.