### PR TITLE
feat(TextRun): add support for formatting

### DIFF
--- a/src/parser/classes/misc/TextRun.ts
+++ b/src/parser/classes/misc/TextRun.ts
@@ -3,9 +3,15 @@ import NavigationEndpoint from '../NavigationEndpoint';
 class TextRun {
   text: string;
   endpoint: NavigationEndpoint | undefined;
+  bold: boolean;
+  italics: boolean;
+  strikethrough: boolean;
 
   constructor(data: any) {
     this.text = data.text;
+    this.bold = Boolean(data.bold);
+    this.italics = Boolean(data.italics);
+    this.strikethrough = Boolean(data.strikethrough);
     this.endpoint = data.navigationEndpoint ? new NavigationEndpoint(data.navigationEndpoint) : undefined;
   }
 }

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -10,6 +10,10 @@ export const VIDEOS = [
   {
     ID: 'I1qsF0WQy8c',
     QUERY: 'mkbhd',
+  },
+  {
+    ID: 'OqiXFXlYFi8',
+    QUERY: 'formatted comment text'
   }
 ];
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import Innertube from '..';
 import { CHANNELS, VIDEOS } from './constants';
 import { streamToIterable } from '../src/utils/Utils';
+import TextRun from '../src/parser/classes/misc/TextRun';
 
 describe('YouTube.js Tests', () => { 
   let yt: Innertube;
@@ -68,6 +69,19 @@ describe('YouTube.js Tests', () => {
       threads = await yt.getComments(VIDEOS[1].ID);
       expect(threads.contents.length).toBeGreaterThan(0);
     });
+
+    it('should parse formatted comments', async () => {
+      const threads = await yt.getComments(VIDEOS[3].ID);
+      const authorComment = threads.contents.find(t => t.comment?.author_is_channel_owner)
+      expect(authorComment).not.toBeUndefined();
+
+      expect(authorComment!.comment?.content.runs?.length).toBeGreaterThan(0)
+      const runs = authorComment!.comment!.content.runs! as TextRun[]
+
+      expect(runs[0].bold).toBeTruthy()
+      expect(runs[2].italics).toBeTruthy()
+      expect(runs[4].strikethrough).toBeTruthy()
+    })
     
     it('should retrieve next batch of comments', async () => {
       const next = await threads.getContinuation();


### PR DESCRIPTION
## Description

YouTube allows users to use bold, italics and strikethrough formatting in their comments (presumably also in video descriptions, I haven't found a video to test my theory though). This pull request makes the parser extract that formatting information. The main use for this, is to be able to replicate the appearance of comments on YouTube, while showing the comments to users.

A good video to test this with is https://www.youtube.com/watch?v=OqiXFXlYFi8, which is mentioned in this article about how to do the formatting https://www.simplehelp.net/2021/08/19/how-to-format-text-in-youtube-comments-bold-italicized-or-crossed-out/

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings