### PR TITLE
feat(Channel): add support for sorting the playlist tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,8 +482,13 @@ Retrieves contents for a given channel.
 - `<channel>#getChannels()`
 - `<channel>#getAbout()`
 - `<channel>#search(query)`
+- `<channel>#applyFilter(filter)`
+- `<channel>#applyContentTypeFilter(content_type_filter)`
+- `<channel>#applySort(sort)`
 - `<channel>#getContinuation()`
 - `<channel>#filters`
+- `<channel>#content_type_filters`
+- `<channel>#sort_filters`
 - `<channel>#page`
 
 </p>

--- a/src/parser/classes/ChannelSubMenu.ts
+++ b/src/parser/classes/ChannelSubMenu.ts
@@ -1,0 +1,27 @@
+import Parser from '..';
+import NavigationEndpoint from './NavigationEndpoint';
+import { YTNode } from '../helpers';
+
+class ChannelSubMenu extends YTNode {
+  static type = 'ChannelSubMenu';
+
+  content_type_sub_menu_items: {
+    endpoint: NavigationEndpoint;
+    selected: boolean;
+    title: string;
+  }[];
+
+  sort_setting;
+
+  constructor(data: any) {
+    super();
+    this.content_type_sub_menu_items = data.contentTypeSubMenuItems.map((item: any) => ({
+      endpoint: new NavigationEndpoint(item.navigationEndpoint || item.endpoint),
+      selected: item.selected,
+      title: item.title
+    }));
+    this.sort_setting = Parser.parseItem(data.sortSetting);
+  }
+}
+
+export default ChannelSubMenu;

--- a/src/parser/classes/SectionList.ts
+++ b/src/parser/classes/SectionList.ts
@@ -8,6 +8,7 @@ class SectionList extends YTNode {
   contents;
   continuation?: string;
   header;
+  sub_menu;
 
   constructor(data: any) {
     super();
@@ -28,6 +29,10 @@ class SectionList extends YTNode {
 
     if (data.header) {
       this.header = Parser.parse(data.header);
+    }
+
+    if (data.subMenu) {
+      this.sub_menu = Parser.parseItem(data.subMenu);
     }
   }
 }

--- a/src/parser/classes/SortFilterSubMenu.ts
+++ b/src/parser/classes/SortFilterSubMenu.ts
@@ -41,7 +41,7 @@ class SortFilterSubMenu extends YTNode {
         title: item.title,
         selected: item.selected,
         continuation: item.continuation?.reloadContinuationData?.continuation,
-        endpoint: new NavigationEndpoint(item.serviceEndpoint),
+        endpoint: new NavigationEndpoint(item.serviceEndpoint || item.navigationEndpoint),
         subtitle: item.subtitle || null
       }));
     }

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -37,6 +37,7 @@ import { default as ChannelHeaderLinks } from './classes/ChannelHeaderLinks';
 import { default as ChannelMetadata } from './classes/ChannelMetadata';
 import { default as ChannelMobileHeader } from './classes/ChannelMobileHeader';
 import { default as ChannelOptions } from './classes/ChannelOptions';
+import { default as ChannelSubMenu } from './classes/ChannelSubMenu';
 import { default as ChannelThumbnailWithLink } from './classes/ChannelThumbnailWithLink';
 import { default as ChannelVideoPlayer } from './classes/ChannelVideoPlayer';
 import { default as Chapter } from './classes/Chapter';
@@ -354,6 +355,7 @@ export const YTNodes = {
   ChannelMetadata,
   ChannelMobileHeader,
   ChannelOptions,
+  ChannelSubMenu,
   ChannelThumbnailWithLink,
   ChannelVideoPlayer,
   Chapter,


### PR DESCRIPTION
## Description

Adds support for sorting the playlist tab, see #290 for more details.

### Usage
```ts
import { Innertube, UniversalCache } from 'youtubei.js';

(async () => {
  const yt = await Innertube.create({ cache: new UniversalCache(), generate_session_locally: true });

  const channel = await yt.getChannel('UCez-2shYlHQY3LfILBuDYqQ');

  let playlists_tab = await channel.getPlaylists();

  /**
   * Channels such as UCez-2shYlHQY3LfILBuDYqQ have their playlists organized into various categories. 
   * In this case, sorting is only possible after a category is selected.
   */
  if (!playlists_tab.memo.has('SortFilterSubMenu')) {
    console.info('Content type filters:', playlists_tab.content_type_filters);
    playlists_tab = await playlists_tab.applyContentTypeFilter('Created playlists');
  }

  console.info('Sort filters:', playlists_tab.sort_filters);

  const sorted_playlist_tab = await playlists_tab.applySort('Last video added');

  console.log(sorted_playlist_tab);
})();
```

Closes #290.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings