### PR TITLE
fix(VideoInfo): Gracefully handle missing watch next continuation

### DIFF
--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -164,7 +164,7 @@ class VideoInfo {
 
       this.watch_next_feed = secondary_results.firstOfType(ItemSection)?.contents || secondary_results;
 
-      if (this.watch_next_feed && Array.isArray(this.watch_next_feed))
+      if (this.watch_next_feed && Array.isArray(this.watch_next_feed) && this.watch_next_feed.at(-1)?.is(ContinuationItem))
         this.#watch_next_continuation = this.watch_next_feed.pop()?.as(ContinuationItem);
 
       this.player_overlays = next?.player_overlays.item().as(PlayerOverlay);
@@ -254,7 +254,11 @@ class VideoInfo {
       throw new InnertubeError('AppendContinuationItemsAction not found');
 
     this.watch_next_feed = data?.contents;
-    this.#watch_next_continuation = this.watch_next_feed?.pop()?.as(ContinuationItem);
+    if (this.watch_next_feed?.at(-1)?.is(ContinuationItem)) {
+      this.#watch_next_continuation = this.watch_next_feed.pop()?.as(ContinuationItem);
+    } else {
+      this.#watch_next_continuation = undefined;
+    }
 
     return this;
   }


### PR DESCRIPTION
## Description

Occasionally YouTube doesn't return a continuation in the watch next feed, which causes this error: `Cannot cast CompactVideo to one of ContinuationItem`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings