### PR TITLE
feat(Music): add automix support and minor improvements 

### DIFF
--- a/docs/API/music.md
+++ b/docs/API/music.md
@@ -14,7 +14,7 @@ YouTube Music class.
   * [.getAlbum(album_id)](#getalbum)
   * [.getPlaylist(playlist_id)](#getplaylist)
   * [.getLyrics(video_id)](#getlyrics)
-  * [.getUpNext(video_id)](#getupnext)
+  * [.getUpNext(video_id, automix?)](#getupnext)
   * [.getRelated(video_id)](#getrelated)
   * [.getRecap()](#getrecap)
   * [.getSearchSuggestions(query)](#getsearchsuggestions)
@@ -28,7 +28,29 @@ Retrieves track info.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| target | `string | MusicTwoRowItem` | video id or list item |
+| target | `string` or `MusicTwoRowItem` | video id or list item |
+
+<details>
+<summary>Methods & Getters</summary>
+<p>
+
+- `<info>#getTab(title)`
+  - Retrieves contents of the given tab.
+
+- `<info>#getUpNext(automix?)`
+  - Retrieves up next.
+
+- `<info>#getRelated()`
+  - Retrieves related content.
+
+- `<info>#getLyrics()`
+  - Retrieves song lyrics.
+
+- `<info>#available_tabs`
+  - Returns available tabs.
+
+</p>
+</details> 
 
 <a name="search"></a>
 ### search(query, filters?)
@@ -227,7 +249,7 @@ Retrieves up next content.
 | Param | Type | Description |
 | --- | --- | --- |
 | video_id | `string` | Video id |
-| automix | `boolean` | if related songs should be fetched |
+| automix? | `boolean` | if automix should be fetched |
 
 <a name="getrelated"></a>
 ### getRelated(video_id)

--- a/docs/API/music.md
+++ b/docs/API/music.md
@@ -5,7 +5,7 @@ YouTube Music class.
 ## API
 
 * Music 
-  * [.getInfo(video_id)](#getinfo)
+  * [.getInfo(target)](#getinfo)
   * [.search(query, filters?)](#search)
   * [.getHomeFeed()](#gethomefeed)
   * [.getExplore()](#getexplore)
@@ -20,7 +20,7 @@ YouTube Music class.
   * [.getSearchSuggestions(query)](#getsearchsuggestions)
 
 <a name="getinfo"></a>
-### getInfo(video_id)
+### getInfo(target)
 
 Retrieves track info.
 
@@ -28,7 +28,7 @@ Retrieves track info.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| video_id | `string` | Video id |
+| target | `string | MusicTwoRowItem` | video id or list item |
 
 <a name="search"></a>
 ### search(query, filters?)
@@ -211,14 +211,14 @@ Retrieves given playlist.
 
 Retrieves song lyrics.
 
-**Returns:** `Promise.<{ text: string; footer: object; }>`
+**Returns:** `Promise.<MusicDescriptionShelf | undefined>`
 
 | Param | Type | Description |
 | --- | --- | --- |
 | video_id | `string` | Video id |
 
 <a name="getupnext"></a>
-### getUpNext(video_id)
+### getUpNext(video_id, automix?)
 
 Retrieves up next content.
 
@@ -227,6 +227,7 @@ Retrieves up next content.
 | Param | Type | Description |
 | --- | --- | --- |
 | video_id | `string` | Video id |
+| automix | `boolean` | if related songs should be fetched |
 
 <a name="getrelated"></a>
 ### getRelated(video_id)

--- a/src/parser/classes/AudioOnlyPlayability.ts
+++ b/src/parser/classes/AudioOnlyPlayability.ts
@@ -1,0 +1,14 @@
+import { YTNode } from '../helpers';
+
+class AudioOnlyPlayability extends YTNode {
+  static type = 'AudioOnlyPlayability';
+
+  audio_only_availability: string;
+
+  constructor (data: any) {
+    super();
+    this.audio_only_availability = data.audioOnlyAvailability;
+  }
+}
+
+export default AudioOnlyPlayability;

--- a/src/parser/classes/BrowserMediaSession.ts
+++ b/src/parser/classes/BrowserMediaSession.ts
@@ -1,0 +1,18 @@
+import Text from './misc/Text';
+import Thumbnail from './misc/Thumbnail';
+import { YTNode } from '../helpers';
+
+class BrowserMediaSession extends YTNode {
+  static type = 'BrowserMediaSession';
+
+  album;
+  thumbnails;
+
+  constructor (data: any) {
+    super();
+    this.album = new Text(data.album);
+    this.thumbnails = Thumbnail.fromResponse(data.thumbnailDetails);
+  }
+}
+
+export default BrowserMediaSession;

--- a/src/parser/classes/MusicDownloadStateBadge.ts
+++ b/src/parser/classes/MusicDownloadStateBadge.ts
@@ -1,0 +1,16 @@
+import { YTNode } from '../helpers';
+
+class MusicDownloadStateBadge extends YTNode {
+  static type = 'MusicDownloadStateBadge';
+
+  playlist_id: string;
+  supported_download_states: string[];
+
+  constructor(data: any) {
+    super();
+    this.playlist_id = data.playlistId;
+    this.supported_download_states = data.supportedDownloadStates;
+  }
+}
+
+export default MusicDownloadStateBadge;

--- a/src/parser/classes/MusicItemThumbnailOverlay.ts
+++ b/src/parser/classes/MusicItemThumbnailOverlay.ts
@@ -1,4 +1,5 @@
 import Parser from '../index';
+import MusicPlayButton from './MusicPlayButton';
 import { YTNode } from '../helpers';
 
 class MusicItemThumbnailOverlay extends YTNode {
@@ -10,7 +11,7 @@ class MusicItemThumbnailOverlay extends YTNode {
 
   constructor(data: any) {
     super();
-    this.content = Parser.parse(data.content);
+    this.content = Parser.parseItem<MusicPlayButton>(data.content, MusicPlayButton);
     this.content_position = data.contentPosition;
     this.display_style = data.displayStyle;
   }

--- a/src/parser/classes/MusicQueue.ts
+++ b/src/parser/classes/MusicQueue.ts
@@ -1,14 +1,15 @@
 import Parser from '../index';
+import PlaylistPanel from './PlaylistPanel';
 import { YTNode } from '../helpers';
 
 class MusicQueue extends YTNode {
   static type = 'MusicQueue';
 
-  content;
+  content: PlaylistPanel | null;
 
   constructor(data: any) {
     super();
-    this.content = Parser.parse(data.content);
+    this.content = Parser.parseItem<PlaylistPanel>(data.content, PlaylistPanel);
   }
 }
 

--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -3,12 +3,16 @@
 
 import Parser from '../index';
 import Text from './misc/Text';
-import { timeToSeconds } from '../../utils/Utils';
+import TextRun from './misc/TextRun';
 import Thumbnail from './misc/Thumbnail';
 import NavigationEndpoint from './NavigationEndpoint';
+import MusicItemThumbnailOverlay from './MusicItemThumbnailOverlay';
+import MusicResponsiveListItemFlexColumn from './MusicResponsiveListItemFlexColumn';
+import MusicResponsiveListItemFixedColumn from './MusicResponsiveListItemFixedColumn';
+import Menu from './menus/Menu';
 
+import { timeToSeconds } from '../../utils/Utils';
 import { YTNode } from '../helpers';
-import TextRun from './misc/TextRun';
 
 class MusicResponsiveListItem extends YTNode {
   static type = 'MusicResponsiveListItem';
@@ -66,8 +70,8 @@ class MusicResponsiveListItem extends YTNode {
 
   constructor(data: any) {
     super();
-    this.#flex_columns = Parser.parseArray(data.flexColumns);
-    this.#fixed_columns = Parser.parseArray(data.fixedColumns);
+    this.#flex_columns = Parser.parseArray<MusicResponsiveListItemFlexColumn>(data.flexColumns, MusicResponsiveListItemFlexColumn);
+    this.#fixed_columns = Parser.parseArray<MusicResponsiveListItemFixedColumn>(data.fixedColumns, MusicResponsiveListItemFixedColumn);
 
     this.#playlist_item_data = {
       video_id: data?.playlistItemData?.videoId || null,
@@ -109,8 +113,8 @@ class MusicResponsiveListItem extends YTNode {
 
     this.thumbnails = data.thumbnail ? Thumbnail.fromResponse(data.thumbnail.musicThumbnailRenderer?.thumbnail) : [];
     this.badges = Parser.parseArray(data.badges);
-    this.menu = Parser.parse(data.menu);
-    this.overlay = Parser.parse(data.overlay);
+    this.menu = Parser.parseItem<Menu>(data.menu, Menu);
+    this.overlay = Parser.parseItem<MusicItemThumbnailOverlay>(data.overlay, MusicItemThumbnailOverlay);
   }
 
   #parseOther() {

--- a/src/parser/classes/MusicTwoRowItem.ts
+++ b/src/parser/classes/MusicTwoRowItem.ts
@@ -5,6 +5,9 @@ import Text from './misc/Text';
 import TextRun from './misc/TextRun';
 import Thumbnail from './misc/Thumbnail';
 import NavigationEndpoint from './NavigationEndpoint';
+import MusicItemThumbnailOverlay from './MusicItemThumbnailOverlay';
+import Menu from './menus/Menu';
+
 import { YTNode } from '../helpers';
 
 class MusicTwoRowItem extends YTNode {
@@ -118,8 +121,8 @@ class MusicTwoRowItem extends YTNode {
     }
 
     this.thumbnail = Thumbnail.fromResponse(data.thumbnailRenderer.musicThumbnailRenderer.thumbnail);
-    this.thumbnail_overlay = Parser.parse(data.thumbnailOverlay);
-    this.menu = Parser.parse(data.menu);
+    this.thumbnail_overlay = Parser.parseItem<MusicItemThumbnailOverlay>(data.thumbnailOverlay, MusicItemThumbnailOverlay);
+    this.menu = Parser.parseItem<Menu>(data.menu, Menu);
   }
 }
 

--- a/src/parser/classes/NavigationEndpoint.ts
+++ b/src/parser/classes/NavigationEndpoint.ts
@@ -247,6 +247,8 @@ class NavigationEndpoint extends YTNode {
         return '/browse';
       case 'watchEndpoint':
         return '/player';
+      case 'watchPlaylistEndpoint':
+        return '/next';
     }
   }
 

--- a/src/parser/classes/NavigationEndpoint.ts
+++ b/src/parser/classes/NavigationEndpoint.ts
@@ -245,6 +245,8 @@ class NavigationEndpoint extends YTNode {
     switch (name) {
       case 'browseEndpoint':
         return '/browse';
+      case 'watchEndpoint':
+        return '/player';
     }
   }
 

--- a/src/parser/classes/PlayerOverlay.ts
+++ b/src/parser/classes/PlayerOverlay.ts
@@ -14,6 +14,8 @@ class PlayerOverlay extends YTNode {
   share_button;
   add_to_menu;
   fullscreen_engagement;
+  actions;
+  browser_media_session;
 
   constructor(data: any) {
     super();
@@ -22,6 +24,8 @@ class PlayerOverlay extends YTNode {
     this.share_button = Parser.parseItem<Button>(data.shareButton, Button);
     this.add_to_menu = Parser.parseItem<Menu>(data.addToMenu, Menu);
     this.fullscreen_engagement = Parser.parse(data.fullscreenEngagement);
+    this.actions = Parser.parseArray(data.actions);
+    this.browser_media_session = Parser.parseItem(data.browserMediaSession);
   }
 }
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -15,6 +15,7 @@ import { YTNode, YTNodeConstructor, SuperParsedResult, ObservedArray, observe, M
 
 import package_json from '../../package.json';
 import MusicMultiSelectMenuItem from './classes/menus/MusicMultiSelectMenuItem';
+import AudioOnlyPlayability from './classes/AudioOnlyPlayability';
 
 export class AppendContinuationItemsAction extends YTNode {
   static readonly type = 'appendContinuationItemsAction';
@@ -259,6 +260,7 @@ export default class Parser {
       playability_status: data.playabilityStatus ? {
         status: data.playabilityStatus.status as string,
         error_screen: Parser.parse(data.playabilityStatus.errorScreen),
+        audio_only_playablility: Parser.parseItem<AudioOnlyPlayability>(data.playabilityStatus.audioOnlyPlayability, AudioOnlyPlayability),
         embeddable: !!data.playabilityStatus.playableInEmbed || false,
         reason: data.playabilityStatus?.reason || ''
       } : undefined,
@@ -373,10 +375,6 @@ export default class Parser {
 
   static parse<T extends YTNode = YTNode>(data: any, requireArray: true, validTypes?: YTNodeConstructor<T> | YTNodeConstructor<T>[]) : ObservedArray<T> | null;
   static parse<T extends YTNode = YTNode>(data: any, requireArray?: false | undefined, validTypes?: YTNodeConstructor<T> | YTNodeConstructor<T>[]) : SuperParsedResult<T>;
-
-  /**
-   * Parses the `contents` property of the response as well as its nodes.
-   */
   static parse<T extends YTNode = YTNode>(data: any, requireArray?: boolean, validTypes?: YTNodeConstructor<T> | YTNodeConstructor<T>[]) {
     if (!data) return null;
 

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -16,11 +16,13 @@ import { default as AnalyticsVodCarouselCard } from './classes/analytics/Analyti
 import { default as CtaGoToCreatorStudio } from './classes/analytics/CtaGoToCreatorStudio';
 import { default as DataModelSection } from './classes/analytics/DataModelSection';
 import { default as StatRow } from './classes/analytics/StatRow';
+import { default as AudioOnlyPlayability } from './classes/AudioOnlyPlayability';
 import { default as AutomixPreviewVideo } from './classes/AutomixPreviewVideo';
 import { default as BackstageImage } from './classes/BackstageImage';
 import { default as BackstagePost } from './classes/BackstagePost';
 import { default as BackstagePostThread } from './classes/BackstagePostThread';
 import { default as BrowseFeedActions } from './classes/BrowseFeedActions';
+import { default as BrowserMediaSession } from './classes/BrowserMediaSession';
 import { default as Button } from './classes/Button';
 import { default as C4TabbedHeader } from './classes/C4TabbedHeader';
 import { default as CallToActionButton } from './classes/CallToActionButton';
@@ -149,6 +151,7 @@ import { default as MusicCarouselShelf } from './classes/MusicCarouselShelf';
 import { default as MusicCarouselShelfBasicHeader } from './classes/MusicCarouselShelfBasicHeader';
 import { default as MusicDescriptionShelf } from './classes/MusicDescriptionShelf';
 import { default as MusicDetailHeader } from './classes/MusicDetailHeader';
+import { default as MusicDownloadStateBadge } from './classes/MusicDownloadStateBadge';
 import { default as MusicEditablePlaylistDetailHeader } from './classes/MusicEditablePlaylistDetailHeader';
 import { default as MusicElementHeader } from './classes/MusicElementHeader';
 import { default as MusicHeader } from './classes/MusicHeader';
@@ -286,11 +289,13 @@ const map: Record<string, YTNodeConstructor> = {
   CtaGoToCreatorStudio,
   DataModelSection,
   StatRow,
+  AudioOnlyPlayability,
   AutomixPreviewVideo,
   BackstageImage,
   BackstagePost,
   BackstagePostThread,
   BrowseFeedActions,
+  BrowserMediaSession,
   Button,
   C4TabbedHeader,
   CallToActionButton,
@@ -419,6 +424,7 @@ const map: Record<string, YTNodeConstructor> = {
   MusicCarouselShelfBasicHeader,
   MusicDescriptionShelf,
   MusicDetailHeader,
+  MusicDownloadStateBadge,
   MusicEditablePlaylistDetailHeader,
   MusicElementHeader,
   MusicHeader,

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -11,7 +11,7 @@ describe('YouTube.js Tests', () => {
   });
   
   describe('Search', () => {
-    it('should search on YouTube', async () => {
+    it('should search', async () => {
       const search = await yt.search(VIDEOS[0].QUERY);
       expect(search.results?.length).toBeLessThanOrEqual(35);
       expect(search.videos.length).toBeLessThanOrEqual(35);
@@ -20,7 +20,7 @@ describe('YouTube.js Tests', () => {
       expect(search.has_continuation).toBe(true);
     });
     
-    it('should retrieve YouTube search continuation', async () => {
+    it('should retrieve search continuation', async () => {
       const search = await yt.search(VIDEOS[0].QUERY);
       const next = await search.getContinuation()
       expect(next.results?.length).toBeLessThanOrEqual(35);
@@ -30,18 +30,8 @@ describe('YouTube.js Tests', () => {
       expect(next.has_continuation).toBe(true);
     });
     
-    it('should search on YouTube Music', async () => {
-      const search = await yt.music.search(VIDEOS[1].QUERY);
-      expect(search.songs?.contents.length).toBeLessThanOrEqual(3);
-    });
-    
-    it('should retrieve YouTube search suggestions', async () => {
+    it('should retrieve search suggestions', async () => {
       const suggestions = await yt.getSearchSuggestions(VIDEOS[0].QUERY);
-      expect(suggestions.length).toBeLessThanOrEqual(10);
-    });
-    
-    it('should retrieve YouTube Music search suggestions', async () => {
-      const suggestions = await yt.music.getSearchSuggestions(VIDEOS[1].QUERY);
       expect(suggestions.length).toBeLessThanOrEqual(10);
     });
   });
@@ -87,14 +77,9 @@ describe('YouTube.js Tests', () => {
   });
   
   describe('General', () => {
-    it('should retrieve playlist with YouTube', async () => {
+    it('should retrieve playlist', async () => {
       const playlist = await yt.getPlaylist('PLLw0AzOz95FU7w2juhPECP9NyGhbZmz_t');
       expect(playlist.items.length).toBeLessThanOrEqual(100);
-    });
-
-    it('should retrieve playlist with YouTube Music', async () => {
-      const playlist = await yt.music.getPlaylist('PLVbEymL-83SyVXXqT7fYX5sEvELvyGjL7');
-      expect(playlist.items?.length).toBeLessThanOrEqual(100);
     });
     
     it('should retrieve home feed', async () => {
@@ -111,6 +96,46 @@ describe('YouTube.js Tests', () => {
       const result = await download(VIDEOS[1].ID, yt);
       expect(result).toBeTruthy();
     }, 30000);
+  });
+  
+  describe('YouTube Music', () => {
+    let search: any;
+
+    it('should search', async () => {
+      search = await yt.music.search(VIDEOS[1].QUERY);
+      expect(search.songs?.contents.length).toBeLessThanOrEqual(3);
+    });
+    
+    it('should retrieve search suggestions', async () => {
+      const suggestions = await yt.music.getSearchSuggestions(VIDEOS[1].QUERY);
+      expect(suggestions.length).toBeLessThanOrEqual(10);
+    });
+    
+    it('should retrieve track info', async () => {
+      const info = await yt.music.getInfo(VIDEOS[1].ID);
+      expect(info.basic_info.id).toBe(VIDEOS[1].ID);
+    });
+    
+    it('should retrieve the "Related" tab', async () => {
+      const info = await yt.music.getInfo(VIDEOS[1].ID);
+      const related = await info.getRelated();
+      expect((related as any).length).toBeGreaterThan(3);
+    });
+    
+    it('should retrieve albums', async () => {
+      const album = await yt.music.getAlbum(search.albums?.contents[0]?.id);
+      expect(album.contents).toBeDefined();
+    });
+    
+    it('should retrieve artists', async () => {
+      const artist = await yt.music.getArtist(search.artists?.contents[0]?.id);
+      expect(artist.sections).toBeDefined();
+    });
+    
+    it('should retrieve playlists', async () => {
+      const playlist = await yt.music.getPlaylist(search.playlists?.contents[0]?.id);
+      expect(playlist.items).toBeDefined();
+    });
   });
 });
 


### PR DESCRIPTION
## Description

This fixes a few inconsistencies in `Innertube#music`, adds `<track_info>#getTab()`, `<track_info>#getRelated()`, `<track_info>#getUpNext()` and `<track_info>#getLyrics()`.

### Usage
```ts
const info = await yt.music.getInfo('video_id');
 
// Get tabs available in the page 
console.info(info.available_tabs);
  
// Retrieve a tab and its contents
const target_tab = await info.getTab('Related');
console.log(target_tab);
  
// Retrieve up next with autoplay/automix on (default)
const up_next = await info.getUpNext(true); // or Music#getUpNext(id_here, true)
console.info(up_next);
  
// Retrieve lyrics
const lyrics = await info.getLyrics();
console.info(lyrics);
  
// Retrieve related content
const related = await info.getRelated();
console.info(related);
```

Fixes #182 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings