### PR TITLE
fix: playlist radios misidentified as videos

### DIFF
--- a/src/parser/classes/MusicTwoRowItem.ts
+++ b/src/parser/classes/MusicTwoRowItem.ts
@@ -54,31 +54,17 @@ class MusicTwoRowItem extends YTNode {
     switch (this.endpoint?.browse?.page_type) {
       case 'MUSIC_PAGE_TYPE_ARTIST':
         this.item_type = 'artist';
-        this.subscribers = this.subtitle.runs?.find((run) => (/^(\d*\.)?\d+[M|K]? subscribers?$/i).test(run.text))?.text || '';
         break;
       case 'MUSIC_PAGE_TYPE_PLAYLIST':
         this.item_type = 'playlist';
-
-        const item_count_run = this.subtitle.runs?.find((run) => run.text.match(/\d+ songs|song/));
-        this.item_count = item_count_run ? (item_count_run as TextRun).text : null;
-
         break;
       case 'MUSIC_PAGE_TYPE_ALBUM':
         this.item_type = 'album';
-        const artists = this.subtitle.runs?.filter((run: any) => run.endpoint?.browse?.id.startsWith('UC'));
-        if (artists) {
-          this.artists = artists.map((artist: any) => ({
-            name: artist.text,
-            channel_id: artist.endpoint.browse.id,
-            endpoint: artist.endpoint
-          }));
-        }
-        this.year = this.subtitle.runs?.slice(-1)[0].text;
-        if (isNaN(Number(this.year)))
-          delete this.year;
         break;
       default:
-        if (this.subtitle.runs?.[0]) {
+        if (this.endpoint?.watch_playlist) {
+          this.item_type = 'endpoint';
+        } else if (this.subtitle.runs?.[0]) {
           if (this.subtitle.runs[0].text !== 'Song') {
             this.item_type = 'video';
           } else {
@@ -89,29 +75,46 @@ class MusicTwoRowItem extends YTNode {
         } else {
           this.item_type = 'unknown';
         }
-
-        if (this.item_type == 'video') {
-          this.views = this?.subtitle.runs?.find((run) => run?.text.match(/(.*?) views/))?.text || 'N/A';
-
-          const author = this.subtitle.runs?.find((run: any) => run.endpoint?.browse?.id?.startsWith('UC'));
-          if (author) {
-            this.author = {
-              name: (author as TextRun)?.text,
-              channel_id: (author as TextRun)?.endpoint?.browse?.id,
-              endpoint: (author as TextRun)?.endpoint
-            };
-          }
-        } else if (this.item_type == 'song') {
-          const artists = this.subtitle.runs?.filter((run: any) => run.endpoint?.browse?.id.startsWith('UC'));
-          if (artists) {
-            this.artists = artists.map((artist: any) => ({
-              name: (artist as TextRun)?.text,
-              channel_id: (artist as TextRun)?.endpoint?.browse?.id,
-              endpoint: (artist as TextRun)?.endpoint
-            }));
-          }
-        }
         break;
+    }
+
+    if (this.item_type == 'artist') {
+      this.subscribers = this.subtitle.runs?.find((run) => (/^(\d*\.)?\d+[M|K]? subscribers?$/i).test(run.text))?.text || '';
+    } else if (this.item_type == 'playlist') {
+      const item_count_run = this.subtitle.runs?.find((run) => run.text.match(/\d+ songs|song/));
+      this.item_count = item_count_run ? (item_count_run as TextRun).text : null;
+    } else if (this.item_type == 'album') {
+      const artists = this.subtitle.runs?.filter((run: any) => run.endpoint?.browse?.id.startsWith('UC'));
+      if (artists) {
+        this.artists = artists.map((artist: any) => ({
+          name: artist.text,
+          channel_id: artist.endpoint.browse.id,
+          endpoint: artist.endpoint
+        }));
+      }
+      this.year = this.subtitle.runs?.slice(-1)[0].text;
+      if (isNaN(Number(this.year)))
+        delete this.year;
+    } else if (this.item_type == 'video') {
+      this.views = this?.subtitle.runs?.find((run) => run?.text.match(/(.*?) views/))?.text || 'N/A';
+
+      const author = this.subtitle.runs?.find((run: any) => run.endpoint?.browse?.id?.startsWith('UC'));
+      if (author) {
+        this.author = {
+          name: (author as TextRun)?.text,
+          channel_id: (author as TextRun)?.endpoint?.browse?.id,
+          endpoint: (author as TextRun)?.endpoint
+        };
+      }
+    } else if (this.item_type == 'song') {
+      const artists = this.subtitle.runs?.filter((run: any) => run.endpoint?.browse?.id.startsWith('UC'));
+      if (artists) {
+        this.artists = artists.map((artist: any) => ({
+          name: (artist as TextRun)?.text,
+          channel_id: (artist as TextRun)?.endpoint?.browse?.id,
+          endpoint: (artist as TextRun)?.endpoint
+        }));
+      }
     }
 
     this.thumbnail = Thumbnail.fromResponse(data.thumbnailRenderer.musicThumbnailRenderer.thumbnail);


### PR DESCRIPTION
Playlist radios are items (`MusicTwoRowItem`) that contain only a 'watch playlist' endpoint. I encountered them in the Home Feed of ytmusic. When a playlist radio is clicked, ytmusic starts playing from the playlist referred to by the watch endpoint. This PR fixes the situation where playlist radios are misidentified as videos.

Also a bit of refactoring done in the process to `MusicTwoRowItem`.