### PR TITLE
feat: add `CollaboratorInfoCardContent` renderer parser

### DIFF
--- a/src/parser/classes/CollaboratorInfoCardContent.ts
+++ b/src/parser/classes/CollaboratorInfoCardContent.ts
@@ -1,0 +1,26 @@
+import Text from './misc/Text';
+import Thumbnail from './misc/Thumbnail';
+import NavigationEndpoint from './NavigationEndpoint';
+
+import { YTNode } from '../helpers';
+
+class CollaboratorInfoCardContent extends YTNode {
+  static type = 'CollaboratorInfoCardContent';
+
+  channel_avatar: Thumbnail[];
+  custom_text: Text;
+  channel_name: Text;
+  subscriber_count: Text;
+  endpoint: NavigationEndpoint;
+
+  constructor(data: any) {
+    super();
+    this.channel_avatar = Thumbnail.fromResponse(data.channelAvatar);
+    this.custom_text = new Text(data.customText);
+    this.channel_name = new Text(data.channelName);
+    this.subscriber_count = new Text(data.subscriberCountText);
+    this.endpoint = new NavigationEndpoint(data.endpoint);
+  }
+}
+
+export default CollaboratorInfoCardContent;

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -38,6 +38,7 @@ import { default as ChannelVideoPlayer } from './classes/ChannelVideoPlayer';
 import { default as ChildVideo } from './classes/ChildVideo';
 import { default as ChipCloud } from './classes/ChipCloud';
 import { default as ChipCloudChip } from './classes/ChipCloudChip';
+import { default as CollaboratorInfoCardContent } from './classes/CollaboratorInfoCardContent';
 import { default as CollageHeroImage } from './classes/CollageHeroImage';
 import { default as AuthorCommentBadge } from './classes/comments/AuthorCommentBadge';
 import { default as Comment } from './classes/comments/Comment';
@@ -305,6 +306,7 @@ const map: Record<string, YTNodeConstructor> = {
   ChildVideo,
   ChipCloud,
   ChipCloudChip,
+  CollaboratorInfoCardContent,
   CollageHeroImage,
   AuthorCommentBadge,
   Comment,


### PR DESCRIPTION
## Description

Add `CollaboratorInfoCardContent`, this renderer represents channels in the `CardCollection` list.
Related: #174 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings