### PR TITLE
feat: add `PlaylistPanelVideoWrapper` parser

### DIFF
--- a/src/parser/classes/PlaylistPanel.ts
+++ b/src/parser/classes/PlaylistPanel.ts
@@ -4,6 +4,7 @@ import PlaylistPanelVideo from './PlaylistPanelVideo';
 
 import { YTNode } from '../helpers';
 import AutomixPreviewVideo from './AutomixPreviewVideo';
+import PlaylistPanelVideoWrapper from './PlaylistPanelVideoWrapper';
 
 class PlaylistPanel extends YTNode {
   static type = 'PlaylistPanel';
@@ -22,7 +23,7 @@ class PlaylistPanel extends YTNode {
     super();
     this.title = data.title;
     this.title_text = new Text(data.titleText);
-    this.contents = Parser.parseArray<PlaylistPanelVideo | AutomixPreviewVideo>(data.contents, [ PlaylistPanelVideo, AutomixPreviewVideo ]);
+    this.contents = Parser.parseArray<PlaylistPanelVideoWrapper | PlaylistPanelVideo | AutomixPreviewVideo>(data.contents);
     this.playlist_id = data.playlistId;
     this.is_infinite = data.isInfinite;
     this.continuation = data.continuations?.[0]?.nextRadioContinuationData?.continuation || data.continuations?.[0]?.nextContinuationData?.continuation;

--- a/src/parser/classes/PlaylistPanelVideoWrapper.ts
+++ b/src/parser/classes/PlaylistPanelVideoWrapper.ts
@@ -1,0 +1,18 @@
+import Parser from '..';
+import { YTNode } from '../helpers';
+import PlaylistPanelVideo from './PlaylistPanelVideo';
+
+class PlaylistPanelVideoWrapper extends YTNode {
+  static type = 'PlaylistPanelVideoWrapper';
+
+  primary: PlaylistPanelVideo | null;
+  counterpart: Array<PlaylistPanelVideo | null>;
+
+  constructor(data: any) {
+    super();
+    this.primary = Parser.parseItem<PlaylistPanelVideo>(data.primaryRenderer);
+    this.counterpart = data.counterpart?.map((item: any) => Parser.parseItem<PlaylistPanelVideo>(item.counterpartRenderer));
+  }
+}
+
+export default PlaylistPanelVideoWrapper;

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -183,6 +183,7 @@ import { default as PlaylistInfoCardContent } from './classes/PlaylistInfoCardCo
 import { default as PlaylistMetadata } from './classes/PlaylistMetadata';
 import { default as PlaylistPanel } from './classes/PlaylistPanel';
 import { default as PlaylistPanelVideo } from './classes/PlaylistPanelVideo';
+import { default as PlaylistPanelVideoWrapper } from './classes/PlaylistPanelVideoWrapper';
 import { default as PlaylistSidebar } from './classes/PlaylistSidebar';
 import { default as PlaylistSidebarPrimaryInfo } from './classes/PlaylistSidebarPrimaryInfo';
 import { default as PlaylistSidebarSecondaryInfo } from './classes/PlaylistSidebarSecondaryInfo';
@@ -448,6 +449,7 @@ const map: Record<string, YTNodeConstructor> = {
   PlaylistMetadata,
   PlaylistPanel,
   PlaylistPanelVideo,
+  PlaylistPanelVideoWrapper,
   PlaylistSidebar,
   PlaylistSidebarPrimaryInfo,
   PlaylistSidebarSecondaryInfo,


### PR DESCRIPTION
When signed in with a YouTube Premium account, calling `Music#getUpNext()` may sometimes generate a '`PlaylistPanelVideoWrapper` not found' error. This PR adds the missing parser class.

As the name implies, this class is a wrapper around multiple instances of `PlaylistPanelVideo` and has the following props:
1. `primary`: `PlaylistPanelVideo`
2. `counterpart`: Array<`PlaylistPanelVideo`>

