### PR TITLE
fix(ChannelAboutFullMetadata) Fix error when there are no primary links

### DIFF
--- a/src/parser/classes/ChannelAboutFullMetadata.ts
+++ b/src/parser/classes/ChannelAboutFullMetadata.ts
@@ -37,11 +37,11 @@ class ChannelAboutFullMetadata extends YTNode {
     this.avatar = Thumbnail.fromResponse(data.avatar);
     this.canonical_channel_url = data.canonicalChannelUrl;
 
-    this.primary_links = data.primaryLinks.map((link: any) => ({
+    this.primary_links = data.primaryLinks?.map((link: any) => ({
       endpoint: new NavigationEndpoint(link.navigationEndpoint),
       icon: Thumbnail.fromResponse(link.icon),
       title: new Text(link.title)
-    }));
+    })) ?? [];
 
     this.views = new Text(data.viewCountText);
     this.joined = new Text(data.joinedDateText);


### PR DESCRIPTION
## Description

Some channels don't have any primary links, think the channels that get generated for every user account but most YouTube users probably don't even know that they have a channel associated with their account.

Currently it prints a warning because it's calling `.map` on `undefined` in those situations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings