### PR TITLE
refactor: improve live chat polling 

### DIFF
--- a/src/parser/classes/livechat/RemoveChatItemByAuthorAction.ts
+++ b/src/parser/classes/livechat/RemoveChatItemByAuthorAction.ts
@@ -1,0 +1,14 @@
+import { YTNode } from '../../helpers';
+
+class RemoveChatItemByAuthorAction extends YTNode {
+  static type = 'RemoveChatItemByAuthorAction';
+
+  external_channel_id: string;
+
+  constructor(data: any) {
+    super();
+    this.external_channel_id = data.externalChannelId;
+  }
+}
+
+export default RemoveChatItemByAuthorAction;

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -112,6 +112,7 @@ import { default as MarkChatItemAsDeletedAction } from './classes/livechat/MarkC
 import { default as MarkChatItemsByAuthorAsDeletedAction } from './classes/livechat/MarkChatItemsByAuthorAsDeletedAction';
 import { default as RemoveBannerForLiveChatCommand } from './classes/livechat/RemoveBannerForLiveChatCommand';
 import { default as RemoveChatItemAction } from './classes/livechat/RemoveChatItemAction';
+import { default as RemoveChatItemByAuthorAction } from './classes/livechat/RemoveChatItemByAuthorAction';
 import { default as ReplaceChatItemAction } from './classes/livechat/ReplaceChatItemAction';
 import { default as ReplayChatItemAction } from './classes/livechat/ReplayChatItemAction';
 import { default as ShowLiveChatActionPanelAction } from './classes/livechat/ShowLiveChatActionPanelAction';
@@ -389,6 +390,7 @@ const map: Record<string, YTNodeConstructor> = {
   MarkChatItemsByAuthorAsDeletedAction,
   RemoveBannerForLiveChatCommand,
   RemoveChatItemAction,
+  RemoveChatItemByAuthorAction,
   ReplaceChatItemAction,
   ReplayChatItemAction,
   ShowLiveChatActionPanelAction,


### PR DESCRIPTION
## Description

Removes the use of `setTimeout`/`setInterval` for polling and instead measures polling interval according to how many actions were emitted in the previous req, if there were 0 actions then the default polling interval will be `1000ms`. This also slightly improves performance for live chats with a larger number of viewers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings