### PR TITLE
Fix author and thumbnails for autogenerated playlists

### DIFF
--- a/src/parser/youtube/Playlist.ts
+++ b/src/parser/youtube/Playlist.ts
@@ -7,6 +7,7 @@ import VideoOwner from '../classes/VideoOwner';
 import PlaylistMetadata from '../classes/PlaylistMetadata';
 import PlaylistSidebarPrimaryInfo from '../classes/PlaylistSidebarPrimaryInfo';
 import PlaylistSidebarSecondaryInfo from '../classes/PlaylistSidebarSecondaryInfo';
+import PlaylistCustomThumbnail from '../classes/PlaylistCustomThumbnail';
 import PlaylistVideoThumbnail from '../classes/PlaylistVideoThumbnail';
 import PlaylistHeader from '../classes/PlaylistHeader';
 
@@ -30,8 +31,8 @@ class Playlist extends Feed {
     this.info = {
       ...this.page.metadata.item().as(PlaylistMetadata),
       ...{
-        author: secondary_info?.owner.item().as(VideoOwner).author,
-        thumbnails: primary_info?.thumbnail_renderer.item().as(PlaylistVideoThumbnail).thumbnail as Thumbnail[],
+        author: secondary_info?.owner.item().as(VideoOwner).author ?? header?.author,
+        thumbnails: primary_info?.thumbnail_renderer.item().as(PlaylistVideoThumbnail, PlaylistCustomThumbnail).thumbnail as Thumbnail[],
         total_items: this.#getStat(0, primary_info),
         views: this.#getStat(1, primary_info),
         last_updated: this.#getStat(2, primary_info),


### PR DESCRIPTION
# Pull Request Template

## Description

While testing https://github.com/FreeTubeApp/FreeTube/pull/2903, we noticed that autogenerated playlists like https://m.youtube.com/playlist?list=RDCLAK5uy_nxNaxtS5HwGabWeGHsAADVA4KKl5l12eQ are partially supported by this library, with it spitting out this error:
![casting_error](https://user-images.githubusercontent.com/48293849/205163070-cb7d2c67-e43c-4124-a2a3-bc3008f638a1.png)

This pull request fixes that casting issue and also fixes the author field on the playlist being empty, the only missing bit of information is the thumbnails for the playlist author (empty array), although YouTube doesn't show it either, so I think that's fine.

The changes in this pull request work well with this FreeTube pull request https://github.com/FreeTubeApp/FreeTube/pull/2903 and were tested with it. Interestingly when I wanted to add a unit test to this library to test the autogenerated playlist, I ran into this error:
![unit_test_error](https://user-images.githubusercontent.com/48293849/205163791-d35df70d-c3c8-48df-b0eb-0539ab9f6943.png)
Which is weird, because YouTube will happily return the playlist when the library is used inside of FreeTube. If I had to guess the differences are probably user agent related. Happy to add a unit test if there is a way to make it work in the unit test.

Here are the relevant lines of code in FreeTube, yes we don't have the most standard setup for YouTube.js 😬, see https://github.com/FreeTubeApp/FreeTube/pull/2855 for some of the reasoning behind our setup. We also disable CORS entirely in Electron, so that we don't have to deal with that.

[_scripts/webpack.renderer.config.js | lines 129-141](https://github.com/FreeTubeApp/FreeTube/blob/c98b6ab3f27895cd81dd302f17ef5473e9691c58/_scripts/webpack.renderer.config.js#L129-L141)

[src/renderer/helpers/api/local.js | lines 18-43](https://github.com/FreeTubeApp/FreeTube/blob/c98b6ab3f27895cd81dd302f17ef5473e9691c58/src/renderer/helpers/api/local.js#L18-L43)

[src/main/index.js | lines 175-183](https://github.com/FreeTubeApp/FreeTube/blob/c98b6ab3f27895cd81dd302f17ef5473e9691c58/src/main/index.js#L175-L183)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings