### PR TITLE
Fix: Assign MetaDataBadge's label

### DIFF
--- a/src/parser/classes/CompactVideo.ts
+++ b/src/parser/classes/CompactVideo.ts
@@ -58,18 +58,18 @@ class CompactVideo extends YTNode {
   }
 
   get is_fundraiser(): boolean {
-    return this.badges.some((badge) => badge.style === 'Fundraiser');
+    return this.badges.some((badge) => badge.label === 'Fundraiser');
   }
 
   get is_live(): boolean {
     return this.badges.some((badge) => {
-      if (badge.label === 'BADGE_STYLE_TYPE_LIVE_NOW' || badge.style === 'LIVE')
+      if (badge.style === 'BADGE_STYLE_TYPE_LIVE_NOW' || badge.label === 'LIVE')
         return true;
     });
   }
 
   get is_new(): boolean {
-    return this.badges.some((badge) => badge.style === 'New');
+    return this.badges.some((badge) => badge.label === 'New');
   }
 
   get is_premiere(): boolean {

--- a/src/parser/classes/MetadataBadge.ts
+++ b/src/parser/classes/MetadataBadge.ts
@@ -20,7 +20,7 @@ class MetadataBadge extends YTNode {
     }
 
     if (data?.label) {
-      this.style = data.label;
+      this.label = data.label;
     }
 
     if (data?.tooltip || data?.iconTooltip) {

--- a/src/parser/classes/Video.ts
+++ b/src/parser/classes/Video.ts
@@ -96,7 +96,7 @@ class Video extends YTNode {
 
   get is_live(): boolean {
     return this.badges.some((badge) => {
-      if (badge.label === 'BADGE_STYLE_TYPE_LIVE_NOW' || badge.style === 'LIVE')
+      if (badge.style === 'BADGE_STYLE_TYPE_LIVE_NOW' || badge.label === 'LIVE')
         return true;
     });
   }
@@ -106,15 +106,15 @@ class Video extends YTNode {
   }
 
   get is_premiere(): boolean {
-    return this.badges.some((badge) => badge.style === 'PREMIERE');
+    return this.badges.some((badge) => badge.label === 'PREMIERE');
   }
 
   get is_4k(): boolean {
-    return this.badges.some((badge) => badge.style === '4K');
+    return this.badges.some((badge) => badge.label === '4K');
   }
 
   get has_captions(): boolean {
-    return this.badges.some((badge) => badge.style === 'CC');
+    return this.badges.some((badge) => badge.label === 'CC');
   }
 
   get best_thumbnail(): Thumbnail | undefined {


### PR DESCRIPTION
# Pull Request Template

## Description

For MetaDataBadge: Assign `label` to label property instead of assigning `label` to style property  (introduced in #256 )

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes. 
- [x] I have checked my code and corrected any misspellings