### PR TITLE
feat: improve support for dubbed content

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Retrieves video info, including playback data and even layout elements such as m
 - `<info>#chooseFormat(options)`
   - Used to choose streaming data formats.
 
-- `<info>#toDash(url_transformer)`
+- `<info>#toDash(url_transformer?, format_filter?)`
   - Converts streaming data to an MPEG-DASH manifest.
 
 - `<info>#download(options)`

--- a/docs/API/kids.md
+++ b/docs/API/kids.md
@@ -47,7 +47,7 @@ Retrieves video info.
 <summary>Methods & Getters</summary>
 <p>
 
-- `<info>#toDash(url_transformer?)`
+- `<info>#toDash(url_transformer?, format_filter?)`
   - Generates a DASH manifest from the streaming data.
 
 - `<info>#chooseFormat(options)`

--- a/docs/API/music.md
+++ b/docs/API/music.md
@@ -49,7 +49,7 @@ Retrieves track info.
 - `<info>#available_tabs`
   - Returns available tabs.
 
-- `<info>#toDash(url_transformer?)`
+- `<info>#toDash(url_transformer?, format_filter?)`
   - Generates a DASH manifest from the streaming data.
 
 - `<info>#chooseFormat(options)`

--- a/src/parser/classes/PlayerCaptionsTracklist.ts
+++ b/src/parser/classes/PlayerCaptionsTracklist.ts
@@ -14,8 +14,15 @@ class PlayerCaptionsTracklist extends YTNode {
   }[];
 
   audio_tracks: {
+    audio_track_id: string;
+    captions_initial_state: string;
+    default_caption_track_index: number;
+    has_default_track: boolean;
+    visibility: string;
     caption_track_indices: number;
   }[];
+
+  default_audio_track_index: number;
 
   translation_languages: {
     language_code: string;
@@ -34,8 +41,15 @@ class PlayerCaptionsTracklist extends YTNode {
     }));
 
     this.audio_tracks = data.audioTracks.map((at: any) => ({
+      audio_track_id: at.audioTrackId,
+      captions_initial_state: at.captionsInitialState,
+      default_caption_track_index: at.defaultCaptionTrackIndex,
+      has_default_track: at.hasDefaultTrack,
+      visibility: at.visibility,
       caption_track_indices: at.captionTrackIndices
     }));
+
+    this.default_audio_track_index = data.defaultAudioTrackIndex;
 
     this.translation_languages = data.translationLanguages.map((tl: any) => ({
       language_code: tl.languageCode,

--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -28,6 +28,11 @@ class Format {
   cipher: string | undefined;
   signature_cipher: string | undefined;
   audio_quality: string | undefined;
+  audio_track?: {
+    audio_is_default: boolean;
+    display_name: string;
+    id: string;
+  };
   approx_duration_ms: number;
   audio_sample_rate: number;
   audio_channels: number;
@@ -75,9 +80,18 @@ class Format {
     if (this.has_audio) {
       const args = new URLSearchParams(this.cipher || this.signature_cipher);
       const url_components = new URLSearchParams(args.get('url') || this.url);
+
       this.language = url_components.get('xtags')?.split(':').find((x: string) => x.startsWith('lang='))?.split('=').at(1) || null;
       this.is_dubbed = url_components.get('xtags')?.split(':').find((x: string) => x.startsWith('acont='))?.split('=').at(1) === 'dubbed';
       this.is_original = url_components.get('xtags')?.split(':').find((x: string) => x.startsWith('acont='))?.split('=').at(1) === 'original' || !this.is_dubbed;
+
+      if (data.audioTrack) {
+        this.audio_track = {
+          audio_is_default: data.audioTrack.audioIsDefault,
+          display_name: data.audioTrack.displayName,
+          id: data.audioTrack.id
+        };
+      }
     }
   }
 

--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -34,6 +34,9 @@ class Format {
   loudness_db: number;
   has_audio: boolean;
   has_video: boolean;
+  language?: string | null;
+  is_dubbed?: boolean;
+  is_original?: boolean;
 
   constructor(data: any) {
     this.itag = data.itag;
@@ -68,6 +71,14 @@ class Format {
     this.loudness_db = data.loudnessDb;
     this.has_audio = !!data.audioBitrate || !!data.audioQuality;
     this.has_video = !!data.qualityLabel;
+
+    if (this.has_audio) {
+      const args = new URLSearchParams(this.cipher || this.signature_cipher);
+      const url_components = new URLSearchParams(args.get('url') || this.url);
+      this.language = url_components.get('xtags')?.split(':').find((x: string) => x.startsWith('lang='))?.split('=').at(1) || null;
+      this.is_dubbed = url_components.get('xtags')?.split(':').find((x: string) => x.startsWith('acont='))?.split('=').at(1) === 'dubbed';
+      this.is_original = url_components.get('xtags')?.split(':').find((x: string) => x.startsWith('acont='))?.split('=').at(1) === 'original' || !this.is_dubbed;
+    }
   }
 
   /**

--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -34,7 +34,8 @@ import type Actions from '../../core/Actions';
 import type { ApiResponse } from '../../core/Actions';
 import type { ObservedArray, YTNode } from '../helpers';
 
-import FormatUtils, { FormatOptions, DownloadOptions, URLTransformer } from '../../utils/FormatUtils';
+import FormatUtils, { FormatOptions, DownloadOptions, URLTransformer, FormatFilter } from '../../utils/FormatUtils';
+
 import { InnertubeError } from '../../utils/Utils';
 
 class VideoInfo {
@@ -308,10 +309,11 @@ class VideoInfo {
   /**
    * Generates a DASH manifest from the streaming data.
    * @param url_transformer - Function to transform the URLs.
+   * @param format_filter - Function to filter the formats.
    * @returns DASH manifest
    */
-  toDash(url_transformer: URLTransformer = (url) => url): string {
-    return FormatUtils.toDash(this.streaming_data, url_transformer);
+  toDash(url_transformer: URLTransformer = (url) => url, format_filter: FormatFilter): string {
+    return FormatUtils.toDash(this.streaming_data, url_transformer, format_filter, this.#cpn, this.#player);
   }
 
   /**

--- a/src/parser/ytkids/VideoInfo.ts
+++ b/src/parser/ytkids/VideoInfo.ts
@@ -14,7 +14,7 @@ import type { ObservedArray, YTNode } from '../helpers';
 import { Constants } from '../../utils';
 import { InnertubeError } from '../../utils/Utils';
 
-import FormatUtils, { DownloadOptions, FormatOptions, URLTransformer } from '../../utils/FormatUtils';
+import FormatUtils, { DownloadOptions, FormatFilter, FormatOptions, URLTransformer } from '../../utils/FormatUtils';
 
 class VideoInfo {
   #page: [ParsedResponse, ParsedResponse?];
@@ -69,10 +69,11 @@ class VideoInfo {
   /**
    * Generates a DASH manifest from the streaming data.
    * @param url_transformer - Function to transform the URLs.
+   * @param format_filter - Function to filter the formats.
    * @returns DASH manifest
    */
-  toDash(url_transformer: URLTransformer = (url) => url): string {
-    return FormatUtils.toDash(this.streaming_data, url_transformer, this.#cpn, this.#actions.session.player);
+  toDash(url_transformer: URLTransformer = (url) => url, format_filter: FormatFilter): string {
+    return FormatUtils.toDash(this.streaming_data, url_transformer, format_filter, this.#cpn, this.#actions.session.player);
   }
 
   /**

--- a/src/parser/ytmusic/TrackInfo.ts
+++ b/src/parser/ytmusic/TrackInfo.ts
@@ -25,7 +25,7 @@ import type PlayerStoryboardSpec from '../classes/PlayerStoryboardSpec';
 import type Format from '../classes/misc/Format';
 
 import type { ObservedArray, YTNode } from '../helpers';
-import FormatUtils, { URLTransformer, FormatOptions, DownloadOptions } from '../../utils/FormatUtils';
+import FormatUtils, { URLTransformer, FormatOptions, DownloadOptions, FormatFilter } from '../../utils/FormatUtils';
 
 class TrackInfo {
   #page: [ ParsedResponse, ParsedResponse? ];
@@ -91,10 +91,11 @@ class TrackInfo {
   /**
  * Generates a DASH manifest from the streaming data.
  * @param url_transformer - Function to transform the URLs.
+ * @param format_filter - Function to filter the formats.
  * @returns DASH manifest
  */
-  toDash(url_transformer: URLTransformer = (url) => url): string {
-    return FormatUtils.toDash(this.streaming_data, url_transformer, this.#cpn, this.#actions.session.player);
+  toDash(url_transformer: URLTransformer = (url) => url, format_filter: FormatFilter): string {
+    return FormatUtils.toDash(this.streaming_data, url_transformer, format_filter, this.#cpn, this.#actions.session.player);
   }
 
   /**


### PR DESCRIPTION
## Description

The goal of this PR is to make it easier to identify and extract the audio tracks of videos with multilingual audio. ~~I'm also considering adding an option to filter out unwanted formats from the DASH manifest and download function, which is why this is a WIP.~~ (done)

### Usage

```ts
import { Innertube, UniversalCache, YTNodes } from 'youtubei.js';

(async () => {
  const yt = await Innertube.create({ cache: new UniversalCache(), generate_session_locally: true });
  
  const search = await yt.search('mrbeast I Survived 50 Hours In Antarctica', { type: 'video' });
  const video_id = search.results?.firstOfType(YTNodes.Video)?.id as string;

  const info = await yt.getInfo(video_id);
  
  // Remove unwanted formats from the DASH manifest:
  console.log(info.toDash(undefined, (fmt) => {
    // Remove all non-English audio tracks (the data in info.captions.audio_tracks is quite helpful for this specifically)
    if (fmt.language && fmt.language !== 'en')
      return true;
    return false;
  }));

  console.log(info.toDash(undefined, (fmt) => {
    // Remove all dubbed audio tracks
    if (fmt.is_dubbed)
      return true;
    return false;
  }));

  // Download a specific audio track:
  const stream = await yt.download(video_id, {
    type: 'audio', language: 'hi' /** Default: 'original' */
  });

  // ...
})();
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings