### PR TITLE
Add `status` to `SearchFilter` and fix `endpoint`

### DIFF
--- a/src/parser/classes/SearchFilter.ts
+++ b/src/parser/classes/SearchFilter.ts
@@ -15,7 +15,7 @@ class SearchFilter extends YTNode {
     super();
 
     this.label = new Text(data.label);
-    this.endpoint = new NavigationEndpoint(data.endpoint);
+    this.endpoint = new NavigationEndpoint(data.endpoint || data.navigationEndpoint);
     this.tooltip = data.tooltip;
 
     if (data.status) {

--- a/src/parser/classes/SearchFilter.ts
+++ b/src/parser/classes/SearchFilter.ts
@@ -9,6 +9,7 @@ class SearchFilter extends YTNode {
   label: Text;
   endpoint: NavigationEndpoint;
   tooltip: string;
+  status?: string;
 
   constructor(data: RawNode) {
     super();
@@ -16,6 +17,18 @@ class SearchFilter extends YTNode {
     this.label = new Text(data.label);
     this.endpoint = new NavigationEndpoint(data.endpoint);
     this.tooltip = data.tooltip;
+
+    if (data.status) {
+      this.status = data.status;
+    }
+  }
+
+  get disabled(): boolean {
+    return this.status === 'FILTER_STATUS_DISABLED';
+  }
+
+  get selected(): boolean {
+    return this.status === 'FILTER_STATUS_SELECTED';
   }
 }
 


### PR DESCRIPTION
1. Add `status` to `SearchFilter`; add `disabled` and `selected` getters for convenience.
2. Parse `data.navigationEndpoint` if `data.endpoint` is missing. In fact, I have never encountered `data.endpoint` for `SearchFilter` but would be cautious about removing it in case it actually exists in some cases.