### PR TITLE
feat: add settings page parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       "license": "MIT",
       "dependencies": {
         "@protobuf-ts/runtime": "^2.7.0",
-        "flat": "^5.0.2",
         "linkedom": "^0.14.12",
         "undici": "^5.7.0"
       },
@@ -2912,14 +2911,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "bin": {
-        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -7404,11 +7395,6 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
-    },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
     },
     "flat-cache": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "license": "MIT",
   "dependencies": {
     "@protobuf-ts/runtime": "^2.7.0",
-    "flat": "^5.0.2",
     "linkedom": "^0.14.12",
     "undici": "^5.7.0"
   },

--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -9,6 +9,10 @@ import History from './parser/youtube/History';
 import Comments from './parser/youtube/Comments';
 import NotificationsMenu from './parser/youtube/NotificationsMenu';
 import VideoInfo, { DownloadOptions, FormatOptions } from './parser/youtube/VideoInfo';
+import NavigationEndpoint from './parser/classes/NavigationEndpoint';
+
+import { ParsedResponse } from './parser';
+import { ActionsResponse } from './core/Actions';
 
 import Feed from './core/Feed';
 import YTMusic from './core/Music';
@@ -250,6 +254,12 @@ class Innertube {
     throwIfMissing({ video_id });
     const info = await this.getBasicInfo(video_id);
     return info.download(options);
+  }
+
+  call(endpoint: NavigationEndpoint, args: { [ key: string ]: any; parse: true }): Promise<ParsedResponse>;
+  call(endpoint: NavigationEndpoint, args?: { [ key: string ]: any; parse?: false }): Promise<ActionsResponse>;
+  call(endpoint: NavigationEndpoint, args?: object): Promise<ActionsResponse | ParsedResponse> {
+    return endpoint.callTest(this.actions, args);
   }
 }
 

--- a/src/core/AccountManager.ts
+++ b/src/core/AccountManager.ts
@@ -9,8 +9,7 @@ import Settings from '../parser/youtube/Settings';
 class AccountManager {
   #actions;
   channel;
-  settings;
-
+  
   constructor(actions: Actions) {
     this.#actions = actions;
 

--- a/src/core/AccountManager.ts
+++ b/src/core/AccountManager.ts
@@ -1,11 +1,10 @@
 import Proto from '../proto/index';
 import Actions from './Actions';
-import Constants from '../utils/Constants';
-import { throwIfMissing, findNode } from '../utils/Utils';
 
 import Analytics from '../parser/youtube/Analytics';
 import TimeWatched from '../parser/youtube/TimeWatched';
 import AccountInfo from '../parser/youtube/AccountInfo';
+import Settings from '../parser/youtube/Settings';
 
 class AccountManager {
   #actions;
@@ -30,84 +29,6 @@ class AccountManager {
        */
       getBasicAnalytics: () => this.getAnalytics()
     };
-
-    this.settings = {
-      notifications: {
-        /**
-         * Notify about activity from the channels you're subscribed to.
-         * @param option - ON | OFF
-         */
-        setSubscriptions: (option: boolean) => this.#setSetting(Constants.ACCOUNT_SETTINGS.SUBSCRIPTIONS, 'SPaccount_notifications', option),
-        /**
-         * Recommended content notifications.
-         * @param option - ON | OFF
-         */
-        setRecommendedVideos: (option: boolean) => this.#setSetting(Constants.ACCOUNT_SETTINGS.RECOMMENDED_VIDEOS, 'SPaccount_notifications', option),
-        /**
-         * Notify about activity on your channel.
-         * @param option - ON | OFF
-         */
-        setChannelActivity: (option: boolean) => this.#setSetting(Constants.ACCOUNT_SETTINGS.CHANNEL_ACTIVITY, 'SPaccount_notifications', option),
-        /**
-         * Notify about replies to your comments.
-         * @param option - ON | OFF
-         */
-        setCommentReplies: (option: boolean) => this.#setSetting(Constants.ACCOUNT_SETTINGS.COMMENT_REPLIES, 'SPaccount_notifications', option),
-        /**
-         * Notify when others mention your channel.
-         * @param option - ON | OFF
-         */
-        setMentions: (option: boolean) => this.#setSetting(Constants.ACCOUNT_SETTINGS.USER_MENTION, 'SPaccount_notifications', option),
-        /**
-         * Notify when others share your content on their channels.
-         * @param option - ON | OFF
-         */
-        setSharedContent: (option: boolean) => this.#setSetting(Constants.ACCOUNT_SETTINGS.SHARED_CONTENT, 'SPaccount_notifications', option)
-      },
-      privacy: {
-        /**
-         * If set to true, your subscriptions won't be visible to others.
-         * @param option - ON | OFF
-         */
-        setSubscriptionsPrivate: (option: boolean) => this.#setSetting(Constants.ACCOUNT_SETTINGS.SUBSCRIPTIONS_PRIVACY, 'SPaccount_privacy', option),
-        /**
-         * If set to true, saved playlists won't appear on your channel.
-         * @param option - ON | OFF
-         */
-        setSavedPlaylistsPrivate: (option: boolean) => this.#setSetting(Constants.ACCOUNT_SETTINGS.PLAYLISTS_PRIVACY, 'SPaccount_privacy', option)
-      }
-    };
-  }
-
-  /**
-   * Internal method to perform changes on an account's settings.
-   */
-  async #setSetting(setting_id: string, type: string, new_value: boolean) {
-    throwIfMissing({ setting_id, type, new_value });
-
-    const response = await this.#actions.browse(type);
-
-    const contents = (() => {
-      switch (type.trim()) {
-        case 'SPaccount_notifications':
-          return findNode(response.data, 'contents', 'Your preferences', 13, false).options;
-        case 'SPaccount_privacy':
-          return findNode(response.data, 'contents', 'settingsSwitchRenderer', 13, false).options;
-        default:
-          // This is just for maximum compatibility, this is most definitely a bad way to handle this
-          throw new TypeError('undefined is not a function');
-      }
-    })();
-
-    const option = contents.find((option: any) => option.settingsSwitchRenderer.enableServiceEndpoint.setSettingEndpoint.settingItemIdForClient == setting_id);
-    const setting_item_id = option.settingsSwitchRenderer.enableServiceEndpoint.setSettingEndpoint.settingItemId;
-
-    const set_setting = await this.#actions.account('account/set_setting', {
-      new_value: type == 'SPaccount_privacy' ? !new_value : new_value,
-      setting_item_id
-    });
-
-    return set_setting;
   }
 
   /**
@@ -128,6 +49,17 @@ class AccountManager {
     });
 
     return new TimeWatched(response);
+  }
+
+  /**
+   * Opens YouTube settings.
+   */
+  async getSettings() {
+    const response = await this.#actions.execute('/browse', {
+      browseId: 'SPaccount_overview'
+    });
+
+    return new Settings(this.#actions, response);
   }
 
   /**

--- a/src/core/AccountManager.ts
+++ b/src/core/AccountManager.ts
@@ -9,7 +9,7 @@ import Settings from '../parser/youtube/Settings';
 class AccountManager {
   #actions;
   channel;
-  
+
   constructor(actions: Actions) {
     this.#actions = actions;
 

--- a/src/core/Actions.ts
+++ b/src/core/Actions.ts
@@ -708,9 +708,17 @@ class Actions {
       if (Reflect.has(data, 'clientActions'))
         delete data.clientActions;
 
+      if (Reflect.has(data, 'settingItemIdForClient'))
+        delete data.settingItemIdForClient;
+
       if (Reflect.has(data, 'action')) {
         data.actions = [ data.action ];
         delete data.action;
+      }
+
+      if (Reflect.has(data, 'boolValue')) {
+        data.newValue = { boolValue: data.boolValue };
+        delete data.boolValue;
       }
 
       if (Reflect.has(data, 'token')) {

--- a/src/core/InteractionManager.ts
+++ b/src/core/InteractionManager.ts
@@ -1,4 +1,4 @@
-import { throwIfMissing, findNode } from '../utils/Utils';
+import { throwIfMissing } from '../utils/Utils';
 import Actions from './Actions';
 
 class InteractionManager {
@@ -79,12 +79,12 @@ class InteractionManager {
       text
     });
 
-    const translated_content = findNode(response.data, 'frameworkUpdates', 'content', 7, false);
+    const mutation = response.data.frameworkUpdates.entityBatchUpdate.mutations[0].payload.commentEntityPayload;
 
     return {
       success: response.success,
       status_code: response.status_code,
-      translated_content: translated_content.content,
+      translated_content: mutation.translatedContent.content,
       data: response.data
     };
   }

--- a/src/parser/classes/ChannelOptions.ts
+++ b/src/parser/classes/ChannelOptions.ts
@@ -1,0 +1,24 @@
+import Text from './misc/Text';
+import Thumbnail from './misc/Thumbnail';
+import NavigationEndpoint from './NavigationEndpoint';
+
+import { YTNode } from '../helpers';
+
+class ChannelOptions extends YTNode {
+  static type = 'ChannelOptions';
+
+  avatar: Thumbnail[];
+  endpoint: NavigationEndpoint;
+  name: string;
+  links: Text[];
+
+  constructor(data: any) {
+    super();
+    this.avatar = Thumbnail.fromResponse(data.avatar);
+    this.endpoint = new NavigationEndpoint(data.avatarEndpoint);
+    this.name = data.name;
+    this.links = data.links.map((link: any) => new Text(link));
+  }
+}
+
+export default ChannelOptions;

--- a/src/parser/classes/CopyLink.ts
+++ b/src/parser/classes/CopyLink.ts
@@ -1,0 +1,20 @@
+import Parser from '../index';
+import Button from './Button';
+import { YTNode } from '../helpers';
+
+class CopyLink extends YTNode {
+  static type = 'CopyLink';
+
+  copy_button: Button | null;
+  short_url: string;
+  style: string;
+
+  constructor(data: any) {
+    super();
+    this.copy_button = Parser.parseItem<Button>(data.copyButton, Button);
+    this.short_url = data.shortUrl;
+    this.style = data.style;
+  }
+}
+
+export default CopyLink;

--- a/src/parser/classes/NavigationEndpoint.ts
+++ b/src/parser/classes/NavigationEndpoint.ts
@@ -235,29 +235,14 @@ class NavigationEndpoint extends YTNode {
     }
   }
 
-  /**
-   * Call endpoint. (This is an experiment and may replace {@link call} in the future.).
-   */
-  async callTest(actions: Actions, args: {
-    parse: false;
-    params?: object
-  }): Promise<ActionsResponse>;
-  async callTest(actions: Actions, args?: {
-    parse?: true;
-    params?: object
-  }): Promise<ParsedResponse>;
-  async callTest(actions: Actions, args: {
-    parse?: boolean;
-    params?: object
-  } = { parse: true, params: {} }): Promise<ParsedResponse | ActionsResponse> {
+  callTest(actions: Actions, args: { [ key: string ]: any; parse: true }): Promise<ParsedResponse>;
+  callTest(actions: Actions, args?: { [ key: string ]: any; parse?: false }): Promise<ActionsResponse>;
+  callTest(actions: Actions, args?: { [ key: string ]: any; parse?: boolean }): Promise<ParsedResponse | ActionsResponse> {
     if (!actions)
       throw new Error('An active caller must be provided');
     if (!this.metadata.api_url)
       throw new Error('Expected an api_url, but none was found, this is a bug.');
-
-    const response = await actions.execute(this.metadata.api_url, { ...this.payload, ...args.params, parse: args.parse });
-
-    return response;
+    return actions.execute(this.metadata.api_url, { ...this.payload, ...args });
   }
 
   // TODO: replace client with an enum or something

--- a/src/parser/classes/PageIntroduction.ts
+++ b/src/parser/classes/PageIntroduction.ts
@@ -1,0 +1,21 @@
+import Text from './misc/Text';
+import { YTNode } from '../helpers';
+
+class PageIntroduction extends YTNode {
+  static type = 'PageIntroduction';
+
+  header_text: string;
+  body_text: string;
+  page_title: string;
+  header_icon_type: string;
+
+  constructor(data: any) {
+    super();
+    this.header_text = new Text(data.headerText).toString();
+    this.body_text = new Text(data.bodyText).toString();
+    this.page_title = new Text(data.pageTitle).toString();
+    this.header_icon_type = data.headerIcon.iconType;
+  }
+}
+
+export default PageIntroduction;

--- a/src/parser/classes/SettingsCheckbox.ts
+++ b/src/parser/classes/SettingsCheckbox.ts
@@ -1,0 +1,23 @@
+import Text from './misc/Text';
+import { YTNode } from '../helpers';
+
+class SettingsCheckbox extends YTNode {
+  static type = 'SettingsCheckbox';
+
+  title: Text;
+  help_text: Text;
+  enabled: boolean;
+  disabled: boolean;
+  id: string;
+
+  constructor(data: any) {
+    super();
+    this.title = new Text(data.title);
+    this.help_text = new Text(data.helpText);
+    this.enabled = data.enabled;
+    this.disabled = data.disabled;
+    this.id = data.id;
+  }
+}
+
+export default SettingsCheckbox;

--- a/src/parser/classes/SettingsOptions.ts
+++ b/src/parser/classes/SettingsOptions.ts
@@ -25,7 +25,10 @@ class SettingsOptions extends YTNode {
     }
 
     if (Reflect.has(data, 'options')) {
-      this.options = Parser.parseArray(data.options, [ SettingsSwitch, Dropdown, CopyLink, SettingsCheckbox, ChannelOptions ]);
+      this.options = Parser.parseArray<SettingsSwitch | Dropdown | CopyLink | SettingsCheckbox | ChannelOptions>(data.options, [
+        SettingsSwitch, Dropdown, CopyLink,
+        SettingsCheckbox, ChannelOptions
+      ]);
     }
   }
 }

--- a/src/parser/classes/SettingsOptions.ts
+++ b/src/parser/classes/SettingsOptions.ts
@@ -1,0 +1,31 @@
+import Parser from '..';
+
+import Text from './misc/Text';
+import Dropdown from './Dropdown';
+import SettingsSwitch from './SettingsSwitch';
+import ChannelOptions from './ChannelOptions';
+
+import { ObservedArray, YTNode } from '../helpers';
+
+class SettingsOptions extends YTNode {
+  static type = 'SettingsOptions';
+
+  title: Text;
+  text?: string;
+  options?: ObservedArray<Dropdown | SettingsSwitch | ChannelOptions>;
+
+  constructor(data: any) {
+    super();
+    this.title = new Text(data.title);
+
+    if (Reflect.has(data, 'text')) {
+      this.text = new Text(data.text).toString();
+    }
+
+    if (Reflect.has(data, 'options')) {
+      this.options = Parser.parseArray<SettingsSwitch | Dropdown | ChannelOptions>(data.options, [ SettingsSwitch, Dropdown, ChannelOptions ]);
+    }
+  }
+}
+
+export default SettingsOptions;

--- a/src/parser/classes/SettingsOptions.ts
+++ b/src/parser/classes/SettingsOptions.ts
@@ -3,16 +3,18 @@ import Parser from '..';
 import Text from './misc/Text';
 import Dropdown from './Dropdown';
 import SettingsSwitch from './SettingsSwitch';
+import SettingsCheckbox from './SettingsCheckbox';
 import ChannelOptions from './ChannelOptions';
+import CopyLink from './CopyLink';
 
-import { ObservedArray, YTNode } from '../helpers';
+import { YTNode } from '../helpers';
 
 class SettingsOptions extends YTNode {
   static type = 'SettingsOptions';
 
   title: Text;
   text?: string;
-  options?: ObservedArray<Dropdown | SettingsSwitch | ChannelOptions>;
+  options?;
 
   constructor(data: any) {
     super();
@@ -23,7 +25,7 @@ class SettingsOptions extends YTNode {
     }
 
     if (Reflect.has(data, 'options')) {
-      this.options = Parser.parseArray<SettingsSwitch | Dropdown | ChannelOptions>(data.options, [ SettingsSwitch, Dropdown, ChannelOptions ]);
+      this.options = Parser.parseArray(data.options, [ SettingsSwitch, Dropdown, CopyLink, SettingsCheckbox, ChannelOptions ]);
     }
   }
 }

--- a/src/parser/classes/SettingsSidebar.ts
+++ b/src/parser/classes/SettingsSidebar.ts
@@ -1,0 +1,23 @@
+import Parser from '../index';
+import Text from './misc/Text';
+import CompactLink from './CompactLink';
+import { ObservedArray, YTNode } from '../helpers';
+
+class SettingsSidebar extends YTNode {
+  static type = 'SettingsSidebar';
+
+  title: Text;
+  items: ObservedArray<CompactLink>;
+
+  constructor(data: any) {
+    super();
+    this.title = new Text(data.title);
+    this.items = Parser.parseArray<CompactLink>(data.items, CompactLink);
+  }
+
+  get contents() {
+    return this.items;
+  }
+}
+
+export default SettingsSidebar;

--- a/src/parser/classes/SettingsSwitch.ts
+++ b/src/parser/classes/SettingsSwitch.ts
@@ -1,0 +1,24 @@
+import Text from './misc/Text';
+import NavigationEndpoint from './NavigationEndpoint';
+import { YTNode } from '../helpers';
+
+class SettingsSwitch extends YTNode {
+  static type = 'SettingsSwitch';
+
+  title: Text;
+  subtitle: Text;
+  enabled: boolean;
+  enable_endpoint: NavigationEndpoint;
+  disable_endpoint: NavigationEndpoint;
+
+  constructor(data: any) {
+    super();
+    this.title = new Text(data.title);
+    this.subtitle = new Text(data.subtitle);
+    this.enabled = data.enabled;
+    this.enable_endpoint = new NavigationEndpoint(data.enableServiceEndpoint);
+    this.disable_endpoint = new NavigationEndpoint(data.disableServiceEndpoint);
+  }
+}
+
+export default SettingsSwitch;

--- a/src/parser/classes/comments/Comment.ts
+++ b/src/parser/classes/comments/Comment.ts
@@ -122,9 +122,7 @@ class Comment extends YTNode {
     const dialog_button = dialog.item().as(CommentReplyDialog).reply_button.item().as(ToggleButton);
 
     const payload = {
-      params: {
-        commentText: text
-      }
+      commentText: text
     };
 
     const response = await dialog_button.endpoint.callTest(this.#actions, payload);

--- a/src/parser/classes/comments/CommentThread.ts
+++ b/src/parser/classes/comments/CommentThread.ts
@@ -35,7 +35,7 @@ class CommentThread extends YTNode {
       throw new InnertubeError('This comment has no replies.', { comment_id: this.comment?.comment_id });
 
     const continuation = this.#replies.key('contents').parsed().array().get({ type: 'ContinuationItem' })?.as(ContinuationItem);
-    const response = await continuation?.endpoint.callTest(this.#actions);
+    const response = await continuation?.endpoint.callTest(this.#actions, { parse: true });
 
     this.replies = response?.on_response_received_endpoints_memo?.getType(Comment).map((comment) => {
       comment.setActions(this.#actions);
@@ -60,7 +60,7 @@ class CommentThread extends YTNode {
     if (!this.#actions)
       throw new InnertubeError('Actions not set for this CommentThread.');
 
-    const response = await this.#continuation.button?.item().key('endpoint').nodeOfType(NavigationEndpoint).callTest(this.#actions);
+    const response = await this.#continuation.button?.item().key('endpoint').nodeOfType(NavigationEndpoint).callTest(this.#actions, { parse: true });
 
     this.replies = response?.on_response_received_endpoints_memo.getType(Comment).map((comment) => {
       comment.setActions(this.#actions);

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -53,6 +53,7 @@ import { default as CompactMix } from './classes/CompactMix';
 import { default as CompactPlaylist } from './classes/CompactPlaylist';
 import { default as CompactVideo } from './classes/CompactVideo';
 import { default as ContinuationItem } from './classes/ContinuationItem';
+import { default as CopyLink } from './classes/CopyLink';
 import { default as CreatePlaylistDialog } from './classes/CreatePlaylistDialog';
 import { default as DidYouMean } from './classes/DidYouMean';
 import { default as DownloadButton } from './classes/DownloadButton';
@@ -205,6 +206,7 @@ import { default as SearchSuggestionsSection } from './classes/SearchSuggestions
 import { default as SecondarySearchContainer } from './classes/SecondarySearchContainer';
 import { default as SectionList } from './classes/SectionList';
 import { default as SettingBoolean } from './classes/SettingBoolean';
+import { default as SettingsCheckbox } from './classes/SettingsCheckbox';
 import { default as SettingsOptions } from './classes/SettingsOptions';
 import { default as SettingsSidebar } from './classes/SettingsSidebar';
 import { default as SettingsSwitch } from './classes/SettingsSwitch';
@@ -311,6 +313,7 @@ const map: Record<string, YTNodeConstructor> = {
   CompactPlaylist,
   CompactVideo,
   ContinuationItem,
+  CopyLink,
   CreatePlaylistDialog,
   DidYouMean,
   DownloadButton,
@@ -463,6 +466,7 @@ const map: Record<string, YTNodeConstructor> = {
   SecondarySearchContainer,
   SectionList,
   SettingBoolean,
+  SettingsCheckbox,
   SettingsOptions,
   SettingsSidebar,
   SettingsSwitch,

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -32,6 +32,7 @@ import { default as ChannelFeaturedContent } from './classes/ChannelFeaturedCont
 import { default as ChannelHeaderLinks } from './classes/ChannelHeaderLinks';
 import { default as ChannelMetadata } from './classes/ChannelMetadata';
 import { default as ChannelMobileHeader } from './classes/ChannelMobileHeader';
+import { default as ChannelOptions } from './classes/ChannelOptions';
 import { default as ChannelThumbnailWithLink } from './classes/ChannelThumbnailWithLink';
 import { default as ChannelVideoPlayer } from './classes/ChannelVideoPlayer';
 import { default as ChildVideo } from './classes/ChildVideo';
@@ -162,6 +163,7 @@ import { default as MusicThumbnail } from './classes/MusicThumbnail';
 import { default as MusicTwoRowItem } from './classes/MusicTwoRowItem';
 import { default as NavigationEndpoint } from './classes/NavigationEndpoint';
 import { default as Notification } from './classes/Notification';
+import { default as PageIntroduction } from './classes/PageIntroduction';
 import { default as PlayerAnnotationsExpanded } from './classes/PlayerAnnotationsExpanded';
 import { default as PlayerCaptionsTracklist } from './classes/PlayerCaptionsTracklist';
 import { default as PlayerErrorMessage } from './classes/PlayerErrorMessage';
@@ -203,6 +205,9 @@ import { default as SearchSuggestionsSection } from './classes/SearchSuggestions
 import { default as SecondarySearchContainer } from './classes/SecondarySearchContainer';
 import { default as SectionList } from './classes/SectionList';
 import { default as SettingBoolean } from './classes/SettingBoolean';
+import { default as SettingsOptions } from './classes/SettingsOptions';
+import { default as SettingsSidebar } from './classes/SettingsSidebar';
+import { default as SettingsSwitch } from './classes/SettingsSwitch';
 import { default as Shelf } from './classes/Shelf';
 import { default as ShowingResultsFor } from './classes/ShowingResultsFor';
 import { default as SimpleCardContent } from './classes/SimpleCardContent';
@@ -285,6 +290,7 @@ const map: Record<string, YTNodeConstructor> = {
   ChannelHeaderLinks,
   ChannelMetadata,
   ChannelMobileHeader,
+  ChannelOptions,
   ChannelThumbnailWithLink,
   ChannelVideoPlayer,
   ChildVideo,
@@ -415,6 +421,7 @@ const map: Record<string, YTNodeConstructor> = {
   MusicTwoRowItem,
   NavigationEndpoint,
   Notification,
+  PageIntroduction,
   PlayerAnnotationsExpanded,
   PlayerCaptionsTracklist,
   PlayerErrorMessage,
@@ -456,6 +463,9 @@ const map: Record<string, YTNodeConstructor> = {
   SecondarySearchContainer,
   SectionList,
   SettingBoolean,
+  SettingsOptions,
+  SettingsSidebar,
+  SettingsSwitch,
   Shelf,
   ShowingResultsFor,
   SimpleCardContent,

--- a/src/parser/youtube/Comments.ts
+++ b/src/parser/youtube/Comments.ts
@@ -67,7 +67,7 @@ class Comments {
     if (!this.#continuation)
       throw new InnertubeError('Continuation not found');
 
-    const data = await this.#continuation.endpoint.callTest(this.#actions);
+    const data = await this.#continuation.endpoint.callTest(this.#actions, { parse: true });
 
     // Copy the previous page so we can keep the header.
     const page = Object.assign({}, this.#page);

--- a/src/parser/youtube/Comments.ts
+++ b/src/parser/youtube/Comments.ts
@@ -51,10 +51,7 @@ class Comments {
       throw new InnertubeError('Could not find target button.');
 
     const response = await button.endpoint.callTest(this.#actions, {
-      params: {
-        commentText: text
-      },
-      parse: false
+      commentText: text
     });
 
     return response;

--- a/src/parser/youtube/Settings.ts
+++ b/src/parser/youtube/Settings.ts
@@ -1,0 +1,118 @@
+import Parser from '..';
+import Actions, { AxioslikeResponse } from '../../core/Actions';
+import { InnertubeError } from '../../utils/Utils';
+
+import Tab from '../classes/Tab';
+import TwoColumnBrowseResults from '../classes/TwoColumnBrowseResults';
+import SectionList from '../classes/SectionList';
+import ItemSection from '../classes/ItemSection';
+
+import PageIntroduction from '../classes/PageIntroduction';
+import SettingsOptions from '../classes/SettingsOptions';
+import SettingsSwitch from '../classes/SettingsSwitch';
+import SettingsSidebar from '../classes/SettingsSidebar';
+
+class Settings {
+  #page;
+  #actions;
+
+  sidebar: SettingsSidebar | null | undefined;
+  introduction: PageIntroduction | null | undefined;
+  sections;
+
+  constructor(actions: Actions, response: AxioslikeResponse) {
+    this.#actions = actions;
+    this.#page = Parser.parseResponse(response.data);
+
+    this.sidebar = this.#page.sidebar?.as(SettingsSidebar);
+
+    const tab = this.#page.contents.item().as(TwoColumnBrowseResults).tabs.array().as(Tab).get({ selected: true });
+
+    if (!tab)
+      throw new InnertubeError('Target tab not found');
+
+    const contents = tab.content?.as(SectionList).contents.array().as(ItemSection);
+
+    this.introduction = contents?.shift()?.contents?.get({ type: 'PageIntroduction' })?.as(PageIntroduction);
+
+    this.sections = contents?.map((el: ItemSection) => ({
+      title: el.header?.title.toString() || null,
+      contents: el.contents
+    }));
+  }
+
+  /**
+   * Selects an item from the sidebar menu. Use {@link sidebar_items} to see available items.
+   */
+  async selectSidebarItem(name: string) {
+    if (!this.sidebar)
+      throw new InnertubeError('Sidebar not available');
+
+    const item = this.sidebar.items.get({ title: name });
+
+    if (!item)
+      throw new InnertubeError(`Item "${name}" not found`, { available_items: this.sidebar_items });
+
+    const response = await item.endpoint.callTest(this.#actions, { parse: false });
+
+    return new Settings(this.#actions, response);
+  }
+
+  /**
+   * Finds a setting by name and returns it. Use {@link setting_options} to see available options.
+   */
+  getSettingOption(name: string) {
+    if (!this.sections)
+      throw new InnertubeError('Sections not available');
+
+    for (const section of this.sections) {
+      if (!section.contents) continue;
+      for (const el of section.contents) {
+        const options = el.as(SettingsOptions).options;
+        if (options) {
+          for (const option of options) {
+            if (
+              option.is(SettingsSwitch) &&
+              option.title?.toString() === name
+            )
+              return option;
+          }
+        }
+      }
+    }
+
+    throw new InnertubeError(`Option "${name}" not found`, { available_options: this.setting_options });
+  }
+
+  /**
+   * Returns settings available in the page.
+   */
+  get setting_options(): string[] {
+    if (!this.sections)
+      throw new InnertubeError('Sections not available');
+
+    let options: any[] = [];
+
+    for (const section of this.sections) {
+      if (!section.contents) continue;
+      for (const el of section.contents) {
+        if (el.as(SettingsOptions).options)
+          options = options.concat(el.as(SettingsOptions).options);
+      }
+    }
+
+    return options.map((opt) => opt.title?.toString()).filter((el) => el);
+  }
+
+  /**
+   * Returns options available in the sidebar.
+   */
+  get sidebar_items(): string[] {
+    if (!this.sidebar)
+      throw new InnertubeError('Sidebar not available');
+
+    return this.sidebar.items.map((item) => item.title.toString());
+  }
+}
+
+export default Settings;

--- a/src/proto/index.ts
+++ b/src/proto/index.ts
@@ -229,8 +229,8 @@ class Proto {
   } = {}) {
     const data: PeformCommentActionParams = {
       type,
-      commentId: args.comment_id || '',
-      videoId: args.video_id || '',
+      commentId: args.comment_id || ' ',
+      videoId: args.video_id || ' ',
       unkNum: 2
     };
 
@@ -244,7 +244,7 @@ class Proto {
             text: args.text as string
           }
         },
-        commentId: args.comment_id || '',
+        commentId: args.comment_id || ' ',
         targetLanguage: args.target_language
       };
     }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,4 +1,3 @@
-import Flatten from 'flat';
 import package_json from '../../package.json';
 import { FetchFunction } from './HTTPClient';
 import userAgents from './user-agents.json';
@@ -30,24 +29,6 @@ export class NoStreamingDataError extends InnertubeError { }
 export class OAuthError extends InnertubeError { }
 export class PlayerError extends Error { }
 export class SessionError extends Error { }
-
-/**
- * Utility to help access deep properties of an object.
- * @param obj - the object.
- * @param key - key of the property being accessed.
- * @param target - anything that might be inside of the property.
- * @param depth - maximum number of nested objects to flatten.
- * @param safe - if set to true arrays will be preserved.
- */
-export function findNode(obj: any, key: string, target: string, depth: number, safe = true): any | any[] {
-  const flat_obj = Flatten(obj, { safe, maxDepth: depth || 2 }) as any;
-  const result = Object.keys(flat_obj).find((entry) => entry.includes(key) && JSON.stringify(flat_obj[entry] || '{}').includes(target));
-  if (!result)
-    throw new ParsingError(`Expected to find "${key}" with content "${target}" but got ${result}`, {
-      key, target, data_snippet: `${JSON.stringify(flat_obj, null, 4).slice(0, 300)}..`
-    });
-  return flat_obj[result];
-}
 
 /**
  * Compares given objects. May not work correctly for


### PR DESCRIPTION
## Description

As I said in the issue, the older implementation was very inefficient and hard to maintain. This implements a proper settings parser which allows the user to navigate through the page however they want to. Also adding `Innertube#call(endpoint)` to simplify endpoint calls.

### Usage:
```ts
const settings = await yt.account.getSettings();

// View sidebar menu items
console.info(settings.sidebar_items);

// Select an item from the sidebar menu, this throws an error if the item doesn't exist
const notifications = await settings.selectSidebarItem('Notifications');
  
// View setting options
console.log(notifications.setting_options);

// Get a setting option, also throws an error if the option doesn't exist
const option = notifications.getSettingOption('Recommended videos');

// And lastly, toggle it on or off
await yt.call(option.enable_endpoint);
await yt.call(option.disable_endpoint);
```

Related: #153 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings