### PR TITLE
fix(PlayerMicroformat): Make the embed field optional

### DIFF
--- a/src/parser/classes/PlayerMicroformat.ts
+++ b/src/parser/classes/PlayerMicroformat.ts
@@ -16,7 +16,7 @@ class PlayerMicroformat extends YTNode {
     // TODO: check these
     width: any;
     height: any;
-  };
+  } | null;
 
   length_seconds: number;
 
@@ -42,13 +42,17 @@ class PlayerMicroformat extends YTNode {
     this.description = new Text(data.description);
     this.thumbnails = Thumbnail.fromResponse(data.thumbnail);
 
-    this.embed = {
-      iframe_url: data.embed.iframeUrl,
-      flash_url: data.embed.flashUrl,
-      flash_secure_url: data.embed.flashSecureUrl,
-      width: data.embed.width,
-      height: data.embed.height
-    };
+    if (data.embed) {
+      this.embed = {
+        iframe_url: data.embed.iframeUrl,
+        flash_url: data.embed.flashUrl,
+        flash_secure_url: data.embed.flashSecureUrl,
+        width: data.embed.width,
+        height: data.embed.height
+      };
+    } else {
+      this.embed = null;
+    }
 
     this.length_seconds = parseInt(data.lengthSeconds);
 


### PR DESCRIPTION
## Description

Videos like https://www.youtube.com/watch?v=HQMkxmtPZhg don't have the embed property in the player microformat response, which causes YouTube.js to log an error about not being able to access `iframeUrl` on undefined.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings