### PR TITLE
fix(Playlist): trying to parse an already parsed response

### DIFF
--- a/src/parser/youtube/Playlist.ts
+++ b/src/parser/youtube/Playlist.ts
@@ -9,22 +9,26 @@ import PlaylistSidebarSecondaryInfo from '../classes/PlaylistSidebarSecondaryInf
 import PlaylistCustomThumbnail from '../classes/PlaylistCustomThumbnail';
 import PlaylistVideoThumbnail from '../classes/PlaylistVideoThumbnail';
 import PlaylistHeader from '../classes/PlaylistHeader';
+import Message from '../classes/Message';
 
 import { InnertubeError } from '../../utils/Utils';
 
 import type Actions from '../../core/Actions';
+import { ObservedArray } from '../helpers';
+import NavigationEndpoint from '../classes/NavigationEndpoint';
 
 class Playlist extends Feed {
   info;
   menu;
-  endpoint;
+  endpoint?: NavigationEndpoint;
+  messages: ObservedArray<Message>;
 
   constructor(actions: Actions, data: any, already_parsed = false) {
     super(actions, data, already_parsed);
 
-    const header = this.memo.getType(PlaylistHeader)?.[0];
-    const primary_info = this.memo.getType(PlaylistSidebarPrimaryInfo)?.[0];
-    const secondary_info = this.memo.getType(PlaylistSidebarSecondaryInfo)?.[0];
+    const header = this.memo.getType(PlaylistHeader).first();
+    const primary_info = this.memo.getType(PlaylistSidebarPrimaryInfo).first();
+    const secondary_info = this.memo.getType(PlaylistSidebarSecondaryInfo).first();
 
     if (!primary_info && !secondary_info)
       throw new InnertubeError('This playlist does not exist');
@@ -46,6 +50,7 @@ class Playlist extends Feed {
 
     this.menu = primary_info?.menu;
     this.endpoint = primary_info?.endpoint;
+    this.messages = this.memo.getType(Message);
   }
 
   #getStat(index: number, primary_info?: PlaylistSidebarPrimaryInfo): string {
@@ -59,7 +64,7 @@ class Playlist extends Feed {
 
   async getContinuation(): Promise<Playlist> {
     const response = await this.getContinuationData();
-    return new Playlist(this.actions, response);
+    return new Playlist(this.actions, response, true);
   }
 }
 


### PR DESCRIPTION
## Description

I saw this issue in https://github.com/FreeTubeApp/FreeTube/issues/3046 and figured I'd take a crack at it. It would seem that InnerTube has some trouble loading the last videos of long playlists (perhaps because they can only load in batches of 100 videos and never less than that?).

Since the library never expects `on_load_received_actions` to be undefined when doing pagination, it thinks the response is not parsed and tries to parse it, inevitably ending up in a `InnertubeError: Type not found!` which is then followed by `InnertubeError: This playlist does not exist` when retrieving the last page of a long playlist. It says “Type not found” because it's trying to run `Parser#parseResponse` on the parsed data all over again. To fix this, I explicitly set `already_parsed` to `true` in `Playlist#getContinuation()` and added a `messages` prop to `Playlist` (which in this case obviously returns `Unavailable videos are hidden` and `No videos in this playlist yet` when YouTube can't return more playlist items).

Code I used to test this:
```ts
let playlist = await yt.getPlaylist('PLcyItF5YjT0dYq2E7Oti1pgBsRNq3A3jW');

let i = 0;

while (true) {
  try {
    console.info(i++);
    playlist = await playlist.getContinuation();
  } catch (e) {
    console.log(e); // after the fix this should return a normal “There are no continuations” error
    console.log(playlist.has_continuation) // false
    console.log(playlist.messages);
  }
}
```

Output:
```
0
1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
InnertubeError: There are no continuations
 at Playlist.<anonymous> (..)
 at Generator.next (<anonymous>)
  ....
```

Note that 100 * 18 = 1800 which is roughly the size of the playlist used.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings