### PR TITLE
Misc fixes and additions

### DIFF
--- a/src/parser/classes/Grid.js
+++ b/src/parser/classes/Grid.js
@@ -11,6 +11,10 @@ class Grid extends YTNode {
     this.visible_row_count = data.visibleRowCount;
     this.target_id = data.targetId;
     this.continuation = data.continuations?.[0]?.nextContinuationData?.continuation || null;
+
+    if (data.header) {
+      this.header = Parser.parse(data.header);
+    }
   }
 
   // XXX: alias for consistency

--- a/src/parser/classes/GridHeader.ts
+++ b/src/parser/classes/GridHeader.ts
@@ -1,0 +1,15 @@
+import Text from './misc/Text';
+import { YTNode } from '../helpers';
+
+class GridHeader extends YTNode {
+  static type = 'GridHeader';
+
+  title: Text;
+
+  constructor(data: any) {
+    super();
+    this.title = new Text(data.title);
+  }
+}
+
+export default GridHeader;

--- a/src/parser/classes/MusicHeader.js
+++ b/src/parser/classes/MusicHeader.js
@@ -1,12 +1,20 @@
 import Parser from '../index';
 import { YTNode } from '../helpers';
+import Text from './misc/Text';
 
 class MusicHeader extends YTNode {
   static type = 'MusicHeader';
 
   constructor(data) {
     super();
-    this.header = Parser.parse(data.header);
+
+    if (data.header) {
+      this.header = Parser.parse(data.header);
+    }
+
+    if (data.title) {
+      this.title = new Text(data.title);
+    }
   }
 }
 

--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -52,7 +52,9 @@ class MusicResponsiveListItem extends YTNode {
   }[];
 
   name?: string;
+  subtitle?: Text;
   subscribers?: string;
+  song_count?: string;
   // TODO: these might be replaceable with Author class
   author?: {
     name: string,
@@ -186,7 +188,9 @@ class MusicResponsiveListItem extends YTNode {
   #parseArtist() {
     this.id = this.endpoint?.browse?.id;
     this.name = this.#flex_columns[0].key('title').instanceof(Text).toString();
-    this.subscribers = this.#flex_columns[1].key('title').instanceof(Text).runs?.[2]?.text || '';
+    this.subtitle = this.#flex_columns[1].key('title').instanceof(Text);  
+    this.subscribers = this.subtitle.runs?.find((run) => /^(\d*\.)?\d+[M|K]? subscribers?$/i.test(run.text))?.text || '';
+    this.song_count = this.subtitle.runs?.find((run) => /^\d+(,\d+)? songs?$/i.test(run.text))?.text || '';
   }
 
   #parseAlbum() {

--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -188,9 +188,9 @@ class MusicResponsiveListItem extends YTNode {
   #parseArtist() {
     this.id = this.endpoint?.browse?.id;
     this.name = this.#flex_columns[0].key('title').instanceof(Text).toString();
-    this.subtitle = this.#flex_columns[1].key('title').instanceof(Text);  
-    this.subscribers = this.subtitle.runs?.find((run) => /^(\d*\.)?\d+[M|K]? subscribers?$/i.test(run.text))?.text || '';
-    this.song_count = this.subtitle.runs?.find((run) => /^\d+(,\d+)? songs?$/i.test(run.text))?.text || '';
+    this.subtitle = this.#flex_columns[1].key('title').instanceof(Text);
+    this.subscribers = this.subtitle.runs?.find((run) => (/^(\d*\.)?\d+[M|K]? subscribers?$/i).test(run.text))?.text || '';
+    this.song_count = this.subtitle.runs?.find((run) => (/^\d+(,\d+)? songs?$/i).test(run.text))?.text || '';
   }
 
   #parseAlbum() {

--- a/src/parser/classes/MusicTwoRowItem.js
+++ b/src/parser/classes/MusicTwoRowItem.js
@@ -22,7 +22,7 @@ class MusicTwoRowItem extends YTNode {
     switch (this.endpoint?.browse?.page_type) {
       case 'MUSIC_PAGE_TYPE_ARTIST':
         this.item_type = 'artist';
-        this.subscribers = this.subtitle.toString();
+        this.subscribers = this.subtitle.runs?.find((run) => /^(\d*\.)?\d+[M|K]? subscribers?$/i.test(run.text))?.text || '';
         break;
       case 'MUSIC_PAGE_TYPE_PLAYLIST':
         this.item_type = 'playlist';

--- a/src/parser/classes/MusicTwoRowItem.js
+++ b/src/parser/classes/MusicTwoRowItem.js
@@ -22,7 +22,7 @@ class MusicTwoRowItem extends YTNode {
     switch (this.endpoint?.browse?.page_type) {
       case 'MUSIC_PAGE_TYPE_ARTIST':
         this.item_type = 'artist';
-        this.subscribers = this.subtitle.runs?.find((run) => /^(\d*\.)?\d+[M|K]? subscribers?$/i.test(run.text))?.text || '';
+        this.subscribers = this.subtitle.runs?.find((run) => (/^(\d*\.)?\d+[M|K]? subscribers?$/i).test(run.text))?.text || '';
         break;
       case 'MUSIC_PAGE_TYPE_PLAYLIST':
         this.item_type = 'playlist';

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -64,6 +64,7 @@ import { default as FeedFilterChipBar } from './classes/FeedFilterChipBar';
 import { default as FeedTabbedHeader } from './classes/FeedTabbedHeader';
 import { default as Grid } from './classes/Grid';
 import { default as GridChannel } from './classes/GridChannel';
+import { default as GridHeader } from './classes/GridHeader';
 import { default as GridPlaylist } from './classes/GridPlaylist';
 import { default as GridVideo } from './classes/GridVideo';
 import { default as HistorySuggestion } from './classes/HistorySuggestion';
@@ -303,6 +304,7 @@ const map: Record<string, YTNodeConstructor> = {
   FeedTabbedHeader,
   Grid,
   GridChannel,
+  GridHeader,
   GridPlaylist,
   GridVideo,
   HistorySuggestion,


### PR DESCRIPTION
#### `Grid` parser
- Parse and include `header` field, if available.

#### `MusicHeader` parser
- Parse and include `title` field, if available.

#### `MusicResponsiveListItem` and `MusicTwoRowItem` - *relating to artist-type items only*
- Add `subtitle` field to `MusicResponsiveListItem` for consistency with `MusicTwoRowItem`.
- Better parsing of `subscribers` value. It is usually available, but not always. If available, it is not always contained in `text.runs[2]`.
- Add `song_count` field, although it is usually unavailable (I can only see it in Library artists).