### PR TITLE
feat: make `Player` instance optional

### DIFF
--- a/src/core/Actions.ts
+++ b/src/core/Actions.ts
@@ -49,7 +49,7 @@ class Actions {
           referer: 'https://www.youtube.com',
           currentUrl: `/watch?v=${id}`,
           autonavState: 'STATE_OFF',
-          signatureTimestamp: this.#session.player.sts,
+          signatureTimestamp: this.#session.player?.sts || 0,
           autoCaptionsDefaultOn: false,
           html5Preference: 'HTML5_PREF_WANTS',
           lactMilliseconds: '-1'
@@ -188,6 +188,7 @@ class Actions {
       'FEsubscriptions',
       'FEmusic_listening_review',
       'FEmusic_library_landing',
+      'SPaccount_overview',
       'SPaccount_notifications',
       'SPaccount_privacy',
       'SPtime_watched'

--- a/src/core/Music.ts
+++ b/src/core/Music.ts
@@ -61,7 +61,7 @@ class Music {
       videoId: video_id,
       playbackContext: {
         contentPlaybackContext: {
-          signatureTimestamp: this.#session.player.sts
+          signatureTimestamp: this.#session.player?.sts || 0
         }
       }
     });
@@ -89,7 +89,7 @@ class Music {
       client: 'YTMUSIC',
       playbackContext: {
         contentPlaybackContext: {
-          signatureTimestamp: this.#session.player.sts
+          signatureTimestamp: this.#session.player?.sts || 0
         }
       }
     });

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -78,7 +78,7 @@ export default class Session extends EventEmitterLike {
   actions;
   cache;
 
-  constructor(context: Context, api_key: string, api_version: string, account_index: number, player: Player, cookie?: string, fetch?: FetchFunction, cache?: UniversalCache) {
+  constructor(context: Context, api_key: string, api_version: string, account_index: number, player?: Player, cookie?: string, fetch?: FetchFunction, cache?: UniversalCache) {
     super();
     this.#context = context;
     this.#account_index = account_index;

--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -1,4 +1,5 @@
 import Player from '../../../core/Player';
+import { InnertubeError } from '../../../utils/Utils';
 
 class Format {
   itag: string;
@@ -73,7 +74,8 @@ class Format {
    * Decipher the streaming url of the format.
    * @returns Deciphered URL.
    */
-  decipher(player: Player): string {
+  decipher(player: Player | undefined): string {
+    if (!player) throw new InnertubeError('Cannot decipher format, this session appears to have no valid player.');
     return player.decipher(this.url, this.signature_cipher, this.cipher);
   }
 }

--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -92,7 +92,7 @@ class VideoInfo {
    * @param data - API response.
    * @param cpn - Client Playback Nonce
    */
-  constructor(data: [ApiResponse, ApiResponse?], actions: Actions, player: Player, cpn: string) {
+  constructor(data: [ApiResponse, ApiResponse?], actions: Actions, player?: Player, cpn?: string) {
     this.#actions = actions;
     this.#player = player;
     this.#cpn = cpn;
@@ -492,7 +492,7 @@ class VideoInfo {
       throw new InnertubeError('Index and init ranges not available', { format });
 
     const url = new URL(format.decipher(this.#player));
-    url.searchParams.set('cpn', this.#cpn);
+    url.searchParams.set('cpn', this.#cpn || '');
 
     set.appendChild(this.#el(document, 'Representation', {
       id: format.itag,
@@ -522,7 +522,7 @@ class VideoInfo {
       throw new InnertubeError('Index and init ranges not available', { format });
 
     const url = new URL(format.decipher(this.#player));
-    url.searchParams.set('cpn', this.#cpn);
+    url.searchParams.set('cpn', this.#cpn || '');
 
     set.appendChild(this.#el(document, 'Representation', {
       id: format.itag,


### PR DESCRIPTION
## Description

This makes the `Player` instance optional when creating new sessions, as suggested by @absidue on Discord.

Usage:
```ts
import { Innertube, Session, UniversalCache } from 'youtubei.js';

(async () => {
  const { context, api_key, api_version, account_index } = await Session.getSessionData();
 
  const session = new Session(
    context,
    api_key,
    api_version,
    account_index,
    undefined, // Player
    undefined, // Cookies
    undefined, // Fetch
    new UniversalCache()
  );

  const yt = new Innertube(session);
  // ...
})();
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings