### PR TITLE
feat(parser): add `view_playlist` to `Playlist`

### DIFF
--- a/src/parser/classes/Playlist.ts
+++ b/src/parser/classes/Playlist.ts
@@ -4,6 +4,7 @@ import Thumbnail from './misc/Thumbnail.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import PlaylistAuthor from './misc/PlaylistAuthor.js';
 import { YTNode } from '../helpers.js';
+import NavigatableText from './misc/NavigatableText.js';
 
 class Playlist extends YTNode {
   static type = 'Playlist';
@@ -20,6 +21,7 @@ class Playlist extends YTNode {
   badges;
   endpoint: NavigationEndpoint;
   thumbnail_overlays;
+  view_playlist?: NavigatableText;
 
   constructor(data: any) {
     super();
@@ -39,6 +41,10 @@ class Playlist extends YTNode {
     this.badges = Parser.parseArray(data.ownerBadges);
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
     this.thumbnail_overlays = Parser.parseArray(data.thumbnailOverlays);
+
+    if (data.viewPlaylistText) {
+      this.view_playlist = new NavigatableText(data.viewPlaylistText);
+    }
   }
 }
 


### PR DESCRIPTION
Minor addition.

Example of `Playlist` having `view_playlist` can be found in YT search results.