### PR TITLE
Fix `DidYouMean` endpoints and add `text` prop

### DIFF
--- a/src/parser/classes/DidYouMean.ts
+++ b/src/parser/classes/DidYouMean.ts
@@ -13,7 +13,7 @@ class DidYouMean extends YTNode {
     super();
     this.text = new Text(data.didYouMean).toString();
     this.corrected_query = new Text(data.correctedQuery);
-    this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
+    this.endpoint = new NavigationEndpoint(data.navigationEndpoint || data.correctedQueryEndpoint);
   }
 }
 

--- a/src/parser/classes/DidYouMean.ts
+++ b/src/parser/classes/DidYouMean.ts
@@ -5,11 +5,13 @@ import { YTNode } from '../helpers';
 class DidYouMean extends YTNode {
   static type = 'DidYouMean';
 
+  text: string;
   corrected_query: Text;
   endpoint: NavigationEndpoint;
 
   constructor(data: any) {
     super();
+    this.text = new Text(data.didYouMean).toString();
     this.corrected_query = new Text(data.correctedQuery);
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
   }


### PR DESCRIPTION
This PR includes `correctedQueryEndpoint` in the data parsed by `DidYouMean`. Currently the parser takes endpoint data from `navigationEndpoint`. I have not encountered this in my search tests (ytmusic) but it could well exist somewhere so I decided not to remove it.

Also added `text`prop for sake of completeness.