### PR TITLE
fix: search continuations not being parsed correctly 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "youtubei.js",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "youtubei.js",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "funding": [
         "https://github.com/sponsors/LuanRT"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtubei.js",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Full-featured wrapper around YouTube's private API.",
   "main": "./dist/index.js",
   "browser": "./bundle/browser.js",
@@ -69,17 +69,18 @@
     "youtubedl",
     "youtube-dl",
     "youtube-downloader",
-    "innertube",
+    "youtube-music",
     "innertubeapi",
+    "innertube",
     "unofficial",
     "downloader",
     "livechat",
+    "studio",
+    "upload",
     "ytmusic",
-    "dislike",
     "search",
     "comment",
     "music",
-    "like",
     "api"
   ]
 }

--- a/src/parser/classes/TitleAndButtonListHeader.ts
+++ b/src/parser/classes/TitleAndButtonListHeader.ts
@@ -1,0 +1,15 @@
+import Text from './misc/Text';
+import { YTNode } from '../helpers';
+
+class TitleAndButtonListHeader extends YTNode {
+  static type = 'TitleAndButtonListHeader';
+
+  title: Text;
+
+  constructor(data: any) {
+    super();
+    this.title = new Text(data.title);
+  }
+}
+
+export default TitleAndButtonListHeader;

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -244,6 +244,7 @@ import { default as ThumbnailOverlayResumePlayback } from './classes/ThumbnailOv
 import { default as ThumbnailOverlaySidePanel } from './classes/ThumbnailOverlaySidePanel';
 import { default as ThumbnailOverlayTimeStatus } from './classes/ThumbnailOverlayTimeStatus';
 import { default as ThumbnailOverlayToggleButton } from './classes/ThumbnailOverlayToggleButton';
+import { default as TitleAndButtonListHeader } from './classes/TitleAndButtonListHeader';
 import { default as ToggleButton } from './classes/ToggleButton';
 import { default as ToggleMenuServiceItem } from './classes/ToggleMenuServiceItem';
 import { default as Tooltip } from './classes/Tooltip';
@@ -508,6 +509,7 @@ const map: Record<string, YTNodeConstructor> = {
   ThumbnailOverlaySidePanel,
   ThumbnailOverlayTimeStatus,
   ThumbnailOverlayToggleButton,
+  TitleAndButtonListHeader,
   ToggleButton,
   ToggleMenuServiceItem,
   Tooltip,

--- a/src/parser/youtube/Search.ts
+++ b/src/parser/youtube/Search.ts
@@ -1,15 +1,17 @@
 import Actions from '../../core/Actions';
-import Feed from '../../core/Feed';
+import { observe, ObservedArray, YTNode } from '../helpers';
 import { InnertubeError } from '../../utils/Utils';
-import HorizontalCardList from '../classes/HorizontalCardList';
+
+import Feed from '../../core/Feed';
+import SectionList from '../classes/SectionList';
 import ItemSection from '../classes/ItemSection';
+import HorizontalCardList from '../classes/HorizontalCardList';
 import RichListHeader from '../classes/RichListHeader';
 import SearchRefinementCard from '../classes/SearchRefinementCard';
 import TwoColumnSearchResults from '../classes/TwoColumnSearchResults';
 import UniversalWatchCard from '../classes/UniversalWatchCard';
 import WatchCardHeroVideo from '../classes/WatchCardHeroVideo';
 import WatchCardSectionSequence from '../classes/WatchCardSectionSequence';
-import { observe, ObservedArray, YTNode } from '../helpers';
 
 class Search extends Feed {
   results: ObservedArray<YTNode> | null | undefined;
@@ -22,11 +24,11 @@ class Search extends Feed {
     super(actions, data, already_parsed);
 
     const contents =
-      this.page.contents.item().as(TwoColumnSearchResults).primary_contents.item().key('contents').parsed().array() ||
+      this.page.contents?.item().as(TwoColumnSearchResults).primary_contents.item().as(SectionList).contents.array() ||
       this.page.on_response_received_commands?.[0].contents;
 
-    const secondary_contents_maybe = this.page.contents.item().key('secondary_contents');
-    const secondary_contents = secondary_contents_maybe.isParsed() ? secondary_contents_maybe.parsed().item().key('contents').parsed().array() : undefined;
+    const secondary_contents_maybe = this.page.contents?.item().key('secondary_contents');
+    const secondary_contents = secondary_contents_maybe?.isParsed() ? secondary_contents_maybe.parsed().item().key('contents').parsed().array() : undefined;
 
     this.results = contents.firstOfType(ItemSection)?.contents;
 
@@ -64,7 +66,7 @@ class Search extends Feed {
       throw new InnertubeError('Invalid refinement card!');
     }
 
-    const page = await target_card.endpoint.call(this.actions);
+    const page = await target_card.endpoint.call(this.actions, null, true);
 
     return new Search(this.actions, page, true);
   }
@@ -81,4 +83,5 @@ class Search extends Feed {
     return new Search(this.actions, continuation, true);
   }
 }
+
 export default Search;

--- a/src/parser/youtube/Search.ts
+++ b/src/parser/youtube/Search.ts
@@ -66,7 +66,7 @@ class Search extends Feed {
       throw new InnertubeError('Invalid refinement card!');
     }
 
-    const page = await target_card.endpoint.call(this.actions, null, true);
+    const page = await target_card.endpoint.call(this.actions, undefined, true);
 
     return new Search(this.actions, page, true);
   }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -20,6 +20,16 @@ describe('YouTube.js Tests', () => {
       expect(search.has_continuation).toBe(true);
     });
     
+    it('should retrieve YouTube search continuation', async () => {
+      const search = await yt.search(VIDEOS[0].QUERY);
+      const next = await search.getContinuation()
+      expect(next.results?.length).toBeLessThanOrEqual(35);
+      expect(next.videos.length).toBeLessThanOrEqual(35);
+      expect(next.playlists.length).toBeLessThanOrEqual(35);
+      expect(next.channels.length).toBeLessThanOrEqual(35);
+      expect(next.has_continuation).toBe(true);
+    });
+    
     it('should search on YouTube Music', async () => {
       const search = await yt.music.search(VIDEOS[1].QUERY);
       expect(search.songs?.contents.length).toBeLessThanOrEqual(3);


### PR DESCRIPTION
## Description

This fixes search continuations & refinement cards.

Related: #172 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings