### PR TITLE
feat: add `<info>#addToWatchHistory()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,9 @@ Retrieves video info, including playback data and even layout elements such as m
 - `<info>#getWatchNextContinuation()`
   - Retrieves the next batch of items for the watch next feed.
 
+- `<info>#addToWatchHistory()`
+  - Adds the video to the watch history.
+
 - `<info>#page`
   - Returns original InnerTube response (sanitized).
 

--- a/src/core/Actions.ts
+++ b/src/core/Actions.ts
@@ -682,6 +682,26 @@ class Actions {
   }
 
   /**
+   * Makes calls to the playback tracking API.
+   */
+  async stats(url: string, client: { client_name: string; client_version: string }, params: { [key: string]: any }) {
+    const s_url = new URL(url);
+
+    s_url.searchParams.set('ver', '2');
+    s_url.searchParams.set('c', client.client_name.toLowerCase());
+    s_url.searchParams.set('cbrver', client.client_version);
+    s_url.searchParams.set('cver', client.client_version);
+
+    for (const key of Object.keys(params)) {
+      s_url.searchParams.set(key, params[key]);
+    }
+
+    const response = await this.#session.http.fetch(s_url);
+
+    return response;
+  }
+
+  /**
    * Executes an API call.
    * @param action - endpoint
    * @param args - call arguments

--- a/src/core/Music.ts
+++ b/src/core/Music.ts
@@ -46,7 +46,7 @@ class Music {
     const continuation = this.#actions.execute('/next', { client: 'YTMUSIC', videoId: video_id });
 
     const response = await Promise.all([ initial_info, continuation ]);
-    return new TrackInfo(response, this.#actions);
+    return new TrackInfo(response, this.#actions, cpn);
   }
 
   /**

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -252,6 +252,10 @@ export default class Parser {
       refinements: data.refinements || null,
       estimated_results: data.estimatedResults ? parseInt(data.estimatedResults) : null,
       player_overlays: Parser.parse(data.playerOverlays),
+      playback_tracking: data.playbackTracking ? {
+        videostats_watchtime_url: data.playbackTracking.videostatsWatchtimeUrl.baseUrl,
+        videostats_playback_url: data.playbackTracking.videostatsPlaybackUrl.baseUrl
+      } : null,
       playability_status: data.playabilityStatus ? {
         status: data.playabilityStatus.status as string,
         error_screen: Parser.parse(data.playabilityStatus.errorScreen),

--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -75,6 +75,9 @@ class VideoInfo {
   endscreen;
   captions;
   cards;
+
+  #playback_tracking;
+
   primary_info;
   secondary_info;
   merchandise;
@@ -130,6 +133,8 @@ class VideoInfo {
     this.captions = info.captions;
     this.cards = info.cards;
 
+    this.#playback_tracking = info.playback_tracking;
+
     const two_col = next?.contents.item().as(TwoColumnWatchNextResults);
 
     const results = two_col?.results;
@@ -175,6 +180,28 @@ class VideoInfo {
     this.watch_next_feed = data?.contents;
 
     return this;
+  }
+
+  /**
+   * Adds the video to the watch history.
+   */
+  async addToWatchHistory() {
+    if (!this.#playback_tracking)
+      throw new InnertubeError('Playback tracking not available');
+
+    const url_params = {
+      cpn: this.#cpn,
+      fmt: 251,
+      rtn: 0,
+      rt: 0
+    };
+
+    const response = await this.#actions.stats(this.#playback_tracking.videostats_playback_url, {
+      client_name: Constants.CLIENTS.WEB.NAME,
+      client_version: Constants.CLIENTS.WEB.VERSION
+    }, url_params);
+
+    return response;
   }
 
   /**
@@ -256,6 +283,10 @@ class VideoInfo {
 
   get actions() {
     return this.#actions;
+  }
+
+  get cpn() {
+    return this.#cpn;
   }
 
   get page() {

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -33,7 +33,8 @@ export const OAUTH = Object.freeze({
 });
 export const CLIENTS = Object.freeze({
   WEB: {
-    NAME: 'WEB'
+    NAME: 'WEB',
+    VERSION: '2.20220902.01.00'
   },
   YTMUSIC: {
     NAME: 'WEB_REMIX',


### PR DESCRIPTION
## Description

This adds support for the playback tracking API. I've only implemented the ability to add videos/songs to the watch history — as actually tracking the playback is a bit more complicated, since it requires the client to poll the endpoint every 30-60 seconds with information about player position among other things. 

### Usage
```ts
// ...

// or const info = await yt.music.getInfo('k79dMVVmvA8');
const info = await yt.getInfo('k79dMVVmvA8');
await info.addToWatchHistory();
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings