### PR TITLE
feat: Add is_live and is_upcoming to VideoDetails

### DIFF
--- a/src/parser/classes/misc/VideoDetails.ts
+++ b/src/parser/classes/misc/VideoDetails.ts
@@ -13,7 +13,9 @@ class VideoDetails {
   view_count: number;
   author: string;
   is_private: boolean;
+  is_live: boolean;
   is_live_content: boolean;
+  is_upcoming: boolean;
   is_crawlable: boolean;
 
   constructor(data: any) {
@@ -29,7 +31,9 @@ class VideoDetails {
     this.view_count = parseInt(data.viewCount);
     this.author = data.author;
     this.is_private = !!data.isPrivate;
+    this.is_live = !!data.isLive;
     this.is_live_content = !!data.isLiveContent;
+    this.is_upcoming = !!data.isUpcoming;
     this.is_crawlable = !!data.isCrawlable;
   }
 }

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -14,6 +14,14 @@ export const VIDEOS = [
   {
     ID: 'OqiXFXlYFi8',
     QUERY: 'formatted comment text'
+  },
+  {
+    ID: 'O3cCYok_ukk',
+    QUERY: 'upcoming video'
+  },
+  {
+    ID: 'jfKfPfyJRdk',
+    QUERY: 'live video'
   }
 ];
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -44,6 +44,16 @@ describe('YouTube.js Tests', () => {
       const b_info = await yt.getBasicInfo(VIDEOS[0].ID);
       expect(b_info.basic_info.id).toBe(VIDEOS[0].ID);
     });
+
+    it('should be upcoming', async () => {
+      const b_info = await yt.getBasicInfo(VIDEOS[4].ID);
+      expect(b_info.basic_info.is_upcoming).toBe(true);
+    });
+
+    it('should be live', async () => {
+      const b_info = await yt.getBasicInfo(VIDEOS[5].ID);
+      expect(b_info.basic_info.is_live).toBe(true);
+    });
   });
   
   describe('Search', () => {


### PR DESCRIPTION
## Description

The current `is_live_content` property only tells you whether the video is a normal one or a live stream, it doesn't provide enough granularity on whether the live stream is live, upcoming or a live stream replay, it's true for all three of those. Extracting the `is_live` and `is_upcoming` properties as well, solves that.

Below is a table of the values of those 3 properties for the 4 types of videos mentioned above.

| Type | `is_live` | `is_live_content` | `is_upcoming` |
| --- | --- | --- | --- |
| currently live live stream | `true` | `true` | `false` |
| live stream replay | `false` | `true` | `false` |
| upcoming live stream | `false` | `true` | `true` |
| normal video | `false` | `false` | `false` |

I haven't added any tests as it'll be hard to find continously running live streams and upcoming live streams that never actually start.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings