### PR TITLE
refactor(LiveChat): Only store required video info values

### DIFF
--- a/src/parser/youtube/LiveChat.ts
+++ b/src/parser/youtube/LiveChat.ts
@@ -52,7 +52,8 @@ export interface LiveMetadata {
 
 class LiveChat extends EventEmitter {
   #actions: Actions;
-  #video_info: VideoInfo;
+  #video_id: string;
+  #channel_id: string;
   #continuation?: string;
   #mcontinuation?: string;
 
@@ -65,7 +66,8 @@ class LiveChat extends EventEmitter {
   constructor(video_info: VideoInfo) {
     super();
 
-    this.#video_info = video_info;
+    this.#video_id = video_info.basic_info.id as string;
+    this.#channel_id = video_info.basic_info.channel_id as string;
     this.#actions = video_info.actions;
     this.#continuation = video_info.livechat?.continuation || undefined;
     this.is_replay = video_info.livechat?.is_replay || false;
@@ -142,7 +144,7 @@ class LiveChat extends EventEmitter {
       const payload: {
         videoId: string | undefined;
         continuation?: string;
-      } = { videoId: this.#video_info.basic_info.id };
+      } = { videoId: this.#video_id };
 
       if (this.#mcontinuation) {
         payload.continuation = this.#mcontinuation;
@@ -175,7 +177,7 @@ class LiveChat extends EventEmitter {
    */
   async sendMessage(text: string): Promise<ObservedArray<AddChatItemAction>> {
     const response = await this.#actions.execute('/live_chat/send_message', {
-      params: Proto.encodeMessageParams(this.#video_info.basic_info.channel_id as string, this.#video_info.basic_info.id as string),
+      params: Proto.encodeMessageParams(this.#channel_id, this.#video_id),
       richMessage: { textSegments: [ { text } ] },
       clientMessageId: uuidv4(),
       parse: true


### PR DESCRIPTION
## Description

The LiveChat object will be used by users of this library for a much longer amount of time than the VideoInfo, as it needs to stick around for the events to be emitted. By storing the video and channel IDs directly inside the LiveChat object instead of storing the whole (large) VideoInfo object, we allow the JavaScript VM to garbage collect the VideoInfo object (and the many objects inside of it) when there are no more references to it in the library user's code, lowering the memory usage.

In FreeTube for example we read the info that we want from the VideoInfo object, then get the live chat if there is one, after that the FreeTube code no longer references the VideoInfo object. With this change, YouTube.js won't hold any references to it either, so it can get garbage collected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings