### PR TITLE
feat(Channel): add support for filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,11 +497,16 @@ Retrieves contents for a given channel.
 <p>
 
 - `<channel>#getVideos()`
+- `<channel>#getShorts()`
+- `<channel>#getLiveStreams()`
 - `<channel>#getPlaylists()`
 - `<channel>#getHome()`
 - `<channel>#getCommunity()`
 - `<channel>#getChannels()`
 - `<channel>#getAbout()`
+- `<channel>#getContinuation()`
+- `<channel>#filters`
+- `<channel>#page`
 
 </p>
 </details> 

--- a/src/core/Feed.ts
+++ b/src/core/Feed.ts
@@ -29,6 +29,7 @@ import AppendContinuationItemsAction from '../parser/classes/actions/AppendConti
 import ContinuationItem from '../parser/classes/ContinuationItem';
 
 import Video from '../parser/classes/Video';
+import ReelItem from '../parser/classes/ReelItem';
 
 class Feed {
   #page: ParsedResponse;
@@ -63,9 +64,10 @@ class Feed {
    * Get all videos on a given page via memo
    */
   static getVideosFromMemo(memo: Memo) {
-    return memo.getType<Video | GridVideo | CompactVideo | PlaylistVideo | PlaylistPanelVideo | WatchCardCompactVideo>([
+    return memo.getType<Video | GridVideo | ReelItem | CompactVideo | PlaylistVideo | PlaylistPanelVideo | WatchCardCompactVideo>([
       Video,
       GridVideo,
+      ReelItem,
       CompactVideo,
       PlaylistVideo,
       PlaylistPanelVideo,

--- a/src/parser/classes/SectionList.ts
+++ b/src/parser/classes/SectionList.ts
@@ -15,6 +15,7 @@ class SectionList extends YTNode {
       this.target_id = data.targetId;
     }
 
+    // TODO: this should be Parser#parseArray
     this.contents = Parser.parse(data.contents);
 
     if (data.continuations) {

--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -41,6 +41,10 @@ export default class Channel extends TabbedFeed {
     this.current_tab = tab;
   }
 
+  /**
+   * Applies given filter to the list.
+   * @param filter - The filter to apply
+   */
   async applyFilter(filter: string | ChipCloudChip) {
     let target_filter: ChipCloudChip | undefined;
 

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -12,3 +12,10 @@ export const VIDEOS = [
     QUERY: 'mkbhd',
   }
 ];
+
+export const CHANNELS = [
+  {
+    ID: 'UC_x5XG1OV2P6uZZ5FSM9Ttw',
+    NAME: 'Linus Tech Tips'
+  }
+];

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import Innertube from '..';
-import { VIDEOS } from './constants';
+import { CHANNELS, VIDEOS } from './constants';
 import { streamToIterable } from '../src/utils/Utils';
 
 describe('YouTube.js Tests', () => { 
@@ -90,6 +90,18 @@ describe('YouTube.js Tests', () => {
       expect(playlist.items.length).toBeLessThanOrEqual(100);
     });
     
+    it('should retrieve channel', async () => {
+      const channel = await yt.getChannel(CHANNELS[0].ID);
+      expect(channel.videos.length).toBeGreaterThan(0);
+      expect(channel.shelves.length).toBeGreaterThan(0);
+
+      const videos_tab = await channel.getVideos();
+      expect(videos_tab.videos.length).toBeGreaterThan(0);
+
+      const filtered_list = await videos_tab.applyFilter('Popular');
+      expect(filtered_list.videos.length).toBeGreaterThan(0);
+    });
+
     it('should retrieve home feed', async () => {
       const homefeed = await yt.getHomeFeed();
       expect(homefeed.header).toBeDefined();


### PR DESCRIPTION
## Description

Adds support for applying filters to a channel's video/livestream/shorts list. 

#### Usage:
```ts
const channel = await yt.getChannel('somechannelid');

const videos_tab = await channel.getVideos();

// Get filter list:
console.info(videos_tab.filters);

// Apply a filter:
const filtered_video_list = await videos.applyFilter('Popular');
console.info(filtered_video_list.videos);
``` 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings