### PR TITLE
feat: bring back `Video#is_live` and add `ExpandableMetadata`

### DIFF
--- a/src/parser/classes/Button.ts
+++ b/src/parser/classes/Button.ts
@@ -6,17 +6,21 @@ import { YTNode } from '../helpers';
 class Button extends YTNode {
   static type = 'Button';
 
-  text: string;
+  text?: string;
 
-  label;
-  tooltip;
-  icon_type;
+  label?: string;
+  tooltip?: string;
+  icon_type?: string;
+  is_disabled?: boolean;
 
   endpoint: NavigationEndpoint;
 
   constructor(data: any) {
     super();
-    this.text = new Text(data.text).toString();
+
+    if (data.text) {
+      this.text = new Text(data.text).toString();
+    }
 
     if (data.accessibility?.label) {
       this.label = data.accessibility?.label;
@@ -28,6 +32,10 @@ class Button extends YTNode {
 
     if (data.icon?.iconType) {
       this.icon_type = data.icon?.iconType;
+    }
+
+    if (Reflect.has(data, 'isDisabled')) {
+      this.is_disabled = data.isDisabled;
     }
 
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint || data.serviceEndpoint || data.command);

--- a/src/parser/classes/ExpandableMetadata.ts
+++ b/src/parser/classes/ExpandableMetadata.ts
@@ -1,0 +1,41 @@
+import Parser from '..';
+
+import Text from './misc/Text';
+import Thumbnail from './misc/Thumbnail';
+
+import Button from './Button';
+import HorizontalCardList from './HorizontalCardList';
+
+import { YTNode } from '../helpers';
+
+class ExpandableMetadata extends YTNode {
+  static type = 'ExpandableMetadata';
+
+  header: {
+    collapsed_title: Text;
+    collapsed_thumbnail: Thumbnail[];
+    collapsed_label: Text;
+    expanded_title: Text;
+  };
+
+  expanded_content: HorizontalCardList | null;
+  expand_button: Button | null;
+  collapse_button: Button | null;
+
+  constructor(data: any) {
+    super();
+
+    this.header = {
+      collapsed_title: new Text(data.header.collapsedTitle),
+      collapsed_thumbnail: Thumbnail.fromResponse(data.header.collapsedThumbnail),
+      collapsed_label: new Text(data.header.collapsedLabel),
+      expanded_title: new Text(data.header.expandedTitle)
+    };
+
+    this.expanded_content = Parser.parseItem<HorizontalCardList>(data.expandedContent);
+    this.expand_button = Parser.parseItem<Button>(data.expandButton);
+    this.collapse_button = Parser.parseItem<Button>(data.collapseButton);
+  }
+}
+
+export default ExpandableMetadata;

--- a/src/parser/classes/HorizontalCardList.ts
+++ b/src/parser/classes/HorizontalCardList.ts
@@ -2,6 +2,7 @@ import Parser from '../index';
 import { YTNode } from '../helpers';
 import SearchRefinementCard from './SearchRefinementCard';
 import Button from './Button';
+import MacroMarkersListItem from './MacroMarkersListItem';
 
 class HorizontalCardList extends YTNode {
   static type = 'HorizontalCardList';
@@ -13,7 +14,7 @@ class HorizontalCardList extends YTNode {
 
   constructor(data: any) {
     super();
-    this.cards = Parser.parseArray<SearchRefinementCard>(data.cards, SearchRefinementCard);
+    this.cards = Parser.parseArray<SearchRefinementCard | MacroMarkersListItem>(data.cards);
     this.header = Parser.parseItem(data.header);
     this.previous_button = Parser.parseItem<Button>(data.previousButton, Button);
     this.next_button = Parser.parseItem<Button>(data.nextButton, Button);

--- a/src/parser/classes/MacroMarkersListItem.ts
+++ b/src/parser/classes/MacroMarkersListItem.ts
@@ -1,0 +1,29 @@
+import Text from './misc/Text';
+import Thumbnail from './misc/Thumbnail';
+import NavigationEndpoint from './NavigationEndpoint';
+
+import { YTNode } from '../helpers';
+
+class MacroMarkersListItem extends YTNode {
+  static type = 'MacroMarkersListItem';
+
+  title: Text;
+  time_description: Text;
+  thumbnail: Thumbnail[];
+  on_tap_endpoint: NavigationEndpoint;
+  layout: string;
+  is_highlighted: boolean;
+
+  constructor(data: any) {
+    super();
+
+    this.title = new Text(data.title);
+    this.time_description = new Text(data.timeDescription);
+    this.thumbnail = Thumbnail.fromResponse(data.thumbnail);
+    this.on_tap_endpoint = new NavigationEndpoint(data.onTap);
+    this.layout = data.layout;
+    this.is_highlighted = data.isHighlighted;
+  }
+}
+
+export default MacroMarkersListItem;

--- a/src/parser/classes/MetadataBadge.ts
+++ b/src/parser/classes/MetadataBadge.ts
@@ -5,7 +5,8 @@ class MetadataBadge extends YTNode {
 
   icon_type?: string;
   style?: string;
-  tooltip: string | null;
+  label?: string;
+  tooltip?: string;
 
   constructor(data: any) {
     super();
@@ -18,7 +19,13 @@ class MetadataBadge extends YTNode {
       this.style = data.style;
     }
 
-    this.tooltip = data?.tooltip || data?.iconTooltip || null;
+    if (data?.label) {
+      this.style = data.label;
+    }
+
+    if (data?.tooltip || data?.iconTooltip) {
+      this.tooltip = data.tooltip || data.iconTooltip;
+    }
   }
 }
 

--- a/src/parser/classes/Video.ts
+++ b/src/parser/classes/Video.ts
@@ -4,6 +4,8 @@ import Author from './misc/Author';
 import Menu from './menus/Menu';
 import Thumbnail from './misc/Thumbnail';
 import NavigationEndpoint from './NavigationEndpoint';
+import MetadataBadge from './MetadataBadge';
+import ExpandableMetadata from './ExpandableMetadata';
 
 import { timeToSeconds } from '../../utils/Utils';
 import { YTNode } from '../helpers';
@@ -18,11 +20,13 @@ class Video extends YTNode {
     text: Text;
     hover_text: Text;
   }[];
+  expandable_metadata: ExpandableMetadata | null;
 
   thumbnails: Thumbnail[];
   thumbnail_overlays;
   rich_thumbnail;
   author: Author;
+  badges: MetadataBadge[];
   endpoint: NavigationEndpoint;
   published: Text;
   view_count: Text;
@@ -36,7 +40,8 @@ class Video extends YTNode {
 
   show_action_menu: boolean;
   is_watched: boolean;
-  menu;
+  menu: Menu | null;
+  search_video_result_entity_key: string;
 
   constructor(data: any) {
     super();
@@ -54,10 +59,13 @@ class Video extends YTNode {
       hover_text: new Text(snippet.snippetHoverText)
     })) || [];
 
+    this.expandable_metadata = Parser.parseItem<ExpandableMetadata>(data.expandableMetadata);
+
     this.thumbnails = Thumbnail.fromResponse(data.thumbnail);
     this.thumbnail_overlays = Parser.parseArray(data.thumbnailOverlays);
     this.rich_thumbnail = data.richThumbnail ? Parser.parseItem(data.richThumbnail) : null;
     this.author = new Author(data.ownerText, data.ownerBadges, data.channelThumbnailSupportedRenderers?.channelThumbnailWithLinkRenderer?.thumbnail);
+    this.badges = Parser.parseArray(data.badges, MetadataBadge);
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
     this.published = new Text(data.publishedTimeText);
     this.view_count = new Text(data.viewCountText);
@@ -76,6 +84,7 @@ class Video extends YTNode {
     this.show_action_menu = data.showActionMenu;
     this.is_watched = data.isWatched || false;
     this.menu = Parser.parseItem<Menu>(data.menu, Menu);
+    this.search_video_result_entity_key = data.searchVideoResultEntityKey;
   }
 
   get description(): string {
@@ -85,22 +94,30 @@ class Video extends YTNode {
     return this.description_snippet?.toString() || '';
   }
 
-  /*
-  Get is_live() {
-    return this.badges.some((badge) => badge.style === 'BADGE_STYLE_TYPE_LIVE_NOW');
+  get is_live(): boolean {
+    return this.badges.some((badge) => {
+      if (badge.label === 'BADGE_STYLE_TYPE_LIVE_NOW' || badge.style === 'LIVE')
+        return true;
+    });
   }
-  */
 
   get is_upcoming(): boolean | undefined {
     return this.upcoming && this.upcoming > new Date();
   }
 
-  /*
-  Get has_captions() {
-    return this.badges.some((badge) => badge.label === 'CC');
-  }*/
+  get is_premiere(): boolean {
+    return this.badges.some((badge) => badge.style === 'PREMIERE');
+  }
 
-  get best_thumbnail(): Thumbnail | undefined{
+  get is_4k(): boolean {
+    return this.badges.some((badge) => badge.style === '4K');
+  }
+
+  get has_captions(): boolean {
+    return this.badges.some((badge) => badge.style === 'CC');
+  }
+
+  get best_thumbnail(): Thumbnail | undefined {
     return this.thumbnails[0];
   }
 }

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -73,6 +73,7 @@ import { default as Endscreen } from './classes/Endscreen';
 import { default as EndscreenElement } from './classes/EndscreenElement';
 import { default as EndScreenPlaylist } from './classes/EndScreenPlaylist';
 import { default as EndScreenVideo } from './classes/EndScreenVideo';
+import { default as ExpandableMetadata } from './classes/ExpandableMetadata';
 import { default as ExpandableTab } from './classes/ExpandableTab';
 import { default as ExpandedShelfContents } from './classes/ExpandedShelfContents';
 import { default as FeedFilterChipBar } from './classes/FeedFilterChipBar';
@@ -137,6 +138,7 @@ import { default as LiveChatItemList } from './classes/LiveChatItemList';
 import { default as LiveChatMessageInput } from './classes/LiveChatMessageInput';
 import { default as LiveChatParticipant } from './classes/LiveChatParticipant';
 import { default as LiveChatParticipantsList } from './classes/LiveChatParticipantsList';
+import { default as MacroMarkersListItem } from './classes/MacroMarkersListItem';
 import { default as Menu } from './classes/menus/Menu';
 import { default as MenuNavigationItem } from './classes/menus/MenuNavigationItem';
 import { default as MenuServiceItem } from './classes/menus/MenuServiceItem';
@@ -363,6 +365,7 @@ export const YTNodes = {
   EndscreenElement,
   EndScreenPlaylist,
   EndScreenVideo,
+  ExpandableMetadata,
   ExpandableTab,
   ExpandedShelfContents,
   FeedFilterChipBar,
@@ -427,6 +430,7 @@ export const YTNodes = {
   LiveChatMessageInput,
   LiveChatParticipant,
   LiveChatParticipantsList,
+  MacroMarkersListItem,
   Menu,
   MenuNavigationItem,
   MenuServiceItem,

--- a/src/parser/youtube/Search.ts
+++ b/src/parser/youtube/Search.ts
@@ -40,7 +40,7 @@ export default class Search extends Feed {
 
     if (typeof card === 'string') {
       if (!this.refinement_cards) throw new InnertubeError('No refinement cards found.');
-      target_card = this.refinement_cards?.cards.get({ query: card });
+      target_card = this.refinement_cards?.cards.get({ query: card })?.as(SearchRefinementCard);
       if (!target_card)
         throw new InnertubeError(`Refinement card "${card}" not found`, { available_cards: this.refinement_card_queries });
     } else if (card.type === 'SearchRefinementCard') {
@@ -58,7 +58,7 @@ export default class Search extends Feed {
    * Returns a list of refinement card queries.
    */
   get refinement_card_queries() {
-    return this.refinement_cards?.cards.map((card) => card.query);
+    return this.refinement_cards?.cards.as(SearchRefinementCard).map((card) => card.query);
   }
 
   /**


### PR DESCRIPTION
## Description

For some reason we had `Video#is_live` commented out, this PR fixes that. This also adds the `ExpandableMetadata` node, which usually contains video chapters data.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings