### PR TITLE
Add parser support for MultiImage community posts

### DIFF
--- a/src/parser/classes/PostMultiImage.ts
+++ b/src/parser/classes/PostMultiImage.ts
@@ -1,0 +1,17 @@
+import Parser from '../index';
+import BackstageImage from './BackstageImage';
+
+import { YTNode } from '../helpers';
+
+class PostMultiImage extends YTNode {
+  static type = 'PostMultiImage';
+
+  images : BackstageImage[];
+
+  constructor(data: any) {
+    super();
+    this.images = Parser.parseArray(data.images, BackstageImage);
+  }
+}
+
+export default PostMultiImage;

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -232,6 +232,7 @@ import { default as PlaylistVideoList } from './classes/PlaylistVideoList';
 import { default as PlaylistVideoThumbnail } from './classes/PlaylistVideoThumbnail';
 import { default as Poll } from './classes/Poll';
 import { default as Post } from './classes/Post';
+import { default as PostMultiImage } from './classes/PostMultiImage';
 import { default as ProfileColumn } from './classes/ProfileColumn';
 import { default as ProfileColumnStats } from './classes/ProfileColumnStats';
 import { default as ProfileColumnStatsEntry } from './classes/ProfileColumnStatsEntry';
@@ -551,6 +552,7 @@ export const YTNodes = {
   PlaylistVideoThumbnail,
   Poll,
   Post,
+  PostMultiImage,
   ProfileColumn,
   ProfileColumnStats,
   ProfileColumnStatsEntry,


### PR DESCRIPTION
# Pull Request Template

## Description
MultiImage community posts were not parsed

related: 
https://github.com/FreeTubeApp/FreeTube/pull/1568

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings


Useful channel id for testing community post types: UCnkp4xDOwqqJD7sSM3xdUiQ