### PR TITLE
Allow checking whether a channel has optional tabs

### DIFF
--- a/src/core/TabbedFeed.ts
+++ b/src/core/TabbedFeed.ts
@@ -47,6 +47,10 @@ class TabbedFeed extends Feed {
     return new TabbedFeed(this.#actions, response.data, false);
   }
 
+  hasTabWithURL(url: string): boolean {
+    return this.#tabs.some((tab) => tab.endpoint.metadata.url?.split('/').pop() === url);
+  }
+
   get title(): string | undefined {
     return this.page.contents_memo.getType(Tab)?.find((tab) => tab.selected)?.title.toString();
   }

--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -208,6 +208,10 @@ export default class Channel extends TabbedFeed {
     return this.hasTabWithURL('streams');
   }
 
+  get has_playlists(): boolean {
+    return this.hasTabWithURL('playlists');
+  }
+
   get has_community(): boolean {
     return this.hasTabWithURL('community');
   }

--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -196,6 +196,22 @@ export default class Channel extends TabbedFeed {
     return new Channel(this.actions, page, true);
   }
 
+  get has_videos(): boolean {
+    return this.hasTabWithURL('videos');
+  }
+
+  get has_shorts(): boolean {
+    return this.hasTabWithURL('shorts');
+  }
+
+  get has_live_streams(): boolean {
+    return this.hasTabWithURL('streams');
+  }
+
+  get has_community(): boolean {
+    return this.hasTabWithURL('community');
+  }
+
   /**
    * Retrives list continuation.
    */

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -37,5 +37,9 @@ export const CHANNELS = [
   {
     ID: 'UCpbpfcZfo-hoDAx2m1blFhg',
     NAME: 'Learning Blocks'
+  },
+  {
+    ID: 'UCt-oJR5teQIjOAxCmIQvcgA',
+    NAME: "They're Just Movies"
   }
 ];

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -168,6 +168,7 @@ describe('YouTube.js Tests', () => {
       expect(channel.has_videos).toBe(true);
       expect(channel.has_shorts).toBe(false);
       expect(channel.has_live_streams).toBe(false);
+      expect(channel.has_playlists).toBe(true);
       expect(channel.has_community).toBe(true);
     })
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -163,6 +163,14 @@ describe('YouTube.js Tests', () => {
       expect(filtered_list.videos.length).toBeGreaterThan(0);
     });
 
+    it('should detect missing channel tabs', async () => {
+      const channel = await yt.getChannel(CHANNELS[2].ID);
+      expect(channel.has_videos).toBe(true);
+      expect(channel.has_shorts).toBe(false);
+      expect(channel.has_live_streams).toBe(false);
+      expect(channel.has_community).toBe(true);
+    })
+
     it('should retrieve home feed', async () => {
       const homefeed = await yt.getHomeFeed();
       expect(homefeed.header).toBeDefined();


### PR DESCRIPTION
## Description

Certain YouTube channels don't have all tabs, depending on what type of content they post. When you are displaying the channel in a GUI, you may want to hide the missing tabs, like YouTube itself does. Currently the only to do that with YouTube.js is to try calling `await channel.getShorts()` and check the error message, unfortunately that also means that if the tab does exist, you will have fetched the content of that tab before the user has even switched to it.

This pull request adds getters to check if the Videos, Shorts, Live Streams and Community tabs exist, without making any requests. Those 4 tabs are the only ones I've notice missing in various combinations depending on the channel. I can add getters for the other tabs just in case, if you would like me to?

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings