### PR TITLE
feat(parser): add `banner` to `PlaylistHeader`

### DIFF
--- a/src/parser/classes/HeroPlaylistThumbnail.ts
+++ b/src/parser/classes/HeroPlaylistThumbnail.ts
@@ -1,0 +1,19 @@
+import { YTNode } from '../helpers.js';
+import NavigationEndpoint from './NavigationEndpoint.js';
+import Thumbnail from './misc/Thumbnail.js';
+
+class HeroPlaylistThumbnail extends YTNode {
+  static type = 'HeroPlaylistThumbnail';
+
+  thumbnails: Thumbnail[];
+  on_tap_endpoint: NavigationEndpoint;
+
+  constructor(data: any) {
+    super();
+
+    this.thumbnails = Thumbnail.fromResponse(data.thumbnail);
+    this.on_tap_endpoint = new NavigationEndpoint(data.onTap);
+  }
+}
+
+export default HeroPlaylistThumbnail;

--- a/src/parser/classes/PlaylistHeader.ts
+++ b/src/parser/classes/PlaylistHeader.ts
@@ -21,6 +21,7 @@ class PlaylistHeader extends YTNode {
   save_button;
   shuffle_play_button;
   menu;
+  banner;
 
   constructor(data: any) {
     super();
@@ -39,6 +40,7 @@ class PlaylistHeader extends YTNode {
     this.save_button = Parser.parse(data.saveButton);
     this.shuffle_play_button = Parser.parse(data.shufflePlayButton);
     this.menu = Parser.parse(data.moreActionsMenu);
+    this.banner = Parser.parseItem(data.playlistHeaderBanner);
   }
 }
 

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -214,6 +214,8 @@ import { default as Heatmap } from './classes/Heatmap.js';
 export { Heatmap };
 import { default as HeatMarker } from './classes/HeatMarker.js';
 export { HeatMarker };
+import { default as HeroPlaylistThumbnail } from './classes/HeroPlaylistThumbnail.js';
+export { HeroPlaylistThumbnail };
 import { default as HighlightsCarousel } from './classes/HighlightsCarousel.js';
 export { HighlightsCarousel };
 import { default as HistorySuggestion } from './classes/HistorySuggestion.js';
@@ -778,6 +780,7 @@ const map: Record<string, YTNodeConstructor> = {
   HashtagHeader,
   Heatmap,
   HeatMarker,
+  HeroPlaylistThumbnail,
   HighlightsCarousel,
   HistorySuggestion,
   HorizontalCardList,


### PR DESCRIPTION
Add `banner` to `PlaylistHeader`, in case someone needs it (e.g. me). Doesn't really do much since `getPlaylist()` already fetches thumbnails and endpoint from other places in the response data, so understandable if you don't merge this :smile: 