### PR TITLE
feat: allow enabling safety mode

### DIFF
--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -126,9 +126,10 @@ export default class Session extends EventEmitterLike {
       options.timezone,
       options.fetch
     );
+
     return new Session(
       context, api_key, api_version, account_index,
-      options.retrieve_player ? await Player.create(options.cache, options.fetch) : undefined,
+      options.retrieve_player === false ? undefined : await Player.create(options.cache, options.fetch),
       options.cookie, options.fetch, options.cache
     );
   }

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -46,7 +46,8 @@ export interface Context {
     utcOffsetMinutes: number;
   };
   user: {
-    lockedSafetyMode: false;
+    enableSafetyMode: boolean;
+    lockedSafetyMode: boolean;
   };
   thirdParty?: {
     embedUrl: string;
@@ -60,6 +61,8 @@ export interface SessionOptions {
   lang?: string;
   location?: string;
   account_index?: number;
+  retrieve_player?: boolean;
+  enable_safety_mode?: boolean;
   device_category?: DeviceCategory;
   client_type?: ClientType;
   timezone?: string;
@@ -117,18 +120,24 @@ export default class Session extends EventEmitterLike {
       options.lang,
       options.location,
       options.account_index,
+      options.enable_safety_mode,
       options.device_category,
       options.client_type,
       options.timezone,
       options.fetch
     );
-    return new Session(context, api_key, api_version, account_index, await Player.create(options.cache, options.fetch), options.cookie, options.fetch, options.cache);
+    return new Session(
+      context, api_key, api_version, account_index,
+      options.retrieve_player ? await Player.create(options.cache, options.fetch) : undefined,
+      options.cookie, options.fetch, options.cache
+    );
   }
 
   static async getSessionData(
     lang = 'en-US',
     location = '',
     account_index = 0,
+    enable_safety_mode = false,
     device_category: DeviceCategory = 'desktop',
     client_name: ClientType = ClientType.WEB,
     tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -186,6 +195,7 @@ export default class Session extends EventEmitterLike {
         utcOffsetMinutes: new Date().getTimezoneOffset()
       },
       user: {
+        enableSafetyMode: enable_safety_mode,
         lockedSafetyMode: false
       },
       request: {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -10,7 +10,7 @@ describe('YouTube.js Tests', () => {
   beforeAll(async () => {
     yt = await Innertube.create();
   });
-  
+
   describe('Info', () => {
     let info: any;
     
@@ -116,6 +116,11 @@ describe('YouTube.js Tests', () => {
   });
   
   describe('General', () => {
+    it('should create sessions without a player instance', async () => {
+      const nop_yt = await Innertube.create({ retrieve_player: false });
+      expect(nop_yt.session.player).toBeUndefined();
+    });
+
     it('should resolve a URL', async () => {
       const url = await yt.resolveURL('https://www.youtube.com/@linustechtips');
       expect(url.payload.browseId).toBe(CHANNELS[0].ID);


### PR DESCRIPTION
## Description

Adds support for safety mode, see #266.
Unrelated: this also simplifies the creation of sessions without a player instance,

#### Usage:
```ts
import { Innertube, UniversalCache } from 'youtubei.js';

(async () => {
  const yt = await Innertube.create({
    cache:  new UniversalCache(),
    enable_safety_mode: true,
    retrieve_player: true
  });

  // ...
})();
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings