### PR TITLE
fix: ytmusic formats returning 401 when deciphered

### DIFF
--- a/src/core/Music.ts
+++ b/src/core/Music.ts
@@ -26,7 +26,7 @@ import SingleColumnMusicWatchNextResults from '../parser/classes/SingleColumnMus
 import WatchNextTabbedResults from '../parser/classes/WatchNextTabbedResults';
 import SectionList from '../parser/classes/SectionList';
 
-import { InnertubeError, throwIfMissing } from '../utils/Utils';
+import { InnertubeError, throwIfMissing, generateRandomString } from '../utils/Utils';
 
 class Music {
   #actions;
@@ -39,7 +39,9 @@ class Music {
    * Retrieves track info.
    */
   async getInfo(video_id: string) {
-    const initial_info = this.#actions.execute('/player', { client: 'YTMUSIC', videoId: video_id });
+    const cpn = generateRandomString(16);
+
+    const initial_info = await this.#actions.getVideoInfo(video_id, cpn, 'YTMUSIC');
     const continuation = this.#actions.execute('/next', { client: 'YTMUSIC', videoId: video_id });
 
     const response = await Promise.all([ initial_info, continuation ]);

--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -18,6 +18,7 @@ import ToggleButton from '../classes/ToggleButton';
 import CommentsEntryPointHeader from '../classes/comments/CommentsEntryPointHeader';
 import ContinuationItem from '../classes/ContinuationItem';
 import PlayerMicroformat from '../classes/PlayerMicroformat';
+import MicroformatData from '../classes/MicroformatData';
 
 import LiveChat from '../classes/LiveChat';
 import LiveChatWrap from './LiveChat';
@@ -100,7 +101,7 @@ class VideoInfo {
     if (info.playability_status?.status === 'ERROR')
       throw new InnertubeError('This video is unavailable', info.playability_status);
 
-    if (info.microformat && !info.microformat?.is(PlayerMicroformat))
+    if (info.microformat && !info.microformat?.is(PlayerMicroformat, MicroformatData))
       throw new InnertubeError('Invalid microformat', info.microformat);
 
     this.basic_info = { // This type is inferred so no need for an explicit type
@@ -110,11 +111,11 @@ class VideoInfo {
          * Microformat is a bit redundant, so only
          * a few things there are interesting to us.
          */
-        embed: info.microformat?.embed,
-        channel: info.microformat?.channel,
+        embed: info.microformat?.is(PlayerMicroformat) ? info.microformat?.embed : null,
+        channel: info.microformat?.is(PlayerMicroformat) ? info.microformat?.channel : null,
         is_unlisted: info.microformat?.is_unlisted,
         is_family_safe: info.microformat?.is_family_safe,
-        has_ypc_metadata: info.microformat?.has_ypc_metadata
+        has_ypc_metadata: info.microformat?.is(PlayerMicroformat) ? info.microformat?.has_ypc_metadata : null
       },
       like_count: undefined as number | undefined,
       is_liked: undefined as boolean | undefined,


### PR DESCRIPTION
## Description 
Include signature timestamp in the request to `/player` for YouTube Music and add a small check for microformats (youtube/VideoInfo).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings