### PR TITLE
feat(yt): add `getGuide()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ const yt = await Innertube.create({
   * [.getSearchSuggestions(query)](#getsearchsuggestions)
   * [.getComments(video_id, sort_by?)](#getcomments)
   * [.getHomeFeed()](#gethomefeed)
+  * [.getGuide()](#getguide)
   * [.getLibrary()](#getlibrary)
   * [.getHistory()](#gethistory)
   * [.getTrending()](#gettrending)
@@ -425,6 +426,12 @@ Retrieves YouTube's home feed.
 
 </p>
 </details> 
+
+<a name="getguide"></a>
+### getGuide()
+Retrieves YouTube's content guide.
+
+**Returns**: `Promise<Guide>`
 
 <a name="getlibrary"></a>
 ### getLibrary()

--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -21,6 +21,7 @@ import PlaylistManager from './core/PlaylistManager.js';
 import YTStudio from './core/Studio.js';
 import TabbedFeed from './core/TabbedFeed.js';
 import HomeFeed from './parser/youtube/HomeFeed.js';
+import Guide from './parser/youtube/Guide.js';
 import Proto from './proto/index.js';
 import Constants from './utils/Constants.js';
 
@@ -168,6 +169,14 @@ class Innertube {
   async getHomeFeed(): Promise<HomeFeed> {
     const response = await this.actions.execute('/browse', { browseId: 'FEwhat_to_watch' });
     return new HomeFeed(this.actions, response);
+  }
+
+  /**
+   * Retrieves YouTube's content guide.
+   */
+  async getGuide(): Promise<Guide> {
+    const response = await this.actions.execute('/guide');
+    return new Guide(response.data);
   }
 
   /**

--- a/src/parser/classes/GuideCollapsibleEntry.ts
+++ b/src/parser/classes/GuideCollapsibleEntry.ts
@@ -17,7 +17,7 @@ class GuideCollapsibleEntry extends YTNode {
 
   constructor(data: any) {
     super();
-    
+
     this.expander_item = {
       title: new Text(data.expanderItem.guideEntryRenderer.formattedTitle).toString(),
       icon_type: data.expanderItem.guideEntryRenderer.icon.iconType

--- a/src/parser/classes/GuideCollapsibleEntry.ts
+++ b/src/parser/classes/GuideCollapsibleEntry.ts
@@ -1,0 +1,35 @@
+import Text from './misc/Text.js';
+import { YTNode } from '../helpers.js';
+import Parser from '../parser.js';
+
+class GuideCollapsibleEntry extends YTNode {
+  static type = 'GuideCollapsibleEntry';
+
+  expander_item: {
+    title: string,
+    icon_type: string
+  };
+  collapser_item: {
+    title: string,
+    icon_type: string
+  };
+  expandable_items;
+
+  constructor(data: any) {
+    super();
+    
+    this.expander_item = {
+      title: new Text(data.expanderItem.guideEntryRenderer.formattedTitle).toString(),
+      icon_type: data.expanderItem.guideEntryRenderer.icon.iconType
+    };
+
+    this.collapser_item = {
+      title: new Text(data.collapserItem.guideEntryRenderer.formattedTitle).toString(),
+      icon_type: data.collapserItem.guideEntryRenderer.icon.iconType
+    };
+
+    this.expandable_items = Parser.parseArray(data.expandableItems);
+  }
+}
+
+export default GuideCollapsibleEntry;

--- a/src/parser/classes/GuideCollapsibleSectionEntry.ts
+++ b/src/parser/classes/GuideCollapsibleSectionEntry.ts
@@ -1,0 +1,23 @@
+import { YTNode } from '../helpers.js';
+import Parser from '../parser.js';
+
+class GuideCollapsibleSectionEntry extends YTNode {
+  static type = 'GuideCollapsibleSectionEntry';
+
+  header_entry;
+  expander_icon: string;
+  collapser_icon: string;
+  section_items;
+
+  constructor(data: any) {
+    super();
+    
+    this.header_entry = Parser.parseItem(data.headerEntry);
+    this.expander_icon = data.expanderIcon.iconType;
+    this.collapser_icon = data.collapserIcon.iconType;
+    this.section_items = Parser.parseArray(data.sectionItems);
+    
+  }
+}
+
+export default GuideCollapsibleSectionEntry;

--- a/src/parser/classes/GuideCollapsibleSectionEntry.ts
+++ b/src/parser/classes/GuideCollapsibleSectionEntry.ts
@@ -11,12 +11,12 @@ class GuideCollapsibleSectionEntry extends YTNode {
 
   constructor(data: any) {
     super();
-    
+
     this.header_entry = Parser.parseItem(data.headerEntry);
     this.expander_icon = data.expanderIcon.iconType;
     this.collapser_icon = data.collapserIcon.iconType;
     this.section_items = Parser.parseArray(data.sectionItems);
-    
+
   }
 }
 

--- a/src/parser/classes/GuideDownloadsEntry.ts
+++ b/src/parser/classes/GuideDownloadsEntry.ts
@@ -1,0 +1,14 @@
+import GuideEntry from './GuideEntry.js';
+
+class GuideDownloadsEntry extends GuideEntry {
+  static type = 'GuideDownloadsEntry';
+
+  always_show: boolean;
+
+  constructor(data: any) {
+    super(data.entryRenderer.guideEntryRenderer);
+    this.always_show = !!data.alwaysShow;
+  }
+}
+
+export default GuideDownloadsEntry;

--- a/src/parser/classes/GuideEntry.ts
+++ b/src/parser/classes/GuideEntry.ts
@@ -1,0 +1,33 @@
+import Text from './misc/Text.js';
+import NavigationEndpoint from './NavigationEndpoint.js';
+import { YTNode } from '../helpers.js';
+import Thumbnail from './misc/Thumbnail.js';
+
+class GuideEntry extends YTNode {
+  static type = 'GuideEntry';
+
+  title: Text;
+  endpoint: NavigationEndpoint;
+  icon_type?: string;
+  thumbnails?: Thumbnail[];
+  badges?: any;
+  is_primary: boolean;
+
+  constructor(data: any) {
+    super();
+    this.title = new Text(data.formattedTitle);
+    this.endpoint = new NavigationEndpoint(data.navigationEndpoint || data.serviceEndpoint);
+    if (data.icon?.iconType) {
+      this.icon_type = data.icon.iconType;
+    }
+    if (data.thumbnail) {
+      this.thumbnails = Thumbnail.fromResponse(data.thumbnail);
+    }
+    if (data.badges) {
+      this.badges = data.badges;
+    }
+    this.is_primary = !!data.isPrimary;
+  }
+}
+
+export default GuideEntry;

--- a/src/parser/classes/GuideSection.ts
+++ b/src/parser/classes/GuideSection.ts
@@ -11,7 +11,7 @@ class GuideSection extends YTNode {
   constructor(data: any) {
     super();
     if (data.formattedTitle) {
-        this.title = new Text(data.formattedTitle);
+      this.title = new Text(data.formattedTitle);
     }
     this.items = Parser.parseArray(data.items);
   }

--- a/src/parser/classes/GuideSection.ts
+++ b/src/parser/classes/GuideSection.ts
@@ -1,0 +1,20 @@
+import Text from './misc/Text.js';
+import { YTNode } from '../helpers.js';
+import Parser from '../parser.js';
+
+class GuideSection extends YTNode {
+  static type = 'GuideSection';
+
+  title?: Text;
+  items;
+
+  constructor(data: any) {
+    super();
+    if (data.formattedTitle) {
+        this.title = new Text(data.formattedTitle);
+    }
+    this.items = Parser.parseArray(data.items);
+  }
+}
+
+export default GuideSection;

--- a/src/parser/classes/GuideSubscriptionsSection.ts
+++ b/src/parser/classes/GuideSubscriptionsSection.ts
@@ -1,0 +1,7 @@
+import GuideSection from './GuideSection.js';
+
+class GuideSubscriptionsSection extends GuideSection {
+  static type = 'GuideSubscriptionsSection';
+}
+
+export default GuideSubscriptionsSection;

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -196,6 +196,18 @@ import { default as GridPlaylist } from './classes/GridPlaylist.js';
 export { GridPlaylist };
 import { default as GridVideo } from './classes/GridVideo.js';
 export { GridVideo };
+import { default as GuideCollapsibleEntry } from './classes/GuideCollapsibleEntry.js';
+export { GuideCollapsibleEntry };
+import { default as GuideCollapsibleSectionEntry } from './classes/GuideCollapsibleSectionEntry.js';
+export { GuideCollapsibleSectionEntry };
+import { default as GuideDownloadsEntry } from './classes/GuideDownloadsEntry.js';
+export { GuideDownloadsEntry };
+import { default as GuideEntry } from './classes/GuideEntry.js';
+export { GuideEntry };
+import { default as GuideSection } from './classes/GuideSection.js';
+export { GuideSection };
+import { default as GuideSubscriptionsSection } from './classes/GuideSubscriptionsSection.js';
+export { GuideSubscriptionsSection };
 import { default as HashtagHeader } from './classes/HashtagHeader.js';
 export { HashtagHeader };
 import { default as Heatmap } from './classes/Heatmap.js';
@@ -757,6 +769,12 @@ const map: Record<string, YTNodeConstructor> = {
   GridHeader,
   GridPlaylist,
   GridVideo,
+  GuideCollapsibleEntry,
+  GuideCollapsibleSectionEntry,
+  GuideDownloadsEntry,
+  GuideEntry,
+  GuideSection,
+  GuideSubscriptionsSection,
   HashtagHeader,
   Heatmap,
   HeatMarker,

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -262,6 +262,14 @@ export default class Parser {
       parsed_data.cards = cards;
     }
 
+    this.#createMemo();
+    const items = this.parse(data.items);
+    if (items) {
+      parsed_data.items = items;
+      parsed_data.items_memo = this.#getMemo();
+    }
+    this.#clearMemo();
+
     return parsed_data;
   }
 
@@ -481,7 +489,8 @@ export default class Parser {
     'RunAttestationCommand',
     'CompactPromotedVideo',
     'StatementBanner',
-    'SearchSubMenu'
+    'SearchSubMenu',
+    'GuideSigninPromo'
   ]);
 
   static shouldIgnore(classname: string) {

--- a/src/parser/types/ParsedResponse.ts
+++ b/src/parser/types/ParsedResponse.ts
@@ -29,6 +29,7 @@ export interface IParsedResponse {
   sidebar_memo?: Memo;
   live_chat_item_context_menu_supported_renderers?: YTNode;
   live_chat_item_context_menu_supported_renderers_memo?: Memo;
+  items_memo?: Memo;
   on_response_received_actions?: ObservedArray<ReloadContinuationItemsCommand | AppendContinuationItemsAction>;
   on_response_received_actions_memo?: Memo;
   on_response_received_endpoints?: ObservedArray<ReloadContinuationItemsCommand | AppendContinuationItemsAction>;
@@ -72,6 +73,7 @@ export interface IParsedResponse {
   storyboards?: PlayerStoryboardSpec | PlayerLiveStoryboardSpec;
   endscreen?: Endscreen;
   cards?: CardCollection;
+  items?: SuperParsedResult<YTNode>;
 }
 
 export interface IPlayerResponse {
@@ -156,4 +158,9 @@ export interface IUpdatedMetadataResponse {
   actions: SuperParsedResult<YTNode>;
   actions_memo: Memo;
   continuation?: Continuation;
+}
+
+export interface IGuideResponse {
+  contents: SuperParsedResult<YTNode>;
+  items_memo: Memo;
 }

--- a/src/parser/types/ParsedResponse.ts
+++ b/src/parser/types/ParsedResponse.ts
@@ -161,6 +161,6 @@ export interface IUpdatedMetadataResponse {
 }
 
 export interface IGuideResponse {
-  contents: SuperParsedResult<YTNode>;
+  items: SuperParsedResult<YTNode>;
   items_memo: Memo;
 }

--- a/src/parser/types/RawResponse.ts
+++ b/src/parser/types/RawResponse.ts
@@ -51,5 +51,6 @@ export interface IRawResponse {
   storyboards?: RawNode;
   endscreen?: RawNode;
   cards?: RawNode;
+  items?: RawNode[];
   frameworkUpdates?: any;
 }

--- a/src/parser/youtube/Guide.ts
+++ b/src/parser/youtube/Guide.ts
@@ -2,7 +2,7 @@ import type { IGuideResponse } from '../types/ParsedResponse.js';
 import { IRawResponse, Parser } from '../index.js';
 import { ObservedArray } from '../helpers.js';
 import GuideSection from '../classes/GuideSection.js';
-import { GuideSubscriptionsSection } from '../map.js';
+import GuideSubscriptionsSection from '../classes/GuideSubscriptionsSection.js';
 
 export default class Guide {
 

--- a/src/parser/youtube/Guide.ts
+++ b/src/parser/youtube/Guide.ts
@@ -2,14 +2,15 @@ import type { IGuideResponse } from '../types/ParsedResponse.js';
 import { IRawResponse, Parser } from '../index.js';
 import { ObservedArray } from '../helpers.js';
 import GuideSection from '../classes/GuideSection.js';
+import { GuideSubscriptionsSection } from '../map.js';
 
 export default class Guide {
 
   #page: IGuideResponse;
-  contents: ObservedArray<GuideSection>;
+  contents: ObservedArray<GuideSection | GuideSubscriptionsSection>;
 
   constructor(data: IRawResponse) {
     this.#page = Parser.parseResponse<IGuideResponse>(data);
-    this.contents = this.#page.items_memo.getType(GuideSection);
+    this.contents = this.#page.items.array().as(GuideSection, GuideSubscriptionsSection);
   }
 }

--- a/src/parser/youtube/Guide.ts
+++ b/src/parser/youtube/Guide.ts
@@ -1,0 +1,15 @@
+import type { IGuideResponse } from '../types/ParsedResponse.js';
+import { IRawResponse, Parser } from '../index.js';
+import { ObservedArray } from '../helpers.js';
+import GuideSection from '../classes/GuideSection.js';
+
+export default class Guide {
+
+  #page: IGuideResponse;
+  contents: ObservedArray<GuideSection>;
+
+  constructor(data: IRawResponse) {
+    this.#page = Parser.parseResponse<IGuideResponse>(data);
+    this.contents = this.#page.items_memo.getType(GuideSection);
+  }
+}

--- a/src/parser/youtube/Guide.ts
+++ b/src/parser/youtube/Guide.ts
@@ -13,4 +13,8 @@ export default class Guide {
     this.#page = Parser.parseResponse<IGuideResponse>(data);
     this.contents = this.#page.items.array().as(GuideSection, GuideSubscriptionsSection);
   }
+
+  get page(): IGuideResponse {
+    return this.#page;
+  }
 }


### PR DESCRIPTION
Add support for fetching YouTube's content guide, contents of which you will find in the left sidebar of YT website:


![image](https://user-images.githubusercontent.com/55383971/222749140-6ae4fa83-8e2e-4bb1-bb85-6616e4a806ab.png)


# Usage
```
const guide = await youtube.getGuide();

// guide.contents:
[
    {
      "type": "GuideSection",
      "items": [
        {
          "type": "GuideEntry",
          "title": {
            "text": "Home"
          },
          "endpoint": {
            "type": "NavigationEndpoint",
            "payload": {
              "browseId": "FEwhat_to_watch"
            },
            "metadata": {
              "url": "/",
              "page_type": "WEB_PAGE_TYPE_BROWSE",
              "api_url": "browse"
            }
          },
          "icon_type": "WHAT_TO_WATCH",
          "is_primary": true
        }
        ...
      ]
    }
    ...
]

```
