### PR TITLE
feat: add support for switching accounts (cookie based auth only)

### DIFF
--- a/src/core/AccountManager.ts
+++ b/src/core/AccountManager.ts
@@ -21,7 +21,7 @@ class AccountManager {
        */
       editName: (new_name: string) => {
         if (!this.#actions.session.logged_in)
-          throw new InnertubeError('You are not signed in');
+          throw new InnertubeError('You must be signed in to perform this operation.');
 
         return this.#actions.execute('/channel/edit_name', {
           givenName: new_name,
@@ -34,7 +34,7 @@ class AccountManager {
        */
       editDescription: (new_description: string) => {
         if (!this.#actions.session.logged_in)
-          throw new InnertubeError('You are not signed in');
+          throw new InnertubeError('You must be signed in to perform this operation.');
 
         return this.#actions.execute('/channel/edit_description', {
           givenDescription: new_description,
@@ -53,7 +53,7 @@ class AccountManager {
    */
   async getInfo() {
     if (!this.#actions.session.logged_in)
-      throw new InnertubeError('You are not signed in');
+      throw new InnertubeError('You must be signed in to perform this operation.');
 
     const response = await this.#actions.execute('/account/accounts_list', { client: 'ANDROID' });
     return new AccountInfo(response);

--- a/src/core/Actions.ts
+++ b/src/core/Actions.ts
@@ -122,7 +122,7 @@ class Actions {
 
       if (Reflect.has(data, 'browseId')) {
         if (this.#needsLogin(data.browseId) && !this.#session.logged_in)
-          throw new InnertubeError('You are not signed in');
+          throw new InnertubeError('You must be signed in to perform this operation.');
       }
 
       if (Reflect.has(data, 'override_endpoint'))

--- a/src/core/InteractionManager.ts
+++ b/src/core/InteractionManager.ts
@@ -17,7 +17,7 @@ class InteractionManager {
     throwIfMissing({ video_id });
 
     if (!this.#actions.session.logged_in)
-      throw new Error('You are not signed in');
+      throw new Error('You must be signed in to perform this operation.');
 
     const action = await this.#actions.execute('/like/like', {
       client: 'ANDROID',
@@ -37,7 +37,7 @@ class InteractionManager {
     throwIfMissing({ video_id });
 
     if (!this.#actions.session.logged_in)
-      throw new Error('You are not signed in');
+      throw new Error('You must be signed in to perform this operation.');
 
     const action = await this.#actions.execute('/like/dislike', {
       client: 'ANDROID',
@@ -57,7 +57,7 @@ class InteractionManager {
     throwIfMissing({ video_id });
 
     if (!this.#actions.session.logged_in)
-      throw new Error('You are not signed in');
+      throw new Error('You must be signed in to perform this operation.');
 
     const action = await this.#actions.execute('/like/removelike', {
       client: 'ANDROID',
@@ -77,7 +77,7 @@ class InteractionManager {
     throwIfMissing({ channel_id });
 
     if (!this.#actions.session.logged_in)
-      throw new Error('You are not signed in');
+      throw new Error('You must be signed in to perform this operation.');
 
     const action = await this.#actions.execute('/subscription/subscribe', {
       client: 'ANDROID',
@@ -96,7 +96,7 @@ class InteractionManager {
     throwIfMissing({ channel_id });
 
     if (!this.#actions.session.logged_in)
-      throw new Error('You are not signed in');
+      throw new Error('You must be signed in to perform this operation.');
 
     const action = await this.#actions.execute('/subscription/unsubscribe', {
       client: 'ANDROID',
@@ -116,7 +116,7 @@ class InteractionManager {
     throwIfMissing({ video_id, text });
 
     if (!this.#actions.session.logged_in)
-      throw new Error('You are not signed in');
+      throw new Error('You must be signed in to perform this operation.');
 
     const action = await this.#actions.execute('/comment/create_comment', {
       client: 'ANDROID',
@@ -163,7 +163,7 @@ class InteractionManager {
     throwIfMissing({ channel_id, type });
 
     if (!this.#actions.session.logged_in)
-      throw new Error('You are not signed in');
+      throw new Error('You must be signed in to perform this operation.');
 
     const pref_types = {
       PERSONALIZED: 1,

--- a/src/core/PlaylistManager.ts
+++ b/src/core/PlaylistManager.ts
@@ -20,7 +20,7 @@ class PlaylistManager {
     throwIfMissing({ title, video_ids });
 
     if (!this.#actions.session.logged_in)
-      throw new InnertubeError('You are not signed in');
+      throw new InnertubeError('You must be signed in to perform this operation.');
 
     const response = await this.#actions.execute('/playlist/create', {
       title,
@@ -44,7 +44,7 @@ class PlaylistManager {
     throwIfMissing({ playlist_id });
 
     if (!this.#actions.session.logged_in)
-      throw new InnertubeError('You are not signed in');
+      throw new InnertubeError('You must be signed in to perform this operation.');
 
     const response = await this.#actions.execute('playlist/delete', { playlistId: playlist_id });
 
@@ -65,7 +65,7 @@ class PlaylistManager {
     throwIfMissing({ playlist_id, video_ids });
 
     if (!this.#actions.session.logged_in)
-      throw new InnertubeError('You are not signed in');
+      throw new InnertubeError('You must be signed in to perform this operation.');
 
     const response = await this.#actions.execute('/browse/edit_playlist', {
       playlistId: playlist_id,
@@ -91,7 +91,7 @@ class PlaylistManager {
     throwIfMissing({ playlist_id, video_ids });
 
     if (!this.#actions.session.logged_in)
-      throw new InnertubeError('You are not signed in');
+      throw new InnertubeError('You must be signed in to perform this operation.');
 
     const info = await this.#actions.execute('/browse', {
       browseId: `VL${playlist_id}`,
@@ -150,7 +150,7 @@ class PlaylistManager {
     throwIfMissing({ playlist_id, moved_video_id, predecessor_video_id });
 
     if (!this.#actions.session.logged_in)
-      throw new InnertubeError('You are not signed in');
+      throw new InnertubeError('You must be signed in to perform this operation.');
 
     const info = await this.#actions.execute('/browse', {
       browseId: `VL${playlist_id}`,

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -110,7 +110,14 @@ export default class Session extends EventEmitterLike {
   }
 
   static async create(options: SessionOptions = {}) {
-    const { context, api_key, api_version, account_index } = await Session.getSessionData(options.lang, options.account_index, options.device_category, options.client_type, options.timezone, options.fetch);
+    const { context, api_key, api_version, account_index } = await Session.getSessionData(
+      options.lang,
+      options.account_index,
+      options.device_category,
+      options.client_type,
+      options.timezone,
+      options.fetch
+    );
     return new Session(context, api_key, api_version, account_index, await Player.create(options.cache, options.fetch), options.cookie, options.fetch, options.cache);
   }
 

--- a/src/core/Studio.ts
+++ b/src/core/Studio.ts
@@ -52,7 +52,7 @@ class Studio {
    */
   async setThumbnail(video_id: string, buffer: Uint8Array): Promise<ApiResponse> {
     if (!this.#session.logged_in)
-      throw new InnertubeError('You are not signed in');
+      throw new InnertubeError('You must be signed in to perform this operation.');
 
     if (!video_id || !buffer)
       throw new MissingParamError('One or more parameters are missing.');
@@ -83,7 +83,7 @@ class Studio {
    */
   async updateVideoMetadata(video_id: string, metadata: VideoMetadata) {
     if (!this.#session.logged_in)
-      throw new InnertubeError('You are not signed in');
+      throw new InnertubeError('You must be signed in to perform this operation.');
 
     const payload = Proto.encodeVideoMetadataPayload(video_id, metadata);
 
@@ -105,7 +105,7 @@ class Studio {
    */
   async upload(file: BodyInit, metadata: UploadedVideoMetadata = {}): Promise<ApiResponse> {
     if (!this.#session.logged_in)
-      throw new InnertubeError('You are not signed in');
+      throw new InnertubeError('You must be signed in to perform this operation.');
 
     const initial_data = await this.#getInitialUploadData();
     const upload_result = await this.#uploadVideo(initial_data.upload_url, file);

--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -103,9 +103,12 @@ export default class HTTPClient {
 
       if (this.#cookie) {
         const papisid = getStringBetweenStrings(this.#cookie, 'PAPISID=', ';');
+       
         if (papisid) {
           request_headers.set('authorization', await generateSidAuth(papisid));
+          request_headers.set('x-goog-authuser', this.#session.account_index.toString());
         }
+
         request_headers.set('cookie', this.#cookie);
       }
     }

--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -103,7 +103,7 @@ export default class HTTPClient {
 
       if (this.#cookie) {
         const papisid = getStringBetweenStrings(this.#cookie, 'PAPISID=', ';');
-       
+
         if (papisid) {
           request_headers.set('authorization', await generateSidAuth(papisid));
           request_headers.set('x-goog-authuser', this.#session.account_index.toString());


### PR DESCRIPTION
## Description

Adds support for switching accounts with cookie based authentication, as suggested by #229.

Usage:
```ts
//...

const yt = await Innertube.create({
  cache: new UniversalCache(),
  account_index: 0, // In this case, 0 would be the first account
  cookie: 'VISITOR_INFO1_LIVE=Cvx_zk; PREF=tx=America ...'
});

// Check if we're on the desired account:
const settings = await yt.getSettings();
console.info(settings.introduction);
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings