### PR TITLE
feat: Add live stream start_timestamp

### DIFF
--- a/src/parser/classes/PlayerMicroformat.ts
+++ b/src/parser/classes/PlayerMicroformat.ts
@@ -34,6 +34,7 @@ class PlayerMicroformat extends YTNode {
   publish_date: string;
   upload_date: string;
   available_countries: string[];
+  start_timestamp: Date | null;
 
   constructor(data: any) {
     super();
@@ -65,6 +66,7 @@ class PlayerMicroformat extends YTNode {
     this.publish_date = data.publishDate;
     this.upload_date = data.uploadDate;
     this.available_countries = data.availableCountries;
+    this.start_timestamp = data.liveBroadcastDetails?.startTimestamp ? new Date(data.liveBroadcastDetails.startTimestamp) : null;
   }
 }
 

--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -133,7 +133,8 @@ class VideoInfo {
         channel: info.microformat?.is(PlayerMicroformat) ? info.microformat?.channel : null,
         is_unlisted: info.microformat?.is_unlisted,
         is_family_safe: info.microformat?.is_family_safe,
-        has_ypc_metadata: info.microformat?.is(PlayerMicroformat) ? info.microformat?.has_ypc_metadata : null
+        has_ypc_metadata: info.microformat?.is(PlayerMicroformat) ? info.microformat?.has_ypc_metadata : null,
+        start_timestamp: info.microformat?.is(PlayerMicroformat) ? info.microformat.start_timestamp : null
       },
       like_count: undefined as number | undefined,
       is_liked: undefined as boolean | undefined,

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -54,6 +54,12 @@ describe('YouTube.js Tests', () => {
       const b_info = await yt.getBasicInfo(VIDEOS[5].ID);
       expect(b_info.basic_info.is_live).toBe(true);
     });
+
+    it('should extract live stream start timestamp', async () => {
+      const b_info = await yt.getBasicInfo(VIDEOS[4].ID);
+      expect(b_info.basic_info.start_timestamp).not.toBeNull()
+      expect(b_info.basic_info.start_timestamp!.toISOString()).toBe('2024-03-30T23:00:00.000Z');
+    })
   });
   
   describe('Search', () => {


### PR DESCRIPTION
## Description

Upcoming live streams and currently live live streams have a start time, which YouTube helpfully tells us about. Some of the use cases for having access to this are showing it to a user, notifications for when a live stream starts or other automations.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings