### PR TITLE
feat: Add support for descriptive audio tracks

### DIFF
--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -41,6 +41,7 @@ class Format {
   has_video: boolean;
   language?: string | null;
   is_dubbed?: boolean;
+  is_descriptive?: boolean;
   is_original?: boolean;
 
   constructor(data: any) {
@@ -83,6 +84,7 @@ class Format {
 
       this.language = url_components.get('xtags')?.split(':').find((x: string) => x.startsWith('lang='))?.split('=').at(1) || null;
       this.is_dubbed = url_components.get('xtags')?.split(':').find((x: string) => x.startsWith('acont='))?.split('=').at(1) === 'dubbed';
+      this.is_descriptive = url_components.get('xtags')?.split(':').find((x: string) => x.startsWith('acont='))?.split('=').at(1) === 'descriptive';
       this.is_original = url_components.get('xtags')?.split(':').find((x: string) => x.startsWith('acont='))?.split('=').at(1) === 'original' || !this.is_dubbed;
 
       if (data.audioTrack) {


### PR DESCRIPTION
## Description

Turns out that YouTube also supports descriptive audio tracks not just dubs (courtesy of https://github.com/TeamNewPipe/NewPipeExtractor/pull/1026)

This pull request adds a new field to the Format class `is_descriptive` and also refactors the DASH manifest code to support descriptive audio tracks. Previously in #308 I did the grouping based on the language, now that we know that it's not the only differentiating factor between audio tracks, I decided to group them based on the audio track id that YouTube provides. That also makes it easier to add support for additonal audio track types in the future, if we find out there are more.

Example video: https://www.youtube.com/watch?v=TjxC-evzxdk

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings