### PR TITLE
feat: add `TVHTML5_SIMPLY_EMBEDDED_PLAYER` client

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Retrieves video info, including playback data and even layout elements such as m
 | Param | Type | Description |
 | --- | --- | --- |
 | video_id | `string` | The id of the video |
-| client? | `InnerTubeClient` | `WEB`, `ANDROID` or `YTMUSIC` |
+| client? | `InnerTubeClient` | `WEB`, `ANDROID`, `YTMUSIC`, `YTMUSIC_ANDROID` or `TV_EMBEDDED` |
 
 <details>
 <summary>Methods & Getters</summary>
@@ -347,7 +347,7 @@ Suitable for cases where you only need basic video metadata. Also, it is faster 
 | Param | Type | Description |
 | --- | --- | --- |
 | video_id | `string` | The id of the video |
-| client? | `InnerTubeClient` | `WEB`, `ANDROID` or `YTMUSIC` |
+| client? | `InnerTubeClient` | `WEB`, `ANDROID`, `YTMUSIC_ANDROID`, `YTMUSIC`, `TV_EMBEDDED` |
 
 <a name="search"></a>
 ### search(query, filters?)
@@ -569,7 +569,7 @@ For example, you may want to call an endpoint directly, that can be achieved wit
 
 const payload = {
   videoId: 'jLTOuvBTLxA',
-  client: 'YTMUSIC', // InnerTube client, can be ANDROID, YTMUSIC, WEB
+  client: 'YTMUSIC', // InnerTube client, can be ANDROID, YTMUSIC, YTMUSIC_ANDROID, WEB or TV_EMBEDDED
   parse: true // tells YouTube.js to parse the response, this is not sent to InnerTube.
 };
 

--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -48,7 +48,7 @@ export interface SearchFilters {
   sort_by?: 'relevance' | 'rating' | 'upload_date' | 'view_count';
 }
 
-export type InnerTubeClient = 'ANDROID' | 'YTMUSIC_ANDROID' | 'WEB' | 'YTMUSIC';
+export type InnerTubeClient = 'WEB' | 'ANDROID' | 'YTMUSIC_ANDROID' | 'YTMUSIC' | 'TV_EMBEDDED';
 
 class Innertube {
   session;

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -25,6 +25,7 @@ export interface Context {
     userAgent: string;
     clientName: string;
     clientVersion: string;
+    clientScreen?: string,
     androidSdkVersion?: string;
     osName: string;
     osVersion: string;

--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -46,9 +46,9 @@ export interface FormatOptions {
    */
   format?: string;
   /**
-   * InnerTube client, can be ANDROID, WEB or YTMUSIC
+   * InnerTube client, can be ANDROID, WEB, YTMUSIC, YTMUSIC_ANDROID or TV_EMBEDDED
    */
-  client?: 'ANDROID' | 'WEB' | 'YTMUSIC'
+  client?: 'ANDROID' | 'WEB' | 'YTMUSIC' | 'YTMUSIC_ANDROID' | 'TV_EMBEDDED'
 }
 
 export interface DownloadOptions extends FormatOptions {

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -49,6 +49,10 @@ export const CLIENTS = Object.freeze({
   YTMUSIC_ANDROID: {
     NAME: 'ANDROID_MUSIC',
     VERSION: '5.17.51'
+  },
+  TV_EMBEDDED: {
+    NAME: 'TVHTML5_SIMPLY_EMBEDDED_PLAYER',
+    VERSION: '2.0'
   }
 });
 export const STREAM_HEADERS = Object.freeze({

--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -146,6 +146,7 @@ export default class HTTPClient {
       case 'TV_EMBEDDED':
         ctx.client.clientVersion = Constants.CLIENTS.TV_EMBEDDED.VERSION;
         ctx.client.clientName = Constants.CLIENTS.TV_EMBEDDED.NAME;
+        ctx.client.clientScreen = 'EMBED';
         break;
       default:
         break;

--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -143,6 +143,10 @@ export default class HTTPClient {
         ctx.client.clientName = Constants.CLIENTS.YTMUSIC_ANDROID.NAME;
         ctx.client.androidSdkVersion = Constants.CLIENTS.ANDROID.SDK_VERSION;
         break;
+      case 'TV_EMBEDDED':
+        ctx.client.clientVersion = Constants.CLIENTS.TV_EMBEDDED.VERSION;
+        ctx.client.clientName = Constants.CLIENTS.TV_EMBEDDED.NAME;
+        break;
       default:
         break;
     }


### PR DESCRIPTION
## Description

This adds support for the `TVHTML5_SIMPLY_EMBEDDED_PLAYER` client, which is able to bypass some age restricted videos. See #191, thanks @unixfox!

### Usage
```ts
// Video info
const info = await yt.getInfo('somevideoid', 'TV_EMBEDDED');
console.log(info);

// Download 
const stream = await yt.download('somevideoid', {
  type: 'video+audio',
  quality: 'best',
  client: 'TV_EMBEDDED'
});
  
const file = createWriteStream('./video.mp4');
    
for await (const chunk of streamToIterable(stream)) {
  file.write(chunk);
}
```
## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings