### PR TITLE
refactor: reduce reliance on localised strings

### DIFF
--- a/src/core/TabbedFeed.ts
+++ b/src/core/TabbedFeed.ts
@@ -17,7 +17,7 @@ class TabbedFeed extends Feed {
     return this.#tabs.map((tab) => tab.title.toString());
   }
 
-  async getTab(title: string) {
+  async getTabByName(title: string) {
     const tab = this.#tabs.find((tab) => tab.title.toLowerCase() === title.toLowerCase());
 
     if (!tab)
@@ -28,8 +28,19 @@ class TabbedFeed extends Feed {
 
     const response = await tab.endpoint.call(this.#actions);
 
-    if (!response)
-      throw new InnertubeError('Failed to call endpoint');
+    return new TabbedFeed(this.#actions, response.data, false);
+  }
+
+  async getTabByURL(url: string) {
+    const tab = this.#tabs.find((tab) => tab.endpoint.metadata.url?.split('/').pop() === url);
+
+    if (!tab)
+      throw new InnertubeError(`Tab "${url}" not found`);
+
+    if (tab.selected)
+      return this;
+
+    const response = await tab.endpoint.call(this.#actions);
 
     return new TabbedFeed(this.#actions, response.data, false);
   }

--- a/src/parser/classes/C4TabbedHeader.ts
+++ b/src/parser/classes/C4TabbedHeader.ts
@@ -1,20 +1,28 @@
 import Parser from '../index';
 import Author from './misc/Author';
-import Thumbnail from './misc/Thumbnail';
 import Text from './misc/Text';
+import Thumbnail from './misc/Thumbnail';
+
+import type Button from './Button';
+import type ChannelHeaderLinks from './ChannelHeaderLinks';
+import type SubscribeButton from './SubscribeButton';
+
 import { YTNode } from '../helpers';
 
 class C4TabbedHeader extends YTNode {
   static type = 'C4TabbedHeader';
 
-  author;
-  banner;
-  tv_banner;
-  mobile_banner;
-  subscribers;
-  sponsor_button;
-  subscribe_button;
-  header_links;
+  author: Author;
+  banner: Thumbnail[];
+  tv_banner: Thumbnail[];
+  mobile_banner: Thumbnail[];
+  subscribers: Text;
+  videos_count: Text;
+  sponsor_button: Button | null;
+  subscribe_button: SubscribeButton | null;
+  header_links: ChannelHeaderLinks | null;
+  channel_handle: Text;
+  channel_id: string;
 
   constructor(data: any) {
     super();
@@ -23,13 +31,16 @@ class C4TabbedHeader extends YTNode {
       navigationEndpoint: data.navigationEndpoint
     }, data.badges, data.avatar);
 
-    this.banner = data.banner ? Thumbnail.fromResponse(data.banner) : [];
-    this.tv_banner = data.tvBanner ? Thumbnail.fromResponse(data.tvBanner) : [];
-    this.mobile_banner = data.mobileBanner ? Thumbnail.fromResponse(data.mobileBanner) : [];
+    this.banner = Thumbnail.fromResponse(data.banner);
+    this.tv_banner = Thumbnail.fromResponse(data.tvBanner);
+    this.mobile_banner = Thumbnail.fromResponse(data.mobileBanner);
     this.subscribers = new Text(data.subscriberCountText);
-    this.sponsor_button = data.sponsorButton ? Parser.parseItem(data.sponsorButton) : undefined;
-    this.subscribe_button = data.subscribeButton ? Parser.parseItem(data.subscribeButton) : undefined;
-    this.header_links = data.headerLinks ? Parser.parse(data.headerLinks) : undefined;
+    this.videos_count = new Text(data.videosCountText);
+    this.sponsor_button = Parser.parseItem<Button>(data.sponsorButton);
+    this.subscribe_button = Parser.parseItem<SubscribeButton>(data.subscribeButton);
+    this.header_links = Parser.parseItem<ChannelHeaderLinks>(data.headerLinks);
+    this.channel_handle = new Text(data.channelHandleText);
+    this.channel_id = data.channelId;
   }
 }
 

--- a/src/parser/classes/ChannelAboutFullMetadata.ts
+++ b/src/parser/classes/ChannelAboutFullMetadata.ts
@@ -1,7 +1,11 @@
+import Parser from '../index';
+
+import Text from './misc/Text';
 import Thumbnail from './misc/Thumbnail';
 import NavigationEndpoint from './NavigationEndpoint';
-import Text from './misc/Text';
-import Parser from '../index';
+
+import type Button from './Button';
+
 import { YTNode } from '../helpers';
 
 class ChannelAboutFullMetadata extends YTNode {
@@ -11,13 +15,20 @@ class ChannelAboutFullMetadata extends YTNode {
   name: Text;
   avatar: Thumbnail[];
   canonical_channel_url: string;
+
+  primary_links: {
+    endpoint: NavigationEndpoint;
+    icon: Thumbnail[];
+    title: Text;
+  }[];
+
   views: Text;
   joined: Text;
   description: Text;
   email_reveal: NavigationEndpoint;
   can_reveal_email: boolean;
   country: Text;
-  buttons;
+  buttons: Button[];
 
   constructor(data: any) {
     super();
@@ -25,13 +36,20 @@ class ChannelAboutFullMetadata extends YTNode {
     this.name = new Text(data.title);
     this.avatar = Thumbnail.fromResponse(data.avatar);
     this.canonical_channel_url = data.canonicalChannelUrl;
+
+    this.primary_links = data.primaryLinks.map((link: any) => ({
+      endpoint: new NavigationEndpoint(link.navigationEndpoint),
+      icon: Thumbnail.fromResponse(link.icon),
+      title: new Text(link.title)
+    }));
+
     this.views = new Text(data.viewCountText);
     this.joined = new Text(data.joinedDateText);
     this.description = new Text(data.description);
     this.email_reveal = new NavigationEndpoint(data.onBusinessEmailRevealClickCommand);
     this.can_reveal_email = !data.signInForBusinessEmail;
     this.country = new Text(data.country);
-    this.buttons = Parser.parse(data.actionButtons);
+    this.buttons = Parser.parseArray<Button>(data.actionButtons);
   }
 }
 

--- a/src/parser/classes/SectionList.ts
+++ b/src/parser/classes/SectionList.ts
@@ -16,7 +16,7 @@ class SectionList extends YTNode {
     }
 
     // TODO: this should be Parser#parseArray
-    this.contents = Parser.parse(data.contents);
+    this.contents = Parser.parseArray(data.contents);
 
     if (data.continuations) {
       if (data.continuations[0].nextContinuationData) {

--- a/src/parser/helpers.ts
+++ b/src/parser/helpers.ts
@@ -360,6 +360,10 @@ export type ObservedArray<T extends YTNode = YTNode> = Array<T> & {
      */
     getAll: (rule: object, del_items?: boolean) => T[];
     /**
+     * Returns the first object to match the condition.
+     */
+    matchCondition: (condition: (node: T) => boolean) => T | undefined;
+    /**
      * Removes the item at the given index.
      */
     remove: (index: number) => T[];
@@ -408,6 +412,14 @@ export function observe<T extends YTNode>(obj: Array<T>) {
               target.splice(index, 1);
             }
             return match;
+          })
+        );
+      }
+
+      if (prop == 'matchCondition') {
+        return (condition: (node: T) => boolean) => (
+          target.find((obj) => {
+            return condition(obj);
           })
         );
       }

--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -9,11 +9,12 @@ import MicroformatData from '../classes/MicroformatData';
 import SubscribeButton from '../classes/SubscribeButton';
 import Tab from '../classes/Tab';
 
-import { InnertubeError } from '../../utils/Utils';
 import FeedFilterChipBar from '../classes/FeedFilterChipBar';
 import ChipCloudChip from '../classes/ChipCloudChip';
 import FilterableFeed from '../../core/FilterableFeed';
 import Feed from '../../core/Feed';
+
+import { InnertubeError } from '../../utils/Utils';
 
 export default class Channel extends TabbedFeed {
   header;
@@ -70,37 +71,37 @@ export default class Channel extends TabbedFeed {
   }
 
   async getHome() {
-    const tab = await this.getTab('Home');
+    const tab = await this.getTabByURL('featured');
     return new Channel(this.actions, tab.page, true);
   }
 
   async getVideos() {
-    const tab = await this.getTab('Videos');
+    const tab = await this.getTabByURL('videos');
     return new Channel(this.actions, tab.page, true);
   }
 
   async getShorts() {
-    const tab = await this.getTab('Shorts');
+    const tab = await this.getTabByURL('shorts');
     return new Channel(this.actions, tab.page, true);
   }
 
   async getLiveStreams() {
-    const tab = await this.getTab('Live');
+    const tab = await this.getTabByURL('streams');
     return new Channel(this.actions, tab.page, true);
   }
 
   async getPlaylists() {
-    const tab = await this.getTab('Playlists');
+    const tab = await this.getTabByURL('playlists');
     return new Channel(this.actions, tab.page, true);
   }
 
   async getCommunity() {
-    const tab = await this.getTab('Community');
+    const tab = await this.getTabByURL('community');
     return new Channel(this.actions, tab.page, true);
   }
 
   async getChannels() {
-    const tab = await this.getTab('Channels');
+    const tab = await this.getTabByURL('channels');
     return new Channel(this.actions, tab.page, true);
   }
 
@@ -109,7 +110,7 @@ export default class Channel extends TabbedFeed {
    * Note that this does not return a new {@link Channel} object.
    */
   async getAbout() {
-    const tab = await this.getTab('About');
+    const tab = await this.getTabByURL('about');
     return tab.memo.getType(ChannelAboutFullMetadata)?.[0];
   }
 

--- a/src/parser/youtube/Search.ts
+++ b/src/parser/youtube/Search.ts
@@ -20,7 +20,7 @@ export default class Search extends Feed {
     super(actions, data, already_parsed);
 
     const contents =
-      this.page.contents_memo.getType(SectionList)?.[0]?.contents?.array() ||
+      this.page.contents_memo.getType(SectionList)?.[0]?.contents ||
       this.page.on_response_received_commands?.[0].contents;
 
     this.results = contents.firstOfType(ItemSection)?.contents;

--- a/src/parser/youtube/Settings.ts
+++ b/src/parser/youtube/Settings.ts
@@ -31,7 +31,7 @@ class Settings {
     if (!tab)
       throw new InnertubeError('Target tab not found');
 
-    const contents = tab.content?.as(SectionList).contents.array().as(ItemSection);
+    const contents = tab.content?.as(SectionList).contents.as(ItemSection);
 
     this.introduction = contents?.shift()?.contents?.get({ type: 'PageIntroduction' })?.as(PageIntroduction);
 

--- a/src/parser/youtube/TimeWatched.ts
+++ b/src/parser/youtube/TimeWatched.ts
@@ -19,7 +19,7 @@ class TimeWatched {
     if (!tab)
       throw new InnertubeError('Could not find target tab.');
 
-    this.contents = tab.content?.as(SectionList).contents.array().as(ItemSection);
+    this.contents = tab.content?.as(SectionList).contents.as(ItemSection);
   }
 
   get page(): ParsedResponse {

--- a/src/parser/ytmusic/Explore.ts
+++ b/src/parser/ytmusic/Explore.ts
@@ -28,8 +28,8 @@ class Explore {
     if (!section_list)
       throw new InnertubeError('Target tab did not have any content.');
 
-    this.top_buttons = section_list.contents.array().firstOfType(Grid)?.items.as(MusicNavigationButton) || ([] as MusicNavigationButton[]);
-    this.sections = section_list.contents.array().getAll({ type: 'MusicCarouselShelf' }) as MusicCarouselShelf[];
+    this.top_buttons = section_list.contents.firstOfType(Grid)?.items.as(MusicNavigationButton) || ([] as MusicNavigationButton[]);
+    this.sections = section_list.contents.getAll({ type: 'MusicCarouselShelf' }) as MusicCarouselShelf[];
   }
 
   get page(): ParsedResponse {

--- a/src/parser/ytmusic/HomeFeed.ts
+++ b/src/parser/ytmusic/HomeFeed.ts
@@ -33,7 +33,7 @@ class HomeFeed {
     }
 
     this.#continuation = tab.content?.as(SectionList).continuation;
-    this.sections = tab.content?.as(SectionList).contents.array().as(MusicCarouselShelf);
+    this.sections = tab.content?.as(SectionList).contents.as(MusicCarouselShelf);
   }
 
   /**

--- a/src/parser/ytmusic/Library.ts
+++ b/src/parser/ytmusic/Library.ts
@@ -30,7 +30,7 @@ class Library {
     const section_list = this.#page.contents_memo.getType(SectionList)?.[0];
 
     this.header = section_list?.header?.item().as(MusicSideAlignedItem);
-    this.contents = section_list?.contents?.array().as(Grid, MusicShelf);
+    this.contents = section_list?.contents?.as(Grid, MusicShelf);
 
     this.#continuation = this.contents?.find((list: Grid | MusicShelf) => list.continuation)?.continuation;
   }

--- a/src/parser/ytmusic/Playlist.ts
+++ b/src/parser/ytmusic/Playlist.ts
@@ -61,7 +61,7 @@ class Playlist {
   /**
    * Retrieves related playlists
    */
-  async getRelated() {
+  async getRelated(): Promise<MusicCarouselShelf> {
     let section_continuation = this.#page.contents_memo.get('SectionList')?.[0].as(SectionList).continuation;
 
     while (section_continuation) {
@@ -74,19 +74,15 @@ class Playlist {
       const section_list = data.continuation_contents?.as(SectionListContinuation);
       const sections = section_list?.contents?.as(MusicCarouselShelf, MusicShelf);
 
-      const related = sections?.filter(
-        (section) =>
-          section.is(MusicCarouselShelf) ? section.header?.title.toString() === 'Related playlists' :
-            section.title.toString() === 'Related playlists'
-      )[0];
+      const related = sections?.matchCondition((section) => section.is(MusicCarouselShelf))?.as(MusicCarouselShelf);
 
       if (related)
-        return related.contents || [];
+        return related;
 
       section_continuation = section_list?.continuation;
     }
 
-    return [];
+    throw new InnertubeError('Target section not found.');
   }
 
   async getSuggestions(refresh = true) {
@@ -115,9 +111,7 @@ class Playlist {
       const section_list = page.continuation_contents?.as(SectionListContinuation);
       const sections = section_list?.contents?.as(MusicCarouselShelf, MusicShelf);
 
-      const suggestions = sections?.filter(
-        (section) => section.is(MusicShelf) && section.title.toString() === 'Suggestions'
-      )[0] as MusicShelf | undefined;
+      const suggestions = sections?.matchCondition((section) => section.is(MusicShelf))?.as(MusicShelf);
 
       return {
         items: suggestions?.contents || [],

--- a/src/parser/ytmusic/Recap.ts
+++ b/src/parser/ytmusic/Recap.ts
@@ -37,7 +37,7 @@ class Recap {
     if (!tab)
       throw new InnertubeError('Target tab not found');
 
-    this.sections = tab.content?.as(SectionList).contents.array().as(ItemSection, MusicCarouselShelf, Message);
+    this.sections = tab.content?.as(SectionList).contents.as(ItemSection, MusicCarouselShelf, Message);
   }
 
   /**

--- a/src/parser/ytmusic/Search.ts
+++ b/src/parser/ytmusic/Search.ts
@@ -49,7 +49,7 @@ class Search {
 
     this.header = tab_content.hasKey('header') ? tab_content.header?.item().as(ChipCloud) : null;
 
-    const shelves = tab_content.contents.array().as(MusicShelf, ItemSection);
+    const shelves = tab_content.contents.as(MusicShelf, ItemSection);
     const item_section = shelves.firstOfType(ItemSection);
 
     this.did_you_mean = item_section?.contents?.firstOfType(DidYouMean) || null;


### PR DESCRIPTION
## Description

Some parts of the parser relied on localised strings to find specific YTNodes, and due to the nature of these strings some features would end up breaking if a different language was used. This PR should fix most of those issues.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings