### PR TITLE
feat(VideoInfo): support get by endpoint + more info

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ const yt = await Innertube.create({
   <summary>Methods</summary>
   <p>
   
-  * [.getInfo(video_id, client?)](#getinfo)
+  * [.getInfo(target, client?)](#getinfo)
   * [.getBasicInfo(video_id, client?)](#getbasicinfo)
   * [.search(query, filters?)](#search)
   * [.getSearchSuggestions(query)](#getsearchsuggestions)
@@ -273,7 +273,7 @@ const yt = await Innertube.create({
   </details> 
 
 <a name="getinfo"></a>
-### getInfo(video_id, client?)
+### getInfo(target, client?)
 
 Retrieves video info, including playback data and even layout elements such as menus, buttons, etc — all nicely parsed.
 
@@ -281,7 +281,7 @@ Retrieves video info, including playback data and even layout elements such as m
 
 | Param | Type | Description |
 | --- | --- | --- |
-| video_id | `string` | The id of the video |
+| target | `string` \| `NavigationEndpoint` | If `string`, the id of the video. If `NavigationEndpoint`, the endpoint of watchable elements such as `Video`, `Mix` and `Playlist`. To clarify, valid endpoints have payloads containing at least `videoId` and optionally `playlistId`, `params` and `index`. |
 | client? | `InnerTubeClient` | `WEB`, `ANDROID`, `YTMUSIC`, `YTMUSIC_ANDROID` or `TV_EMBEDDED` |
 
 <details>
@@ -320,6 +320,9 @@ Retrieves video info, including playback data and even layout elements such as m
 
 - `<info>#addToWatchHistory()`
   - Adds the video to the watch history.
+
+- `<info>#autoplay_video_endpoint`
+  - Returns the endpoint of the video for Autoplay.
 
 - `<info>#page`
   - Returns original InnerTube response (sanitized).

--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -72,7 +72,7 @@ class Innertube {
 
   /**
    * Retrieves video info.
-   * @param video_id - The video id.
+   * @param target - The video id or `NavigationEndpoint`.
    * @param client - The client to use.
    */
   async getInfo(target: string | NavigationEndpoint, client?: InnerTubeClient): Promise<VideoInfo> {

--- a/src/parser/classes/TwoColumnWatchNextResults.ts
+++ b/src/parser/classes/TwoColumnWatchNextResults.ts
@@ -1,5 +1,15 @@
 import Parser from '../index.js';
 import { YTNode } from '../helpers.js';
+import Text from './misc/Text.js';
+import PlaylistAuthor from './misc/PlaylistAuthor.js';
+import NavigationEndpoint from './NavigationEndpoint.js';
+
+import type Menu from './menus/Menu.js';
+
+type AutoplaySet = {
+  autoplay_video: NavigationEndpoint,
+  next_button_video?: NavigationEndpoint
+};
 
 class TwoColumnWatchNextResults extends YTNode {
   static type = 'TwoColumnWatchNextResults';
@@ -7,12 +17,66 @@ class TwoColumnWatchNextResults extends YTNode {
   results;
   secondary_results;
   conversation_bar;
+  playlist?: {
+    id: string,
+    title: string,
+    author: Text | PlaylistAuthor,
+    contents: YTNode[],
+    current_index: number,
+    is_infinite: boolean,
+    menu: Menu | null
+  };
+  autoplay?: {
+    sets: AutoplaySet[],
+    modified_sets?: AutoplaySet[],
+    count_down_secs?: number
+  };
 
   constructor(data: any) {
     super();
     this.results = Parser.parseArray(data.results?.results.contents);
     this.secondary_results = Parser.parseArray(data.secondaryResults?.secondaryResults.results);
     this.conversation_bar = Parser.parseItem(data?.conversationBar);
+
+    const playlistData = data.playlist?.playlist;
+    if (playlistData) {
+      this.playlist = {
+        id: playlistData.playlistId,
+        title: playlistData.title,
+        author: playlistData.shortBylineText?.simpleText ?
+          new Text(playlistData.shortBylineText) :
+          new PlaylistAuthor(playlistData.longBylineText),
+        contents: Parser.parseArray(playlistData.contents),
+        current_index: playlistData.currentIndex,
+        is_infinite: !!playlistData.isInfinite,
+        menu: Parser.parseItem<Menu>(playlistData.menu)
+      };
+    }
+
+    const autoplayData = data.autoplay?.autoplay;
+    if (autoplayData) {
+      this.autoplay = {
+        sets: autoplayData.sets.map((set: any) => this.#parseAutoplaySet(set))
+      };
+      if (autoplayData.modifiedSets) {
+        this.autoplay.modified_sets = autoplayData.modifiedSets.map((set: any) => this.#parseAutoplaySet(set));
+      }
+      if (autoplayData.countDownSecs) {
+        this.autoplay.count_down_secs = autoplayData.countDownSecs;
+      }
+    }
+  }
+
+  #parseAutoplaySet(data: any): AutoplaySet {
+    const result = {
+      autoplay_video: new NavigationEndpoint(data.autoplayVideo)
+    } as AutoplaySet;
+
+    if (data.nextButtonVideo) {
+      result.next_button_video = new NavigationEndpoint(data.nextButtonVideo);
+    }
+
+    return result;
   }
 }
 

--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -20,6 +20,7 @@ import TwoColumnWatchNextResults from '../classes/TwoColumnWatchNextResults.js';
 import VideoPrimaryInfo from '../classes/VideoPrimaryInfo.js';
 import VideoSecondaryInfo from '../classes/VideoSecondaryInfo.js';
 import LiveChatWrap from './LiveChat.js';
+import NavigationEndpoint from '../classes/NavigationEndpoint.js';
 
 import type CardCollection from '../classes/CardCollection.js';
 import type Endscreen from '../classes/Endscreen.js';
@@ -60,6 +61,7 @@ class VideoInfo {
 
   primary_info?: VideoPrimaryInfo | null;
   secondary_info?: VideoSecondaryInfo | null;
+  playlist?;
   game_info?;
   merchandise?: MerchandiseShelf | null;
   related_chip_cloud?: ChipCloud | null;
@@ -67,6 +69,7 @@ class VideoInfo {
   player_overlays?: PlayerOverlay | null;
   comments_entry_point_header?: CommentsEntryPointHeader | null;
   livechat?: LiveChat | null;
+  autoplay?;
 
   /**
    * @param data - API response.
@@ -141,12 +144,20 @@ class VideoInfo {
       this.merchandise = results.firstOfType(MerchandiseShelf);
       this.related_chip_cloud = secondary_results.firstOfType(RelatedChipCloud)?.content.item().as(ChipCloud);
 
+      if (two_col?.playlist) {
+        this.playlist = two_col.playlist;
+      }
+
       this.watch_next_feed = secondary_results.firstOfType(ItemSection)?.contents || secondary_results;
 
       if (this.watch_next_feed && Array.isArray(this.watch_next_feed) && this.watch_next_feed.at(-1)?.is(ContinuationItem))
         this.#watch_next_continuation = this.watch_next_feed.pop()?.as(ContinuationItem);
 
       this.player_overlays = next?.player_overlays?.item().as(PlayerOverlay);
+
+      if (two_col?.autoplay) {
+        this.autoplay = two_col.autoplay;
+      }
 
       const segmented_like_dislike_button = this.primary_info?.menu?.top_level_buttons.firstOfType(SegmentedLikeDislikeButton);
 
@@ -375,6 +386,13 @@ class VideoInfo {
    */
   get wn_has_continuation(): boolean {
     return !!this.#watch_next_continuation;
+  }
+
+  /**
+   * Gets the endpoint of the autoplay video
+   */
+  get autoplay_video_endpoint(): NavigationEndpoint | null {
+    return this.autoplay?.sets?.[0]?.autoplay_video || null;
   }
 
   /**


### PR DESCRIPTION
Adds support for getting video info by endpoint in `getInfo()`.  In addition, add `playlist` and `autoplay` to `VideoInfo`. 

The result is that you can now obtain video info within the context of a list such as `Playlist` or `Mix`.  To illustrate, consider the following endpoint for a `Mix` item:

```
// mixEndpoint:
{
  "type": "NavigationEndpoint",
  "payload": {
    "videoId": "XHedu3KcPP0",
    "playlistId": "RDXHedu3KcPP0",
    "params": "OALAAQE%3D",
    "continuePlayback": true
  },
  ...
}

// Call `getInfo()` with mixEndpoint:

const info = await youtube.getInfo(mixEndpoint);

// Now you can get not only info about the video (as referenced by id 'XHedu3KcPP0') itself, but 
// also other items in the list.

// info.playlist:
{
  "id": "RDXHedu3KcPP0",
  "title": "Mix - ...",
  "author": ...,
  "contents": [
    {
      "type": "PlaylistPanelVideo",
      ...
    }
  ]
  ...
}

```

`info.playlist` mirrors what you would see on YouTube:

![image](https://user-images.githubusercontent.com/55383971/223692184-43d18056-0f8c-40d0-b983-4ddee4eca6da.png)


Now, say you want to play the last item in the list and get info on that:
```
const lastVideo = info.playlist.contents.pop();
const newInfo = await youtube.getInfo(lastVideo.endpoint);

// `newInfo.playlist` will now have updated contents based on the `selected` video.
// In the context of a Mix, there would be new items added with some older ones removed.
```

In addition, you can get the Autoplay video endpoint:
```
const endpoint = info.autoplay_video_endpoint;

// or obtain from `info.autoplay`
```
This points to the next item in the list or, if there are none (end of list reached), a video as determined by YouTube autoplay logic.

Of course, you can still call `getInfo()` with `video_id: string`. Apparently, there won't be `playlist` info in this case.