### PR TITLE
feat: add LiveChatAutoModMessage

### DIFF
--- a/src/parser/classes/livechat/items/LiveChatAutoModMessage.ts
+++ b/src/parser/classes/livechat/items/LiveChatAutoModMessage.ts
@@ -1,0 +1,24 @@
+import Text from '../../misc/Text';
+import Parser from '../../../index';
+import { YTNode } from '../../../helpers';
+
+class LiveChatAutoModMessage extends YTNode {
+  static type = 'LiveChatAutoModMessage';
+
+  auto_moderated_item;
+  header_text: Text;
+
+  timestamp: number;
+  id: string;
+
+  constructor(data: any) {
+    super();
+
+    this.auto_moderated_item = Parser.parse(data.autoModeratedItem);
+    this.header_text = new Text(data.headerText);
+    this.timestamp = Math.floor(parseInt(data.timestampUsec) / 1000);
+    this.id = data.id;
+  }
+}
+
+export default LiveChatAutoModMessage;

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -88,6 +88,7 @@ import { default as LiveChat } from './classes/LiveChat';
 import { default as AddBannerToLiveChatCommand } from './classes/livechat/AddBannerToLiveChatCommand';
 import { default as AddChatItemAction } from './classes/livechat/AddChatItemAction';
 import { default as AddLiveChatTickerItemAction } from './classes/livechat/AddLiveChatTickerItemAction';
+import { default as LiveChatAutoModMessage } from './classes/livechat/items/LiveChatAutoModMessage';
 import { default as LiveChatBanner } from './classes/livechat/items/LiveChatBanner';
 import { default as LiveChatBannerHeader } from './classes/livechat/items/LiveChatBannerHeader';
 import { default as LiveChatBannerPoll } from './classes/livechat/items/LiveChatBannerPoll';
@@ -353,6 +354,7 @@ const map: Record<string, YTNodeConstructor> = {
   AddBannerToLiveChatCommand,
   AddChatItemAction,
   AddLiveChatTickerItemAction,
+  LiveChatAutoModMessage,
   LiveChatBanner,
   LiveChatBannerHeader,
   LiveChatBannerPoll,


### PR DESCRIPTION
## Description

I create new livechat item: `LiveChatAutoModMessage`.
This item is only available for streamers themselves and their modelators.

Some chat items such as lil bit sensitive one will be pending, and only streamers and moderators can see the item and decide to or not to show by click buttons on the chat layer.
`LiveChatAutoModMessage` has such infos.
- `auto_moderated_item` is the pending item whose type is such as LiveChatTextMessage.
- `header_text` is the message means "This message is pending." in their local language.
- `timestamp` and `id` are same as others.

Actual Responses from YouTube has other data such as endpoint to handle messages by moderator and something, but my parser doesn't parse them.

I locally ran `Parser.parseResponse` with actual responses contains `LiveChatAutoModMessage` in `addChatItemAction`, and it seems to works well.

No related issues.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings