### PR TITLE
feat: Add paid chat color info

### DIFF
--- a/src/parser/classes/livechat/items/LiveChatPaidMessage.ts
+++ b/src/parser/classes/livechat/items/LiveChatPaidMessage.ts
@@ -20,6 +20,10 @@ class LiveChatPaidMessage extends YTNode {
     is_verified_artist: boolean | null;
   };
 
+  headerBackgroundColor: number;
+  headerTextColor: number;
+  bodyBackgroundColor: number;
+  bodyTextColor: number;
   purchase_amount: string;
   menu_endpoint: NavigationEndpoint;
   timestamp: number;
@@ -47,6 +51,10 @@ class LiveChatPaidMessage extends YTNode {
     this.author.is_verified = badges?.some((badge: any) => badge.style == 'BADGE_STYLE_TYPE_VERIFIED') || null;
     this.author.is_verified_artist = badges?.some((badge: any) => badge.style == 'BADGE_STYLE_TYPE_VERIFIED_ARTIST') || null;
 
+    this.headerBackgroundColor = data.headerBackgroundColor;
+    this.headerTextColor = data.headerTextColor;
+    this.bodyBackgroundColor = data.bodyBackgroundColor;
+    this.bodyTextColor = data.bodyTextColor;
     this.purchase_amount = new Text(data.purchaseAmountText).toString();
     this.menu_endpoint = new NavigationEndpoint(data.contextMenuEndpoint);
     this.timestamp = Math.floor(parseInt(data.timestampUsec) / 1000);

--- a/src/parser/classes/livechat/items/LiveChatPaidMessage.ts
+++ b/src/parser/classes/livechat/items/LiveChatPaidMessage.ts
@@ -20,10 +20,10 @@ class LiveChatPaidMessage extends YTNode {
     is_verified_artist: boolean | null;
   };
 
-  headerBackgroundColor: number;
-  headerTextColor: number;
-  bodyBackgroundColor: number;
-  bodyTextColor: number;
+  header_background_color: number;
+  header_text_color: number;
+  body_background_color: number;
+  body_text_color: number;
   purchase_amount: string;
   menu_endpoint: NavigationEndpoint;
   timestamp: number;
@@ -51,10 +51,10 @@ class LiveChatPaidMessage extends YTNode {
     this.author.is_verified = badges?.some((badge: any) => badge.style == 'BADGE_STYLE_TYPE_VERIFIED') || null;
     this.author.is_verified_artist = badges?.some((badge: any) => badge.style == 'BADGE_STYLE_TYPE_VERIFIED_ARTIST') || null;
 
-    this.headerBackgroundColor = data.headerBackgroundColor;
-    this.headerTextColor = data.headerTextColor;
-    this.bodyBackgroundColor = data.bodyBackgroundColor;
-    this.bodyTextColor = data.bodyTextColor;
+    this.header_background_color = data.headerBackgroundColor;
+    this.header_text_color = data.headerTextColor;
+    this.body_background_color = data.bodyBackgroundColor;
+    this.body_text_color = data.bodyTextColor;
     this.purchase_amount = new Text(data.purchaseAmountText).toString();
     this.menu_endpoint = new NavigationEndpoint(data.contextMenuEndpoint);
     this.timestamp = Math.floor(parseInt(data.timestampUsec) / 1000);

--- a/src/parser/classes/livechat/items/LiveChatPaidSticker.ts
+++ b/src/parser/classes/livechat/items/LiveChatPaidSticker.ts
@@ -16,6 +16,10 @@ class LiveChatPaidSticker extends YTNode {
     badges: any;
   };
 
+  moneyChipBackgroundColor: number;
+  moneyChipTextColor: number;
+  backgroundColor: number;
+  authorNameTextColor: number;
   sticker: Thumbnail[];
   purchase_amount: string;
   context_menu: NavigationEndpoint;
@@ -32,6 +36,10 @@ class LiveChatPaidSticker extends YTNode {
       badges: Parser.parse(data.authorBadges)
     };
 
+    this.moneyChipBackgroundColor = data.moneyChipBackgroundColor;
+    this.moneyChipTextColor = data.moneyChipTextColor;
+    this.backgroundColor = data.backgroundColor;
+    this.authorNameTextColor = data.authorNameTextColor;
     this.sticker = Thumbnail.fromResponse(data.sticker);
     this.purchase_amount = new Text(data.purchaseAmountText).toString();
     this.context_menu = new NavigationEndpoint(data.contextMenuEndpoint);

--- a/src/parser/classes/livechat/items/LiveChatPaidSticker.ts
+++ b/src/parser/classes/livechat/items/LiveChatPaidSticker.ts
@@ -16,10 +16,10 @@ class LiveChatPaidSticker extends YTNode {
     badges: any;
   };
 
-  moneyChipBackgroundColor: number;
-  moneyChipTextColor: number;
-  backgroundColor: number;
-  authorNameTextColor: number;
+  money_chip_background_color: number;
+  money_chip_text_color: number;
+  background_color: number;
+  author_name_text_color: number;
   sticker: Thumbnail[];
   purchase_amount: string;
   context_menu: NavigationEndpoint;
@@ -36,10 +36,10 @@ class LiveChatPaidSticker extends YTNode {
       badges: Parser.parse(data.authorBadges)
     };
 
-    this.moneyChipBackgroundColor = data.moneyChipBackgroundColor;
-    this.moneyChipTextColor = data.moneyChipTextColor;
-    this.backgroundColor = data.backgroundColor;
-    this.authorNameTextColor = data.authorNameTextColor;
+    this.money_chip_background_color = data.moneyChipBackgroundColor;
+    this.money_chip_text_color = data.moneyChipTextColor;
+    this.background_color = data.backgroundColor;
+    this.author_name_text_color = data.authorNameTextColor;
     this.sticker = Thumbnail.fromResponse(data.sticker);
     this.purchase_amount = new Text(data.purchaseAmountText).toString();
     this.context_menu = new NavigationEndpoint(data.contextMenuEndpoint);


### PR DESCRIPTION
# Pull Request Template

## Description

I added some color info to LiveChatPaidMessage and LiveChatPaidSticker.

Actual response from YouTube has some color info: red for expensive purchase and blue for cheap one, etc..., but LiveChatPaidMessage and LiveChatPaidSticker of current version don't have them.
So I added `headerBackgroundColor`, `headerTextColor`, `bodyBackgroundColor`, `bodyTextColor` to LiveChatPaidMessage and `moneyChipBackgroundColor`, `moneyChipTextColor`, `backgroundColor`, `authorNameTextColor` for LiveChatPaidSticker.

I locally ran `Parser.parseResponse` with actual responses contains `liveChatPaidMessageRenderer` and `liveChatPaidStickerRenderer`, and it seems to works well.

no related issues

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings