### PR TITLE
feat(EmojiRun): Add is_custom to identify custom emojis

### DIFF
--- a/src/parser/classes/misc/EmojiRun.ts
+++ b/src/parser/classes/misc/EmojiRun.ts
@@ -7,6 +7,7 @@ class EmojiRun {
     shortcuts: string[];
     search_terms: string[];
     image: Thumbnail[];
+    is_custom: boolean;
   };
 
   constructor(data: any) {
@@ -19,7 +20,8 @@ class EmojiRun {
       emoji_id: data.emoji.emojiId,
       shortcuts: data.emoji?.shortcuts || [],
       search_terms: data.emoji?.searchTerms || [],
-      image: Thumbnail.fromResponse(data.emoji.image)
+      image: Thumbnail.fromResponse(data.emoji.image),
+      is_custom: !!data.emoji?.isCustomEmoji
     };
   }
 }


### PR DESCRIPTION
## Description

With normal emojis the `emoji_id` is the actual emoji, so when you display the image it works well as the alt text. The `emoji_id` for custom emojis however is the id of it on YouTube's servers, so a bunch of letters with a slash in the middle, which doesn't work well as an alt text, in those cases using the shortcuts and search terms as the alt text would be more user friendly. To make it easier to handle emojis and custom emojis differently (my first thought was to use this regex `/(\p{Emoji_Presentation}|\p{Extended_Pictographic})/u` in the FreeTube code, until i had the thought that YouTube might already do it for us), this PR extracts YouTube's `isCustomEmoji` property.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings