### PR TITLE
fix(VideoInfo): watch next feed not being parsed when logged out

### DIFF
--- a/src/parser/classes/TwoColumnWatchNextResults.ts
+++ b/src/parser/classes/TwoColumnWatchNextResults.ts
@@ -10,9 +10,9 @@ class TwoColumnWatchNextResults extends YTNode {
 
   constructor(data: any) {
     super();
-    this.results = Parser.parse(data.results?.results.contents, true);
-    this.secondary_results = Parser.parse(data.secondaryResults?.secondaryResults.results, true);
-    this.conversation_bar = Parser.parse(data?.conversationBar);
+    this.results = Parser.parseArray(data.results?.results.contents);
+    this.secondary_results = Parser.parseArray(data.secondaryResults?.secondaryResults.results);
+    this.conversation_bar = Parser.parseItem(data?.conversationBar);
   }
 }
 

--- a/src/parser/helpers.ts
+++ b/src/parser/helpers.ts
@@ -376,6 +376,10 @@ export type ObservedArray<T extends YTNode = YTNode> = Array<T> & {
      */
     firstOfType<R extends YTNode, K extends YTNodeConstructor<R>[]>(...types: K): InstanceType<K[number]> | undefined;
     /**
+     * Get the first item
+     */
+    first: () => T | undefined;
+    /**
      * This is similar to filter but throws if there's a type mismatch.
      */
     as<R extends YTNode, K extends YTNodeConstructor<R>[]>(...types: K): ObservedArray<InstanceType<K[number]>>;
@@ -435,6 +439,7 @@ export function observe<T extends YTNode>(obj: Array<T>): ObservedArray<T> {
         };
       }
 
+
       if (prop == 'firstOfType') {
         return (...types: YTNodeConstructor<YTNode>[]) => {
           return target.find((node: YTNode) => {
@@ -443,6 +448,10 @@ export function observe<T extends YTNode>(obj: Array<T>): ObservedArray<T> {
             return false;
           });
         };
+      }
+
+      if (prop == 'first') {
+        return () => target[0];
       }
 
       if (prop == 'as') {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -40,6 +40,10 @@ describe('YouTube.js Tests', () => {
       expect(heatmap).toBeDefined();
     });
 
+    it('should have watch next feed', () => {
+      expect(info.watch_next_feed).toBeDefined();
+    });
+    
     it('should retrieve basic video info', async () => {
       const b_info = await yt.getBasicInfo(VIDEOS[0].ID);
       expect(b_info.basic_info.id).toBe(VIDEOS[0].ID);


### PR DESCRIPTION
## Description

Fixed issues discussed in #69. The watch next feed has a slightly different layout for unauthenticated sessions.

Closes #69.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings