### PR TITLE
Live Chat - add RemoveChatItemAction and LiveChatTickerStickerItem

### DIFF
--- a/src/parser/classes/livechat/RemoveChatItemAction.ts
+++ b/src/parser/classes/livechat/RemoveChatItemAction.ts
@@ -1,0 +1,14 @@
+import { YTNode } from '../../helpers';
+
+class RemoveChatItemAction extends YTNode {
+  static type = 'RemoveChatItemAction';
+
+  target_item_id: string;
+
+  constructor(data: any) {
+    super();
+    this.target_item_id = data.targetItemId;
+  }
+}
+
+export default RemoveChatItemAction;

--- a/src/parser/classes/livechat/items/LiveChatTickerPaidStickerItem.ts
+++ b/src/parser/classes/livechat/items/LiveChatTickerPaidStickerItem.ts
@@ -1,0 +1,56 @@
+import Text from '../../misc/Text';
+import Thumbnail from '../../misc/Thumbnail';
+import NavigationEndpoint from '../../NavigationEndpoint';
+import MetadataBadge from '../../MetadataBadge';
+import LiveChatAuthorBadge from '../../LiveChatAuthorBadge';
+import Parser from '../../../index';
+
+import { YTNode } from '../../../helpers';
+
+class LiveChatTickerPaidStickerItem extends YTNode {
+  static type = 'LiveChatTickerPaidStickerItem';
+
+  author: {
+    id: string;
+    thumbnails: Thumbnail[];
+    badges: LiveChatAuthorBadge[] | MetadataBadge[];
+    is_moderator: boolean | null;
+    is_verified: boolean | null;
+    is_verified_artist: boolean | null;
+  };
+
+  amount: Text;
+  duration_sec: string; // Or number?
+  full_duration_sec: string;
+  show_item;
+  show_item_endpoint: NavigationEndpoint;
+  id: string;
+
+  constructor(data: any) {
+    super();
+
+    this.author = {
+      id: data.authorExternalChannelId,
+      thumbnails: Thumbnail.fromResponse(data.authorPhoto),
+      badges: Parser.parseArray<LiveChatAuthorBadge | MetadataBadge>(data.authorBadges, [ MetadataBadge, LiveChatAuthorBadge ]),
+      is_moderator: null,
+      is_verified: null,
+      is_verified_artist: null
+    };
+
+    const badges = Parser.parseArray<LiveChatAuthorBadge | MetadataBadge>(data.authorBadges, [ MetadataBadge, LiveChatAuthorBadge ]);
+
+    this.author.badges = badges;
+    this.author.is_moderator = badges?.some((badge) => badge.icon_type == 'MODERATOR') || null;
+    this.author.is_verified = badges?.some((badge) => badge.style == 'BADGE_STYLE_TYPE_VERIFIED') || null;
+    this.author.is_verified_artist = badges?.some((badge) => badge.style == 'BADGE_STYLE_TYPE_VERIFIED_ARTIST') || null;
+    this.amount = new Text(data.amount);
+    this.duration_sec = data.durationSec;
+    this.full_duration_sec = data.fullDurationSec;
+    this.show_item = Parser.parse(data.showItemEndpoint.showLiveChatItemEndpoint.renderer);
+    this.show_item_endpoint = new NavigationEndpoint(data.showItemEndpoint);
+    this.id = data.id;
+  }
+}
+
+export default LiveChatTickerPaidStickerItem;

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -103,6 +103,7 @@ import { default as LiveChatPlaceholderItem } from './classes/livechat/items/Liv
 import { default as LiveChatProductItem } from './classes/livechat/items/LiveChatProductItem';
 import { default as LiveChatTextMessage } from './classes/livechat/items/LiveChatTextMessage';
 import { default as LiveChatTickerPaidMessageItem } from './classes/livechat/items/LiveChatTickerPaidMessageItem';
+import { default as LiveChatTickerPaidStickerItem } from './classes/livechat/items/LiveChatTickerPaidStickerItem';
 import { default as LiveChatTickerSponsorItem } from './classes/livechat/items/LiveChatTickerSponsorItem';
 import { default as LiveChatViewerEngagementMessage } from './classes/livechat/items/LiveChatViewerEngagementMessage';
 import { default as PollHeader } from './classes/livechat/items/PollHeader';
@@ -110,6 +111,7 @@ import { default as LiveChatActionPanel } from './classes/livechat/LiveChatActio
 import { default as MarkChatItemAsDeletedAction } from './classes/livechat/MarkChatItemAsDeletedAction';
 import { default as MarkChatItemsByAuthorAsDeletedAction } from './classes/livechat/MarkChatItemsByAuthorAsDeletedAction';
 import { default as RemoveBannerForLiveChatCommand } from './classes/livechat/RemoveBannerForLiveChatCommand';
+import { default as RemoveChatItemAction } from './classes/livechat/RemoveChatItemAction';
 import { default as ReplaceChatItemAction } from './classes/livechat/ReplaceChatItemAction';
 import { default as ReplayChatItemAction } from './classes/livechat/ReplayChatItemAction';
 import { default as ShowLiveChatActionPanelAction } from './classes/livechat/ShowLiveChatActionPanelAction';
@@ -378,6 +380,7 @@ const map: Record<string, YTNodeConstructor> = {
   LiveChatProductItem,
   LiveChatTextMessage,
   LiveChatTickerPaidMessageItem,
+  LiveChatTickerPaidStickerItem,
   LiveChatTickerSponsorItem,
   LiveChatViewerEngagementMessage,
   PollHeader,
@@ -385,6 +388,7 @@ const map: Record<string, YTNodeConstructor> = {
   MarkChatItemAsDeletedAction,
   MarkChatItemsByAuthorAsDeletedAction,
   RemoveBannerForLiveChatCommand,
+  RemoveChatItemAction,
   ReplaceChatItemAction,
   ReplayChatItemAction,
   ShowLiveChatActionPanelAction,


### PR DESCRIPTION
## Description

### add a new live chat action: `RemoveChatItemAction`
This seems to be a new action and replacement for `MarkChatItemAsDeletedAction`.
Actual response has only target_id

### add new chat item: `LiveChatTickerStickerItem`
This is a ticker item for `LivaChatPaidSticker`.

No related issues

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings