### PR TITLE
feat!: Add support for OTF format streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ const videoInfo = await youtube.getInfo('videoId');
 // now convert to a dash manifest
 // again - to be able to stream the video in the browser - we must proxy the requests through our own server
 // to do this, we provide a method to transform the URLs before writing them to the manifest
-const manifest = videoInfo.toDash(url => {
+const manifest = await videoInfo.toDash(url => {
   // modify the url
   // and return it
   return url;

--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -5,6 +5,7 @@ import type { RawNode } from '../../index.js';
 class Format {
   itag: number;
   mime_type: string;
+  is_type_otf: boolean;
   bitrate: number;
   average_bitrate: number;
   width: number;
@@ -48,6 +49,7 @@ class Format {
   constructor(data: RawNode) {
     this.itag = data.itag;
     this.mime_type = data.mimeType;
+    this.is_type_otf = data.type === 'FORMAT_STREAM_TYPE_OTF';
     this.bitrate = data.bitrate;
     this.average_bitrate = data.averageBitrate;
     this.width = data.width || undefined;

--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -348,8 +348,8 @@ class VideoInfo {
    * @param format_filter - Function to filter the formats.
    * @returns DASH manifest
    */
-  toDash(url_transformer?: URLTransformer, format_filter?: FormatFilter): string {
-    return FormatUtils.toDash(this.streaming_data, url_transformer, format_filter, this.#cpn, this.#player);
+  async toDash(url_transformer?: URLTransformer, format_filter?: FormatFilter): Promise<string> {
+    return await FormatUtils.toDash(this.streaming_data, url_transformer, format_filter, this.#cpn, this.#player, this.#actions);
   }
 
   /**

--- a/src/parser/ytkids/VideoInfo.ts
+++ b/src/parser/ytkids/VideoInfo.ts
@@ -73,8 +73,8 @@ class VideoInfo {
    * @param format_filter - Function to filter the formats.
    * @returns DASH manifest
    */
-  toDash(url_transformer?: URLTransformer, format_filter?: FormatFilter): string {
-    return FormatUtils.toDash(this.streaming_data, url_transformer, format_filter, this.#cpn, this.#actions.session.player);
+  async toDash(url_transformer?: URLTransformer, format_filter?: FormatFilter): Promise<string> {
+    return await FormatUtils.toDash(this.streaming_data, url_transformer, format_filter, this.#cpn, this.#actions.session.player, this.#actions);
   }
 
   /**

--- a/src/parser/ytmusic/TrackInfo.ts
+++ b/src/parser/ytmusic/TrackInfo.ts
@@ -95,8 +95,8 @@ class TrackInfo {
  * @param format_filter - Function to filter the formats.
  * @returns DASH manifest
  */
-  toDash(url_transformer?: URLTransformer, format_filter?: FormatFilter): string {
-    return FormatUtils.toDash(this.streaming_data, url_transformer, format_filter, this.#cpn, this.#actions.session.player);
+  async toDash(url_transformer?: URLTransformer, format_filter?: FormatFilter): Promise<string> {
+    return await FormatUtils.toDash(this.streaming_data, url_transformer, format_filter, this.#cpn, this.#actions.session.player, this.#actions);
   }
 
   /**


### PR DESCRIPTION
## Description

Some videos have formats that are a bit different than other ones, YouTube seems to refer to these as OTF. According to NewPipeExtractor (https://github.com/TeamNewPipe/NewPipeExtractor/blob/dev/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/DeliveryType.java#L23-L38) these can occur on videos with low view counts and live stream replays that have just been reencoded to normal videos. Instead of allowing you to request arbitrary chunks with the `range` query parameter, instead you use the `sq` query parameter to request sequences, the first sequence (`&sq=0`) contains the duration of the sequences, so we need to request it while building the DASH manifest.

This implementation was inspired by the NewPipeExtractor implementation, so big thanks to them :).

Here is a video with OTF streams: https://www.youtube.com/watch?v=DJ8GQUNUXGM
The 720p and 360p streams are normal, the other ones (144p, 240p and 480p) are OTF streams

## ⚠️ Breaking change ⚠️
The `toDash` functions are now asynchronous, they return a `Promise<string>` instead of a `string`, as we need to fetch the first sequence while building the manifest.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings