### PR TITLE
feat(Session): allow overriding geolocation

### DIFF
--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -56,6 +56,7 @@ export interface Context {
 
 export interface SessionOptions {
   lang?: string;
+  location?: string;
   account_index?: number;
   device_category?: DeviceCategory;
   client_type?: ClientType;
@@ -112,6 +113,7 @@ export default class Session extends EventEmitterLike {
   static async create(options: SessionOptions = {}) {
     const { context, api_key, api_version, account_index } = await Session.getSessionData(
       options.lang,
+      options.location,
       options.account_index,
       options.device_category,
       options.client_type,
@@ -123,6 +125,7 @@ export default class Session extends EventEmitterLike {
 
   static async getSessionData(
     lang = 'en-US',
+    location = '',
     account_index = 0,
     device_category: DeviceCategory = 'desktop',
     client_name: ClientType = ClientType.WEB,
@@ -157,7 +160,7 @@ export default class Session extends EventEmitterLike {
     const context: Context = {
       client: {
         hl: device_info[0],
-        gl: device_info[2],
+        gl: location || device_info[2],
         remoteHost: device_info[3],
         screenDensityFloat: 1,
         screenHeightPoints: 720,

--- a/src/parser/classes/CompactVideo.ts
+++ b/src/parser/classes/CompactVideo.ts
@@ -4,6 +4,8 @@ import Author from './misc/Author';
 import { timeToSeconds } from '../../utils/Utils';
 import Thumbnail from './misc/Thumbnail';
 import NavigationEndpoint from './NavigationEndpoint';
+import type Menu from './menus/Menu';
+
 import { YTNode } from '../helpers';
 
 class CompactVideo extends YTNode {
@@ -25,7 +27,7 @@ class CompactVideo extends YTNode {
 
   thumbnail_overlays;
   endpoint: NavigationEndpoint;
-  menu;
+  menu: Menu | null;
 
   constructor(data: any) {
     super();
@@ -43,9 +45,9 @@ class CompactVideo extends YTNode {
       seconds: timeToSeconds(new Text(data.lengthText).toString())
     };
 
-    this.thumbnail_overlays = Parser.parse(data.thumbnailOverlays);
+    this.thumbnail_overlays = Parser.parseArray(data.thumbnailOverlays);
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
-    this.menu = Parser.parse(data.menu);
+    this.menu = Parser.parseItem<Menu>(data.menu);
   }
 
   get best_thumbnail() {

--- a/src/parser/classes/GridVideo.ts
+++ b/src/parser/classes/GridVideo.ts
@@ -3,6 +3,9 @@ import Text from './misc/Text';
 import Thumbnail from './misc/Thumbnail';
 import NavigationEndpoint from './NavigationEndpoint';
 import Author from './misc/Author';
+
+import type Menu from './menus/Menu';
+
 import { YTNode } from '../helpers';
 
 class GridVideo extends YTNode {
@@ -14,12 +17,12 @@ class GridVideo extends YTNode {
   thumbnail_overlays;
   rich_thumbnail;
   published: Text;
-  duration: Text | string;
+  duration: Text | null;
   author: Author;
   views: Text;
   short_view_count: Text;
   endpoint: NavigationEndpoint;
-  menu;
+  menu: Menu | null;
 
   constructor(data: any) {
     super();
@@ -27,15 +30,15 @@ class GridVideo extends YTNode {
     this.id = data.videoId;
     this.title = new Text(data.title);
     this.thumbnails = Thumbnail.fromResponse(data.thumbnail);
-    this.thumbnail_overlays = Parser.parse(data.thumbnailOverlays);
+    this.thumbnail_overlays = Parser.parseArray(data.thumbnailOverlays);
     this.rich_thumbnail = data.richThumbnail && Parser.parse(data.richThumbnail);
     this.published = new Text(data.publishedTimeText);
-    this.duration = data.lengthText ? new Text(data.lengthText) : length_alt?.text ? new Text(length_alt.text) : '';
+    this.duration = data.lengthText ? new Text(data.lengthText) : length_alt?.text ? new Text(length_alt.text) : null;
     this.author = data.shortBylineText && new Author(data.shortBylineText, data.ownerBadges);
     this.views = new Text(data.viewCountText);
     this.short_view_count = new Text(data.shortViewCountText);
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
-    this.menu = Parser.parse(data.menu);
+    this.menu = Parser.parseItem<Menu>(data.menu);
   }
 }
 

--- a/src/parser/classes/PlaylistPanelVideo.ts
+++ b/src/parser/classes/PlaylistPanelVideo.ts
@@ -76,8 +76,8 @@ class PlaylistPanelVideo extends YTNode {
       }));
     }
 
-    this.badges = Parser.parse(data.badges);
-    this.menu = Parser.parse(data.menu);
+    this.badges = Parser.parseArray(data.badges);
+    this.menu = Parser.parseItem(data.menu);
     this.set_video_id = data.playlistSetVideoId;
   }
 }

--- a/src/parser/classes/PlaylistVideo.ts
+++ b/src/parser/classes/PlaylistVideo.ts
@@ -3,6 +3,8 @@ import Parser from '../index';
 import Thumbnail from './misc/Thumbnail';
 import PlaylistAuthor from './misc/PlaylistAuthor';
 import NavigationEndpoint from './NavigationEndpoint';
+import type Menu from './menus/Menu';
+
 import { YTNode } from '../helpers';
 
 class PlaylistVideo extends YTNode {
@@ -17,7 +19,7 @@ class PlaylistVideo extends YTNode {
   set_video_id: string | undefined;
   endpoint: NavigationEndpoint;
   is_playable: boolean;
-  menu;
+  menu: Menu | null;
 
   duration: {
     text: string;
@@ -35,7 +37,7 @@ class PlaylistVideo extends YTNode {
     this.set_video_id = data?.setVideoId;
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
     this.is_playable = data.isPlayable;
-    this.menu = Parser.parse(data.menu);
+    this.menu = Parser.parseItem<Menu>(data.menu);
     this.duration = {
       text: new Text(data.lengthText).text,
       seconds: parseInt(data.lengthSeconds)

--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -48,7 +48,7 @@ export default class HTTPClient {
     const request_headers = new Headers(headers);
 
     request_headers.set('Accept', '*/*');
-    request_headers.set('Accept-Language', `en-${this.#session.context.client.gl || 'US'}`);
+    request_headers.set('Accept-Language', `${this.#session.context.client.hl}-${this.#session.context.client.gl}`);
     request_headers.set('x-goog-visitor-id', this.#session.context.client.visitorData || '');
     request_headers.set('x-origin', request_url.origin);
     request_headers.set('x-youtube-client-version', this.#session.context.client.clientVersion || '');


### PR DESCRIPTION
## Description

Implements #259. 

### Usage:
```ts
import { Innertube, UniversalCache } from 'youtubei.js';

(async () => {
  const yt = await Innertube.create({
    lang: 'en',
    location: 'HK',
    cache: new UniversalCache()
  });

  const home = await yt.getHomeFeed();
  console.log(home);

  // ...
})();    
```

Or:
```ts
import { Innertube, Session, UniversalCache } from 'youtubei.js';

(async () => {
  const { context, api_key, api_version, account_index } = await Session.getSessionData('en', 'HK');

  const session = new Session(
    context,
    api_key,
    api_version,
    account_index,
    undefined, // Player
    undefined, // Cookies
    undefined, // Fetch
    new UniversalCache()
  );

  const yt = new Innertube(session);

  const home = await yt.getHomeFeed();
  console.log(home);
})();    
```


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings