### PR TITLE
fix: `Music#getAlbum()`fails for private album ID

### DIFF
--- a/src/core/Music.ts
+++ b/src/core/Music.ts
@@ -102,7 +102,7 @@ class Music {
   async getAlbum(album_id: string) {
     throwIfMissing({ album_id });
 
-    if (!album_id.startsWith('MPR'))
+    if (!album_id.startsWith('MPR') && !album_id.startsWith('FEmusic_library_privately_owned_release'))
       throw new InnertubeError('Invalid album id', album_id);
 
     const response = await this.#actions.browse(album_id, { client: 'YTMUSIC' });


### PR DESCRIPTION
Private albums (created automatically when you upload songs to ytmusic) have IDs starting with `FEmusic_library_privately_owned_release`. This fails the ID check in `Music#getAlbum()`. This PR fixes this.