### PR TITLE
Fix token refining. Adding replace where breaking on JSON.parse

### DIFF
--- a/lib/utils/Utils.js
+++ b/lib/utils/Utils.js
@@ -120,7 +120,7 @@ function refineNTokenData(data) {
   return data
     .replace(/function\(d,e\)/g, '"function(d,e)').replace(/function\(d\)/g, '"function(d)')
     .replace(/function\(\)/g, '"function()').replace(/function\(d,e,f\)/g, '"function(d,e,f)')
-    .replace(/\[function\(d,e,f\)/g, '["function(d,e,f)').replace(/,b,/g, ',"b",')
+    .replace(/\[function\(d,e,f\)/g, '["function(d,e,f)').replace(/,b,/g, ',"b",').replace(/,function/g, ',"function')
     .replace(/,b/g, ',"b"').replace(/b,/g, '"b",').replace(/b]/g, '"b"]')
     .replace(/\[b/g, '["b"').replace(/}]/g, '"]').replace(/},/g, '}",')
     .replace(/""/g, '').replace(/length]\)}"/g, 'length])}');


### PR DESCRIPTION
NToken.js@#getTrasnformationData was throwing errors when trying to download videos. I traced it to Utils.js@refineNTokenData and added a replace() to get the string to JSON.parse correctly 👍🏼 

Fixes # (issue)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)