### PR TITLE
feat: Add upcoming and live info to playlist videos

### DIFF
--- a/src/parser/classes/PlaylistVideo.ts
+++ b/src/parser/classes/PlaylistVideo.ts
@@ -3,6 +3,7 @@ import Parser from '../index.js';
 import Thumbnail from './misc/Thumbnail.js';
 import PlaylistAuthor from './misc/PlaylistAuthor.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
+import ThumbnailOverlayTimeStatus from './ThumbnailOverlayTimeStatus.js';
 import type Menu from './menus/Menu.js';
 
 import { YTNode } from '../helpers.js';
@@ -20,6 +21,7 @@ class PlaylistVideo extends YTNode {
   endpoint: NavigationEndpoint;
   is_playable: boolean;
   menu: Menu | null;
+  upcoming;
 
   duration: {
     text: string;
@@ -33,15 +35,29 @@ class PlaylistVideo extends YTNode {
     this.title = new Text(data.title);
     this.author = new PlaylistAuthor(data.shortBylineText);
     this.thumbnails = Thumbnail.fromResponse(data.thumbnail);
-    this.thumbnail_overlays = Parser.parse(data.thumbnailOverlays);
+    this.thumbnail_overlays = Parser.parseArray(data.thumbnailOverlays);
     this.set_video_id = data?.setVideoId;
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
     this.is_playable = data.isPlayable;
     this.menu = Parser.parseItem<Menu>(data.menu);
+
+    const upcoming = data.upcomingEventData && Number(`${data.upcomingEventData.startTime}000`);
+    if (upcoming) {
+      this.upcoming = new Date(upcoming);
+    }
+
     this.duration = {
       text: new Text(data.lengthText).text,
       seconds: parseInt(data.lengthSeconds)
     };
+  }
+
+  get is_live(): boolean {
+    return this.thumbnail_overlays.firstOfType(ThumbnailOverlayTimeStatus)?.style === 'LIVE';
+  }
+
+  get is_upcoming(): boolean {
+    return this.thumbnail_overlays.firstOfType(ThumbnailOverlayTimeStatus)?.style === 'UPCOMING';
   }
 }
 

--- a/src/parser/classes/ThumbnailOverlayTimeStatus.ts
+++ b/src/parser/classes/ThumbnailOverlayTimeStatus.ts
@@ -5,10 +5,12 @@ class ThumbnailOverlayTimeStatus extends YTNode {
   static type = 'ThumbnailOverlayTimeStatus';
 
   text: string;
+  style: string;
 
   constructor(data: any) {
     super();
     this.text = new Text(data.text).toString();
+    this.style = data.style;
   }
 }
 


### PR DESCRIPTION
## Description

Currently the live and upcoming status as well as the premiere date of playlist videos is not extracted. I choose property names that are the same as the ones in `src/parser/classes/Video.ts`.

Here are two playlists I found that can be used to test it (went to youtube.com/live, clicked through to the channels and looked for playlists with the live and upcoming videos in them):

Live: https://www.youtube.com/playlist?list=PL6NdkXsPL07IFb3kA-m9QNY8oUMctNM3i
Upcoming: https://www.youtube.com/playlist?list=PLT2PUxNJBoeONIclW0JlAhuX8j7umZKwZ

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings