### PR TITLE
Don't remove "VL" from playlist id

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -220,7 +220,7 @@ class Innertube {
    */
   async getPlaylist(id: string) {
     throwIfMissing({ id });
-    const response = await this.actions.browse(`VL${id.replace(/VL/g, '')}`);
+    const response = await this.actions.browse(`VL${id}`);
     return new Playlist(this.actions, response.data);
   }
 


### PR DESCRIPTION
Playlist ids can contain `VL`. Example: https://www.youtube.com/playlist?list=PLakb9q7NpRvVL-j6lY85YW4GEWvrf8sXM
The current code would corrupt the playlist id by removing `VL` anywhere in the string.
This behavior is not documented and doesn't have a test.
I don't think this function should try to remove `VL`, but I can fix the regex to `/^VL/` instead if requested.