### PR TITLE
feat: add `MusicSortFilterButton`

### DIFF
--- a/src/core/Actions.ts
+++ b/src/core/Actions.ts
@@ -6,9 +6,10 @@ import Parser, { ParsedResponse } from '../parser/index';
 import { hasKeys, InnertubeError, MissingParamError, uuidv4 } from '../utils/Utils';
 
 export interface BrowseArgs {
-  params?: string;
+  params?: string | null;
   is_ytm?: boolean;
   is_ctoken?: boolean;
+  form_data?: {};
   client?: string;
 }
 
@@ -92,6 +93,10 @@ class Actions {
       data.continuation = id;
     } else {
       data.browseId = id;
+    }
+
+    if (args.form_data) {
+      data.formData = args.form_data;
     }
 
     if (args.client) {

--- a/src/parser/classes/MusicDetailHeader.ts
+++ b/src/parser/classes/MusicDetailHeader.ts
@@ -19,7 +19,7 @@ class MusicDetailHeader extends YTNode {
   badges;
   author?: {
     name: string;
-    channel_id: string;
+    channel_id: string | undefined;
     endpoint: NavigationEndpoint | undefined;
   };
   menu;

--- a/src/parser/classes/MusicShelf.ts
+++ b/src/parser/classes/MusicShelf.ts
@@ -13,6 +13,7 @@ class MusicShelf extends YTNode {
   endpoint: NavigationEndpoint | null;
   continuation: string | null;
   bottom_text: Text | null;
+  subheaders?: Array<any>;
 
   constructor(data: any) {
     super();
@@ -24,6 +25,9 @@ class MusicShelf extends YTNode {
       data.continuations?.[0].nextContinuationData?.continuation ||
       data.continuations?.[0].reloadContinuationData?.continuation || null;
     this.bottom_text = Reflect.has(data, 'bottomText') ? new Text(data.bottomText) : null;
+    if (data.subheaders) {
+      this.subheaders = Parser.parseArray(data.subheaders);
+    }
   }
 }
 

--- a/src/parser/classes/MusicSideAlignedItem.ts
+++ b/src/parser/classes/MusicSideAlignedItem.ts
@@ -1,0 +1,19 @@
+import Parser from '../index';
+
+import { YTNode } from '../helpers';
+
+class MusicSideAlignedItem extends YTNode {
+  static type = 'MusicSideAlignedItem';
+
+  start_items?;
+
+  constructor(data: any) {
+    super();
+
+    if (data.startItems) {
+      this.start_items = Parser.parseArray(data.startItems);
+    }
+  }
+}
+
+export default MusicSideAlignedItem;

--- a/src/parser/classes/MusicSortFilterButton.ts
+++ b/src/parser/classes/MusicSortFilterButton.ts
@@ -1,0 +1,23 @@
+import Parser from '../index';
+
+import { YTNode } from '../helpers';
+import MusicMultiSelectMenu from './menus/MusicMultiSelectMenu';
+import Text from './misc/Text';
+
+class MusicSortFilterButton extends YTNode {
+  static type = 'MusicSortFilterButton';
+
+  title: string;
+  icon_type: string;
+  menu: MusicMultiSelectMenu | null;
+
+  constructor(data: any) {
+    super();
+
+    this.title = new Text(data.title).text;
+    this.icon_type = data.icon?.icon_type || null;
+    this.menu = Parser.parseItem(data.menu, MusicMultiSelectMenu);
+  }
+}
+
+export default MusicSortFilterButton;

--- a/src/parser/classes/MusicTwoRowItem.ts
+++ b/src/parser/classes/MusicTwoRowItem.ts
@@ -25,13 +25,13 @@ class MusicTwoRowItem extends YTNode {
 
   artists?: {
     name: string;
-    channel_id: string;
+    channel_id: string | undefined;
     endpoint: NavigationEndpoint | undefined;
   }[];
 
   author?: {
     name: string;
-    channel_id: string;
+    channel_id: string | undefined;
     endpoint: NavigationEndpoint | undefined;
   };
 

--- a/src/parser/classes/NavigationEndpoint.ts
+++ b/src/parser/classes/NavigationEndpoint.ts
@@ -18,7 +18,13 @@ class NavigationEndpoint extends YTNode {
   };
 
   // TODO: these should be given proper types, currently infered
-  browse;
+  browse?: {
+    id: string,
+    params: string | null,
+    base_url: string | null,
+    page_type: string | null,
+    form_data?: {}
+  };
   watch;
   search;
   subscribe;

--- a/src/parser/classes/menus/MusicMenuItemDivider.ts
+++ b/src/parser/classes/menus/MusicMenuItemDivider.ts
@@ -1,0 +1,12 @@
+import { YTNode } from '../../helpers';
+
+class MusicMenuItemDivider extends YTNode {
+  static type = 'MusicMenuItemDivider';
+
+  // eslint-disable-next-line
+  constructor(data: any) {
+    super();
+  }
+}
+
+export default MusicMenuItemDivider;

--- a/src/parser/classes/menus/MusicMultiSelectMenu.ts
+++ b/src/parser/classes/menus/MusicMultiSelectMenu.ts
@@ -1,0 +1,21 @@
+import MusicMultiSelectMenuItem from './MusicMultiSelectMenuItem';
+import MusicMenuItemDivider from './MusicMenuItemDivider';
+import { YTNode } from '../../helpers';
+import Text from '../misc/Text';
+import Parser from '../..';
+
+class MusicMultiSelectMenu extends YTNode {
+  static type = 'MusicMultiSelectMenu';
+
+  title: string;
+  options: Array<MusicMultiSelectMenuItem | MusicMenuItemDivider>;
+
+  constructor(data: any) {
+    super();
+
+    this.title = new Text(data.title.musicMenuTitleRenderer?.primaryText).text;
+    this.options = Parser.parseArray(data.options, [ MusicMultiSelectMenuItem, MusicMenuItemDivider ]);
+  }
+}
+
+export default MusicMultiSelectMenu;

--- a/src/parser/classes/menus/MusicMultiSelectMenuItem.ts
+++ b/src/parser/classes/menus/MusicMultiSelectMenuItem.ts
@@ -1,0 +1,37 @@
+import { YTNode } from '../../helpers';
+import Text from '../misc/Text';
+import NavigationEndpoint from '../NavigationEndpoint';
+
+class MusicMultiSelectMenuItem extends YTNode {
+  static type = 'MusicMultiSelectMenuItem';
+
+  title: string;
+  form_item_entity_key: string;
+  selected_icon_type: string;
+  endpoint?: NavigationEndpoint;
+  selected: boolean;
+
+  constructor(data: any) {
+    super();
+
+    this.title = new Text(data.title).text;
+    this.form_item_entity_key = data.formItemEntityKey;
+    this.selected_icon_type = data.selectedIcon?.iconType || null;
+    const command = data.selectedCommand?.commandExecutorCommand?.commands?.find((command: any) => command.musicBrowseFormBinderCommand?.browseEndpoint);
+    if (command) {
+      /**
+       * At this point, endpoint will still be missing `form_data` field which is required for
+       * selection to take effect. This can only be obtained from the response data which
+       * we don't have here. We shall delegate this task back to `Parser`.
+       */
+      this.endpoint = new NavigationEndpoint(command.musicBrowseFormBinderCommand);
+    }
+    /**
+     * Inferring selected state from existence of endpoint. `Parser` shall
+     * update this with the definitive value obtained from response data.
+     */
+    this.selected = !!this.endpoint;
+  }
+}
+
+export default MusicMultiSelectMenuItem;

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -120,6 +120,9 @@ import { default as MenuServiceItem } from './classes/menus/MenuServiceItem';
 import { default as MenuServiceItemDownload } from './classes/menus/MenuServiceItemDownload';
 import { default as MultiPageMenu } from './classes/menus/MultiPageMenu';
 import { default as MultiPageMenuNotificationSection } from './classes/menus/MultiPageMenuNotificationSection';
+import { default as MusicMenuItemDivider } from './classes/menus/MusicMenuItemDivider';
+import { default as MusicMultiSelectMenu } from './classes/menus/MusicMultiSelectMenu';
+import { default as MusicMultiSelectMenuItem } from './classes/menus/MusicMultiSelectMenuItem';
 import { default as SimpleMenuHeader } from './classes/menus/SimpleMenuHeader';
 import { default as MerchandiseItem } from './classes/MerchandiseItem';
 import { default as MerchandiseShelf } from './classes/MerchandiseShelf';
@@ -149,6 +152,8 @@ import { default as MusicResponsiveListItem } from './classes/MusicResponsiveLis
 import { default as MusicResponsiveListItemFixedColumn } from './classes/MusicResponsiveListItemFixedColumn';
 import { default as MusicResponsiveListItemFlexColumn } from './classes/MusicResponsiveListItemFlexColumn';
 import { default as MusicShelf } from './classes/MusicShelf';
+import { default as MusicSideAlignedItem } from './classes/MusicSideAlignedItem';
+import { default as MusicSortFilterButton } from './classes/MusicSortFilterButton';
 import { default as MusicThumbnail } from './classes/MusicThumbnail';
 import { default as MusicTwoRowItem } from './classes/MusicTwoRowItem';
 import { default as NavigationEndpoint } from './classes/NavigationEndpoint';
@@ -364,6 +369,9 @@ const map: Record<string, YTNodeConstructor> = {
   MenuServiceItemDownload,
   MultiPageMenu,
   MultiPageMenuNotificationSection,
+  MusicMenuItemDivider,
+  MusicMultiSelectMenu,
+  MusicMultiSelectMenuItem,
   SimpleMenuHeader,
   MerchandiseItem,
   MerchandiseShelf,
@@ -393,6 +401,8 @@ const map: Record<string, YTNodeConstructor> = {
   MusicResponsiveListItemFixedColumn,
   MusicResponsiveListItemFlexColumn,
   MusicShelf,
+  MusicSideAlignedItem,
+  MusicSortFilterButton,
   MusicThumbnail,
   MusicTwoRowItem,
   NavigationEndpoint,


### PR DESCRIPTION
A `MusicSortFilterButton` pulls up a menu much like a dropdown. Example of one is the country selector found on YouTube Music -> Explore -> Charts. The following code illustrates usage of `MusicSortFilterButton`:

```
// Endpoint for YouTube Music Charts page
const endpoint = new NavigationEndpoint({
  browseEndpoint: {
    browseId: 'FEmusic_charts'
  }
});

const fetchAndPrint = async (endpoint) => {
  console.log('Fetching Charts...')
  const response = await endpoint.call(youtube.actions, 'YTMUSIC');
  const page = Parser.parseResponse(response.data);
  const sections = page.contents_memo.getType(SectionList)?.[0]?.contents?.array() || [];
  console.log('Got the following sections:');
  console.log(JSON.stringify(sections));
  return page;
}

const page = await fetchAndPrint(endpoint);

// The Charts page shows a country selector, which is a MusicSortFilterButton.
// For convenience sake, we will just get it from the page's `contents_memo`.

const countrySelector = page.contents_memo.getType(MusicSortFilterButton)?.[0];

if (countrySelector) {
  // Get the currently selected option

  const selectedIndex = countrySelector.menu.options.findIndex((item) => item.selected);
  const selectedCountry = countrySelector.menu.options[selectedIndex];
  console.log('Currently selected country is: ' + selectedCountry.title);

  // Randomly select an option. Note the conditional check for item type, since an item 
  // in `MusicSortFilterButton.menu.options` can either be a `MusicMultiSelectMenuItem`
  // or `MusicMenuItemDivider`. `MusicMultiSelectMenuItem` is the one we are interested
  // in, since it contains the endpoint for getting updated content.

  const randomCountry = countrySelector.menu.options.find(
    (item, index) => item.type === 'MusicMultiSelectMenuItem' &&
      Math.random() > 0.5 && index !== selectedIndex); // Hey, what are the chances of random() always < 0.5 :)

  if (randomCountry) {
    console.log('Let\'s change country to: ' + randomCountry.title);
    await fetchAndPrint(randomCountry.endpoint);  // Charts page with randomCountry selected
  }
}
```

As far as coding is concerned, implementation of `MusicSortFilterButton` requires mutations data from `response.data`, which is not available within the parser. This is therefore done in the `Parser` class after `MusicSortFilterButton` has been constructed. See `Parser#applyMutations()`. I do not know if this deviates from the coding guidelines of the library, but I cannot think of a more appropriate way to do it...
