### PR TITLE
Add `end_icons` to `MusicCarouselShelfBasicHeader` and fix `music#getPlaylist()`

### DIFF
--- a/src/core/Music.ts
+++ b/src/core/Music.ts
@@ -113,7 +113,10 @@ class Music {
   async getPlaylist(playlist_id: string) {
     throwIfMissing({ playlist_id });
 
-    const response = await this.#actions.browse(`VL${playlist_id.replace(/VL/g, '')}`, { client: 'YTMUSIC' });
+    if (!playlist_id.startsWith('VL')) {
+      playlist_id = `VL${playlist_id}`;
+    }
+    const response = await this.#actions.browse(playlist_id, { client: 'YTMUSIC' });
     return new Playlist(response, this.#actions);
   }
 

--- a/src/parser/classes/IconLink.ts
+++ b/src/parser/classes/IconLink.ts
@@ -1,0 +1,25 @@
+import Text from './misc/Text';
+import { YTNode } from '../helpers';
+import NavigationEndpoint from './NavigationEndpoint';
+
+class IconLink extends YTNode {
+  static type = 'IconLink';
+
+  icon_type: string;
+  tooltip?: string;
+  endpoint: NavigationEndpoint;
+
+  constructor(data: any) {
+    super();
+
+    this.icon_type = data.icon?.iconType;
+
+    if (data.tooltip) {
+      this.tooltip = new Text(data.tooltip).toString();
+    }
+
+    this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
+  }
+}
+
+export default IconLink;

--- a/src/parser/classes/MusicCarouselShelfBasicHeader.ts
+++ b/src/parser/classes/MusicCarouselShelfBasicHeader.ts
@@ -3,6 +3,7 @@ import { YTNode } from '../helpers';
 import MusicThumbnail from './MusicThumbnail';
 import Parser from '..';
 import Button from './Button';
+import IconLink from './IconLink';
 
 class MusicCarouselShelfBasicHeader extends YTNode {
   static type = 'MusicCarouselShelfBasicHeader';
@@ -11,6 +12,7 @@ class MusicCarouselShelfBasicHeader extends YTNode {
   title: Text;
   thumbnail?: MusicThumbnail | null;
   more_content?: Button | null;
+  end_icons?: Array<IconLink>;
 
   constructor(data: any) {
     super();
@@ -28,6 +30,10 @@ class MusicCarouselShelfBasicHeader extends YTNode {
 
     if (data.moreContentButton) {
       this.more_content = Parser.parseItem<Button>(data.moreContentButton, Button);
+    }
+
+    if (data.endIcons) {
+      this.end_icons = Parser.parseArray<IconLink>(data.endIcons, IconLink);
     }
   }
 }

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -70,6 +70,7 @@ import { default as GridVideo } from './classes/GridVideo';
 import { default as HistorySuggestion } from './classes/HistorySuggestion';
 import { default as HorizontalCardList } from './classes/HorizontalCardList';
 import { default as HorizontalList } from './classes/HorizontalList';
+import { default as IconLink } from './classes/IconLink';
 import { default as ItemSection } from './classes/ItemSection';
 import { default as ItemSectionHeader } from './classes/ItemSectionHeader';
 import { default as ItemSectionTab } from './classes/ItemSectionTab';
@@ -310,6 +311,7 @@ const map: Record<string, YTNodeConstructor> = {
   HistorySuggestion,
   HorizontalCardList,
   HorizontalList,
+  IconLink,
   ItemSection,
   ItemSectionHeader,
   ItemSectionTab,


### PR DESCRIPTION
2 commits:

1. Add `end_icons` field to `MusicCarouselShelfBasicHeader` (array of `IconLink` - similar to `Button` with endpoint).
2. Fix `music#getPlaylist()`. The current implementation strips *all* occurrences of 'VL' from `playlist_id` and then adds one to the beginning. This breaks fetching for `playlist_id` that contains 'VL' not at the beginning, but somewhere after that.