### PR TITLE
fix(TopicChannelDetails): avatar and subtitle parsing

### DIFF
--- a/src/parser/classes/TopicChannelDetails.ts
+++ b/src/parser/classes/TopicChannelDetails.ts
@@ -19,8 +19,8 @@ class TopicChannelDetails extends YTNode {
     super();
 
     this.title = new Text(data.title);
-    this.avatar = Thumbnail.fromResponse(data.thumbnail);
-    this.subtitle = new Text(data.title);
+    this.avatar = Thumbnail.fromResponse(data.thumbnail ?? data.avatar);
+    this.subtitle = new Text(data.subtitle);
     this.subscribe_button = Parser.parseItem<SubscribeButton>(data.subscribeButton, SubscribeButton);
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
   }


### PR DESCRIPTION
## Description

This pull request fixes the title and subtitle properties on the TopicChannelDetails being identical and the avatar array being empty.

I haven't come across a case where `data.thumbnail` actually existed but I've left it in there just in case there is an edge case that uses it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings