### PR TITLE
feat(Channel): Add getters for all optional tabs

### DIFF
--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -196,6 +196,10 @@ export default class Channel extends TabbedFeed {
     return new Channel(this.actions, page, true);
   }
 
+  get has_home(): boolean {
+    return this.hasTabWithURL('featured');
+  }
+
   get has_videos(): boolean {
     return this.hasTabWithURL('videos');
   }
@@ -214,6 +218,18 @@ export default class Channel extends TabbedFeed {
 
   get has_community(): boolean {
     return this.hasTabWithURL('community');
+  }
+
+  get has_channels(): boolean {
+    return this.hasTabWithURL('channels');
+  }
+
+  get has_about(): boolean {
+    return this.hasTabWithURL('about');
+  }
+
+  get has_search(): boolean {
+    return this.memo.getType(ExpandableTab)?.length > 0;
   }
 
   /**

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -41,5 +41,9 @@ export const CHANNELS = [
   {
     ID: 'UCt-oJR5teQIjOAxCmIQvcgA',
     NAME: "They're Just Movies"
+  },
+  {
+    ID: 'UCOpNcN46UbXVtpKMrmU4Abg',
+    NAME: "Gaming"
   }
 ];

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -165,11 +165,28 @@ describe('YouTube.js Tests', () => {
 
     it('should detect missing channel tabs', async () => {
       const channel = await yt.getChannel(CHANNELS[2].ID);
+      expect(channel.has_home).toBe(true);
       expect(channel.has_videos).toBe(true);
       expect(channel.has_shorts).toBe(false);
       expect(channel.has_live_streams).toBe(false);
       expect(channel.has_playlists).toBe(true);
       expect(channel.has_community).toBe(true);
+      expect(channel.has_channels).toBe(true);
+      expect(channel.has_about).toBe(true);
+      expect(channel.has_search).toBe(true);
+    })
+
+    it('should have no channel tabs channel tabs', async () => {
+      const channel = await yt.getChannel(CHANNELS[3].ID);
+      expect(channel.has_home).toBe(false);
+      expect(channel.has_videos).toBe(false);
+      expect(channel.has_shorts).toBe(false);
+      expect(channel.has_live_streams).toBe(false);
+      expect(channel.has_playlists).toBe(false);
+      expect(channel.has_community).toBe(false);
+      expect(channel.has_channels).toBe(false);
+      expect(channel.has_about).toBe(false);
+      expect(channel.has_search).toBe(false);
     })
 
     it('should retrieve home feed', async () => {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -176,7 +176,7 @@ describe('YouTube.js Tests', () => {
       expect(channel.has_search).toBe(true);
     })
 
-    it('should have no channel tabs channel tabs', async () => {
+    it('should have no channel tabs', async () => {
       const channel = await yt.getChannel(CHANNELS[3].ID);
       expect(channel.has_home).toBe(false);
       expect(channel.has_videos).toBe(false);


### PR DESCRIPTION
## Description

Follow up to #296

Since making that pull request, I've noticed that there are auto generated channels that don't have any tabs like https://www.youtube.com/@gaming (technically it does have a single tab but it's unlabeled and doesn't have a navigation endpoint) so I've added getters for the remaining tabs. Additionally it doesn't have a search field, so I added a getter for that too.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings