### PR TITLE
fix: `Music#Artist`parse err if missing shelves

### DIFF
--- a/src/parser/ytmusic/Artist.ts
+++ b/src/parser/ytmusic/Artist.ts
@@ -20,8 +20,8 @@ class Artist {
 
     this.header = this.page.header.item().as(MusicImmersiveHeader);
 
-    const music_shelf = this.#page.contents_memo.get('MusicShelf') as MusicShelf[];
-    const music_carousel_shelf = this.#page.contents_memo.get('MusicCarouselShelf') as MusicCarouselShelf[];
+    const music_shelf = this.#page.contents_memo.get('MusicShelf') as MusicShelf[] || [];
+    const music_carousel_shelf = this.#page.contents_memo.get('MusicCarouselShelf') as MusicCarouselShelf[] || [];
 
     this.sections = [ ...music_shelf, ...music_carousel_shelf ];
   }


### PR DESCRIPTION
Example `id` that throws error when calling `Music#getArtist()`: 

```
// This channel does not have MusicShelf sections
// https://music.youtube.com/channel/UC9PTPzzGQ-C_kDHlwQOrDFQ
const id = 'UC9PTPzzGQ-C_kDHlwQOrDFQ'; 
const artist = await youtube.music.getArtist(id); // throws error
```

This PR fixes this.