### PR TITLE
fix: captions should be a PlayerCaptionsTracklist

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -4,6 +4,7 @@ import GetParserByName from './map';
 import Endscreen from './classes/Endscreen';
 import CardCollection from './classes/CardCollection';
 import NavigationEndpoint from './classes/NavigationEndpoint';
+import PlayerCaptionsTracklist from './classes/PlayerCaptionsTracklist';
 
 import { InnertubeError, ParsingError } from '../utils/Utils';
 import { YTNode, YTNodeConstructor, SuperParsedResult, ObservedArray, observe, Memo } from './helpers';
@@ -257,8 +258,7 @@ export default class Parser {
         dls_manifest_url: data.streamingData?.dashManifestUrl || null
       } : undefined,
       current_video_endpoint: data.currentVideoEndpoint ? new NavigationEndpoint(data.currentVideoEndpoint) : null,
-      // TODO: PlayerCaptionsTracklist ?
-      captions: Parser.parse(data.captions),
+      captions: Parser.parseItem<PlayerCaptionsTracklist>(data.captions, PlayerCaptionsTracklist),
       video_details: data.videoDetails ? new VideoDetails(data.videoDetails) : undefined,
       // TODO: might want to type check these two and use parseItem
       annotations: Parser.parse(data.annotations),

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -58,6 +58,23 @@ describe('YouTube.js Tests', () => {
       expect(thread.replies.length).toBeLessThanOrEqual(10);
     });
   });
+
+  describe('Info', () => {
+    it('should retrieve full video info', async () => {
+      const info = await yt.getInfo(VIDEOS[0].ID);
+      expect(info.basic_info.id).toBe(VIDEOS[0].ID);
+    });
+
+    it('should have captions on full video info', async () => {
+      const info = await yt.getInfo(VIDEOS[0].ID);
+      expect(info.captions?.caption_tracks.length).toBeGreaterThan(0);
+    });
+
+    it('should retrieve basic video info', async () => {
+      const info = await yt.getBasicInfo(VIDEOS[0].ID);
+      expect(info.basic_info.id).toBe(VIDEOS[0].ID);
+    });
+  });
   
   describe('General', () => {
     it('should retrieve playlist with YouTube', async () => {
@@ -78,17 +95,7 @@ describe('YouTube.js Tests', () => {
     it('should retrieve trending content', async () => {
       const trending = await yt.getTrending();
       expect(trending.videos.length).toBeGreaterThan(0);
-    }); 
-    
-    it('should retrieve full video info', async () => {
-      const info = await yt.getInfo(VIDEOS[0].ID);
-      expect(info.basic_info.id).toBe(VIDEOS[0].ID);
     });
-    
-    it('should retrieve basic video info', async () => {
-      const info = await yt.getBasicInfo(VIDEOS[0].ID);
-      expect(info.basic_info.id).toBe(VIDEOS[0].ID);
-    }); 
     
     it('should download video', async () => {
       const result = await download(VIDEOS[1].ID, yt);


### PR DESCRIPTION
# Pull Request Template

## Description
video info captions is an empty SuperParsedResult, it should be a PlayerCaptionsTracklist in order to parse properly.

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A ] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings