### PR TITLE
fix(youtube):  add `PlayerLegacyDesktopYpcOffer` node

### DIFF
--- a/src/parser/classes/PlayerLegacyDesktopYpcOffer.ts
+++ b/src/parser/classes/PlayerLegacyDesktopYpcOffer.ts
@@ -1,0 +1,21 @@
+import { YTNode } from '../helpers.js';
+import type { RawNode } from '../index.js';
+
+class PlayerLegacyDesktopYpcOffer extends YTNode {
+  static type = 'PlayerLegacyDesktopYpcOffer';
+
+  title: string;
+  thumbnail: string;
+  offer_description: string;
+  offer_id: string;
+
+  constructor(data: RawNode) {
+    super();
+    this.title = data.itemTitle;
+    this.thumbnail = data.itemThumbnail;
+    this.offer_description = data.offerDescription;
+    this.offer_id = data.offerId;
+  }
+}
+
+export default PlayerLegacyDesktopYpcOffer;

--- a/src/parser/classes/VideoPrimaryInfo.ts
+++ b/src/parser/classes/VideoPrimaryInfo.ts
@@ -1,7 +1,9 @@
+import { YTNode } from '../helpers.js';
+import type { RawNode } from '../index.js';
+import type { ObservedArray } from '../helpers.js';
+import { YTNodes } from '../index.js';
 import Parser from '../index.js';
 import Text from './misc/Text.js';
-import { YTNode } from '../helpers.js';
-import Menu from './menus/Menu.js';
 
 class VideoPrimaryInfo extends YTNode {
   static type = 'VideoPrimaryInfo';
@@ -10,17 +12,21 @@ class VideoPrimaryInfo extends YTNode {
   super_title_link: Text;
   view_count: Text;
   short_view_count: Text;
+  badges: ObservedArray<YTNodes.MetadataBadge>;
   published: Text;
-  menu;
+  relative_date: Text;
+  menu: YTNodes.Menu | null;
 
-  constructor(data: any) {
+  constructor(data: RawNode) {
     super();
     this.title = new Text(data.title);
     this.super_title_link = new Text(data.superTitleLink);
-    this.view_count = new Text(data.viewCount.videoViewCountRenderer.viewCount);
-    this.short_view_count = new Text(data.viewCount.videoViewCountRenderer.shortViewCount);
+    this.view_count = new Text(data.viewCount?.videoViewCountRenderer?.viewCount);
+    this.short_view_count = new Text(data.viewCount?.videoViewCountRenderer?.shortViewCount);
+    this.badges = Parser.parseArray(data.badges, YTNodes.MetadataBadge);
     this.published = new Text(data.dateText);
-    this.menu = Parser.parseItem(data.videoActions, Menu);
+    this.relative_date = new Text(data.relativeDateText);
+    this.menu = Parser.parseItem(data.videoActions, YTNodes.Menu);
   }
 }
 

--- a/src/parser/map.ts
+++ b/src/parser/map.ts
@@ -448,6 +448,8 @@ import { default as PlayerCaptionsTracklist } from './classes/PlayerCaptionsTrac
 export { PlayerCaptionsTracklist };
 import { default as PlayerErrorMessage } from './classes/PlayerErrorMessage.js';
 export { PlayerErrorMessage };
+import { default as PlayerLegacyDesktopYpcOffer } from './classes/PlayerLegacyDesktopYpcOffer.js';
+export { PlayerLegacyDesktopYpcOffer };
 import { default as PlayerLiveStoryboardSpec } from './classes/PlayerLiveStoryboardSpec.js';
 export { PlayerLiveStoryboardSpec };
 import { default as PlayerMicroformat } from './classes/PlayerMicroformat.js';
@@ -898,6 +900,7 @@ const map: Record<string, YTNodeConstructor> = {
   PlayerAnnotationsExpanded,
   PlayerCaptionsTracklist,
   PlayerErrorMessage,
+  PlayerLegacyDesktopYpcOffer,
   PlayerLiveStoryboardSpec,
   PlayerMicroformat,
   PlayerOverlay,


### PR DESCRIPTION
## Description

Adds the `PlayerLegacyDesktopYpcOffer` error screen node, which appears when trying to retrieve members-only content. This also fixes a couple of warnings regarding the `VideoPrimaryInfo` node that only appear when viewing such content as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings