### PR TITLE
fix: add YouTube Studio to the list of clients

### DIFF
--- a/src/proto/index.ts
+++ b/src/proto/index.ts
@@ -201,7 +201,7 @@ class Proto {
         client: {
           unkparam: 14,
           clientName: CLIENTS.ANDROID.NAME,
-          clientVersion: CLIENTS.ANDROID.VERSION
+          clientVersion: CLIENTS.YTSTUDIO_ANDROID.VERSION
         }
       },
       target: video_id
@@ -263,7 +263,7 @@ class Proto {
         client: {
           unkparam: 14,
           clientName: CLIENTS.ANDROID.NAME,
-          clientVersion: CLIENTS.ANDROID.VERSION
+          clientVersion: CLIENTS.YTSTUDIO_ANDROID.VERSION
         }
       },
       target: video_id,

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -43,8 +43,11 @@ export const CLIENTS = Object.freeze({
   },
   ANDROID: {
     NAME: 'ANDROID',
-    VERSION: '17.17.32',
+    VERSION: '17.34.35',
     SDK_VERSION: '29'
+  },
+  YTSTUDIO_ANDROID: {
+    VERSION: '22.43.101'
   },
   YTMUSIC_ANDROID: {
     NAME: 'ANDROID_MUSIC',


### PR DESCRIPTION
## Description

As of December 16, YouTube Studio (Android) endpoints fail with a ["Precondition check failed." ](https://github.com/LuanRT/ApodYT/actions/runs/3739549142/jobs/6346892168) message. If a newer version of the YouTube app is used then it throws a `404`, indicating that it is now a requirement to use the correct client for YT Studio requests. I would say that's a bit of a bummer as we'll have to keep track of yet another client's version to make sure it doesn't get _too outdated_.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings