### PR TITLE
feat: add `MusicVisualHeader`

### DIFF
--- a/src/parser/classes/MusicVisualHeader.ts
+++ b/src/parser/classes/MusicVisualHeader.ts
@@ -1,0 +1,25 @@
+import Parser from '../index';
+import { YTNode } from '../helpers';
+import Text from './misc/Text';
+import Thumbnail from './misc/Thumbnail';
+import Menu from './menus/Menu';
+
+class MusicVisualHeader extends YTNode {
+  static type = 'MusicVisualHeader';
+
+  title;
+  thumbnails;
+  menu;
+  foreground_thumbnails;
+
+  constructor(data: any) {
+    super();
+
+    this.title = new Text(data.title);
+    this.thumbnails = data.thumbnail ? Thumbnail.fromResponse(data.thumbnail.musicThumbnailRenderer?.thumbnail) : [];
+    this.menu = Parser.parseItem(data.menu, Menu);
+    this.foreground_thumbnails = data.foregroundThumbnail ? Thumbnail.fromResponse(data.foregroundThumbnail.musicThumbnailRenderer?.thumbnail) : [];
+  }
+}
+
+export default MusicVisualHeader;

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -162,6 +162,7 @@ import { default as MusicSideAlignedItem } from './classes/MusicSideAlignedItem'
 import { default as MusicSortFilterButton } from './classes/MusicSortFilterButton';
 import { default as MusicThumbnail } from './classes/MusicThumbnail';
 import { default as MusicTwoRowItem } from './classes/MusicTwoRowItem';
+import { default as MusicVisualHeader } from './classes/MusicVisualHeader';
 import { default as NavigationEndpoint } from './classes/NavigationEndpoint';
 import { default as Notification } from './classes/Notification';
 import { default as PageIntroduction } from './classes/PageIntroduction';
@@ -422,6 +423,7 @@ const map: Record<string, YTNodeConstructor> = {
   MusicSortFilterButton,
   MusicThumbnail,
   MusicTwoRowItem,
+  MusicVisualHeader,
   NavigationEndpoint,
   Notification,
   PageIntroduction,

--- a/src/parser/ytmusic/Artist.ts
+++ b/src/parser/ytmusic/Artist.ts
@@ -6,6 +6,7 @@ import MusicShelf from '../classes/MusicShelf';
 import MusicCarouselShelf from '../classes/MusicCarouselShelf';
 import MusicPlaylistShelf from '../classes/MusicPlaylistShelf';
 import MusicImmersiveHeader from '../classes/MusicImmersiveHeader';
+import MusicVisualHeader from '../classes/MusicVisualHeader';
 
 class Artist {
   #page;
@@ -18,7 +19,7 @@ class Artist {
     this.#page = Parser.parseResponse((response as AxioslikeResponse).data);
     this.#actions = actions;
 
-    this.header = this.page.header.item().as(MusicImmersiveHeader);
+    this.header = this.page.header.item().as(MusicImmersiveHeader, MusicVisualHeader);
 
     const music_shelf = this.#page.contents_memo.get('MusicShelf') as MusicShelf[] || [];
     const music_carousel_shelf = this.#page.contents_memo.get('MusicCarouselShelf') as MusicCarouselShelf[] || [];


### PR DESCRIPTION
Some artists have a `MusicVisualHeader` instead of the more common `MusicImmersiveHeader`. This PR adds the missing parser class so `Music#Artist` won't error when this type of header is encountered.

Example channel ID with `MusicVisualHeader`:  [UCsykiwtxpFJsdBHaEhWGXFw](https://music.youtube.com/channel/UCsykiwtxpFJsdBHaEhWGXFw)