### PR TITLE
fix: signature decipher extraction failing

### DIFF
--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -167,13 +167,13 @@ export default class Player {
 
   static extractSigSourceCode(data: string) {
     const calls = getStringBetweenStrings(data, 'function(a){a=a.split("")', 'return a.join("")}');
-    const obj_name = calls?.split('.')?.[0]?.replace(';', '');
-    const functions = getStringBetweenStrings(data, `var ${obj_name}=`, '};');
+    const obj_name = calls?.split(/\.|\[/)?.[0]?.replace(';', '')?.trim();
+    const functions = getStringBetweenStrings(data, `var ${obj_name}={`, '};');
 
     if (!functions || !calls)
       console.warn(new PlayerError('Failed to extract signature decipher algorithm'));
 
-    return `function descramble_sig(a) { a = a.split(""); let ${obj_name}=${functions}}${calls} return a.join("") } descramble_sig(sig);`;
+    return `function descramble_sig(a) { a = a.split(""); let ${obj_name}={${functions}}${calls} return a.join("") } descramble_sig(sig);`;
   }
 
   static extractNSigSourceCode(data: string) {


### PR DESCRIPTION
## Description

The signature decipher code extraction was failing due to the way functions are being called in player [11667490](https://www.youtube.com/s/player/11667490/player_ias.vflset/en_US/base.js). Ex: instead of `MC.if(a, 71)`, it uses `MC["if"](a, 71)`.

Note:
If you are using UniversalCache, you will have to clear it so the library can extract the deciphers correctly.

Fixes #248 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings