### PR TITLE
Fix `music#library.getArtists()` and add `MusicShelf.bottom_button`

### DIFF
--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -86,10 +86,13 @@ class MusicResponsiveListItem extends YTNode {
         this.#parsePlaylist();
         break;
       case 'MUSIC_PAGE_TYPE_ARTIST':
-      case 'MUSIC_PAGE_TYPE_LIBRARY_ARTIST':
       case 'MUSIC_PAGE_TYPE_USER_CHANNEL':
         this.item_type = 'artist';
         this.#parseArtist();
+        break;
+      case 'MUSIC_PAGE_TYPE_LIBRARY_ARTIST':
+        this.item_type = 'library_artist';
+        this.#parseLibraryArtist();
         break;
       default:
         if (this.#flex_columns[1]) {
@@ -191,7 +194,12 @@ class MusicResponsiveListItem extends YTNode {
     this.name = this.#flex_columns[0].key('title').instanceof(Text).toString();
     this.subtitle = this.#flex_columns[1].key('title').instanceof(Text);
     this.subscribers = this.subtitle.runs?.find((run) => (/^(\d*\.)?\d+[M|K]? subscribers?$/i).test(run.text))?.text || '';
-    this.song_count = this.subtitle.runs?.find((run) => (/^\d+(,\d+)? songs?$/i).test(run.text))?.text || '';
+  }
+
+  #parseLibraryArtist() {
+    this.name = this.#flex_columns[0].key('title').instanceof(Text).toString();
+    this.subtitle = this.#flex_columns[1].key('title').instanceof(Text);
+    this.song_count = this.subtitle?.runs?.find((run) => (/^\d+(,\d+)? songs?$/i).test(run.text))?.text || '';
   }
 
   #parseAlbum() {

--- a/src/parser/classes/MusicShelf.ts
+++ b/src/parser/classes/MusicShelf.ts
@@ -4,6 +4,7 @@ import NavigationEndpoint from './NavigationEndpoint';
 import MusicResponsiveListItem from './MusicResponsiveListItem';
 
 import { YTNode } from '../helpers';
+import Button from './Button';
 
 class MusicShelf extends YTNode {
   static type = 'MusicShelf';
@@ -13,6 +14,7 @@ class MusicShelf extends YTNode {
   endpoint: NavigationEndpoint | null;
   continuation: string | null;
   bottom_text: Text | null;
+  bottom_button?: Button | null;
 
   constructor(data: any) {
     super();
@@ -23,7 +25,8 @@ class MusicShelf extends YTNode {
     this.continuation =
       data.continuations?.[0].nextContinuationData?.continuation ||
       data.continuations?.[0].reloadContinuationData?.continuation || null;
-    this.bottom_text = Reflect.has(data, 'bottomText') ? new Text(data.bottomText) : null;
+    this.bottom_text = Reflect.has(data, 'bottomText') ? new Text(data.bottomText) : null;   
+    this.bottom_button = Parser.parseItem(data.bottomButton, Button);
   }
 }
 

--- a/src/parser/classes/MusicShelf.ts
+++ b/src/parser/classes/MusicShelf.ts
@@ -25,7 +25,7 @@ class MusicShelf extends YTNode {
     this.continuation =
       data.continuations?.[0].nextContinuationData?.continuation ||
       data.continuations?.[0].reloadContinuationData?.continuation || null;
-    this.bottom_text = Reflect.has(data, 'bottomText') ? new Text(data.bottomText) : null;   
+    this.bottom_text = Reflect.has(data, 'bottomText') ? new Text(data.bottomText) : null;
     this.bottom_button = Parser.parseItem(data.bottomButton, Button);
   }
 }

--- a/src/parser/classes/MusicTwoRowItem.ts
+++ b/src/parser/classes/MusicTwoRowItem.ts
@@ -25,13 +25,13 @@ class MusicTwoRowItem extends YTNode {
 
   artists?: {
     name: string;
-    channel_id: string;
+    channel_id: string | undefined;
     endpoint: NavigationEndpoint | undefined;
   }[];
 
   author?: {
     name: string;
-    channel_id: string;
+    channel_id: string | undefined;
     endpoint: NavigationEndpoint | undefined;
   };
 

--- a/src/parser/ytmusic/Library.ts
+++ b/src/parser/ytmusic/Library.ts
@@ -103,7 +103,7 @@ class Library {
    * Retrieves the library's artists
    */
   async getArtists(args?: { sort_by?: SortBy }) {
-    const data = await this.#fetchAndParseTabContents(this.#getBrowseId('artists'), (item) => item.item_type === 'artist');
+    const data = await this.#fetchAndParseTabContents(this.#getBrowseId('artists'), (item) => item.item_type === 'library_artist');
     const sort_by = args?.sort_by || null;
     return sort_by ? this.#applySortBy(data, sort_by) : data;
   }


### PR DESCRIPTION
Kind of fixes #143 by returning items with `item_type` of  'library_artist'  instead of 'artist'. Items of this type have an `endpoint` that leads to a page listing of the artist's songs (equivalent to clicking an artist in Library -> Artists). I think, at this stage, it would have to be up to the user to call the endpoint to obtain further content, including the artist's channel_id. I am however open to ideas on how this part can be better presented to the user.

PR also adds `bottom_button` to `MusicShelf`. If you follow the endpoint of a library artist, you will see one such button with the 'See All By Artist' text.