### PR TITLE
feat: improve parsing

### DIFF
--- a/src/parser/classes/MusicDetailHeader.js
+++ b/src/parser/classes/MusicDetailHeader.js
@@ -14,7 +14,7 @@ class MusicDetailHeader extends YTNode {
     this.second_subtitle = new Text(data.secondSubtitle);
     this.year = this.subtitle.runs.find((run) => (/^[12][0-9]{3}$/).test(run.text))?.text || null;
     this.song_count = this.second_subtitle.runs[0].text;
-    this.total_duration = this.second_subtitle.runs[2].text;
+    this.total_duration = this.second_subtitle.runs[2]?.text || '';
     this.thumbnails = Thumbnail.fromResponse(data.thumbnail.croppedSquareThumbnailRenderer.thumbnail);
     this.badges = Parser.parse(data.subtitleBadges);
 

--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -178,7 +178,8 @@ class MusicResponsiveListItem extends YTNode {
       }));
     }
 
-    const duration_text = this.#flex_columns[1].key('title').instanceof(Text).runs?.find((run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text;
+    const duration_text = this.#flex_columns[1].key('title').instanceof(Text).runs?.find((run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text ||
+      this.#fixed_columns[0]?.key('title').instanceof(Text).runs?.find((run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text;
     duration_text && (this.duration = {
       text: duration_text,
       seconds: timeToSeconds(duration_text)


### PR DESCRIPTION
2 minor commits:

1. In `MusicResponsiveListItem`, get video duration from `fixed_columns` if not found in `flex_columns`
2. In `MusicDetailHeader`, guard against parser from throwing error when `total_duration` is not available (such as when parsing header of "Your Likes" playlist which doesn't show duration info)