### PR TITLE
refactor(shim): Move node CustomEvent polyfill to Platform.shim

### DIFF
--- a/src/platform/deno.ts
+++ b/src/platform/deno.ts
@@ -105,7 +105,8 @@ Platform.load({
   Headers: globalThis.Headers,
   FormData: globalThis.FormData,
   File: globalThis.File,
-  ReadableStream: globalThis.ReadableStream
+  ReadableStream: globalThis.ReadableStream,
+  CustomEvent: globalThis.CustomEvent
 });
 
 export * from './lib.js';

--- a/src/platform/node.ts
+++ b/src/platform/node.ts
@@ -17,6 +17,7 @@ import os from 'os';
 import fs from 'fs/promises';
 import { readFileSync } from 'fs';
 import DOMParser from './polyfills/server-dom.js';
+import CustomEvent from './polyfills/node-custom-event.js';
 import { fileURLToPath } from 'url';
 import evaluate from './jsruntime/jinter.js';
 
@@ -123,7 +124,8 @@ Platform.load({
   Headers: Headers as unknown as typeof globalThis.Headers,
   FormData: FormData as unknown as typeof globalThis.FormData,
   File: File as unknown as typeof globalThis.File,
-  ReadableStream: ReadableStream as unknown as typeof globalThis.ReadableStream
+  ReadableStream: ReadableStream as unknown as typeof globalThis.ReadableStream,
+  CustomEvent: CustomEvent as unknown as typeof globalThis.CustomEvent
 });
 
 export * from './lib.js';

--- a/src/platform/polyfills/node-custom-event.ts
+++ b/src/platform/polyfills/node-custom-event.ts
@@ -1,0 +1,13 @@
+// See https://github.com/nodejs/node/issues/40678#issuecomment-1126944677
+export default class CustomEvent extends Event {
+  #detail;
+
+  constructor(type: string, options?: CustomEventInit<any[]>) {
+    super(type, options);
+    this.#detail = options?.detail ?? null;
+  }
+
+  get detail() {
+    return this.#detail;
+  }
+}

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -115,7 +115,8 @@ Platform.load({
   Headers: globalThis.Headers,
   FormData: globalThis.FormData,
   File: globalThis.File,
-  ReadableStream: globalThis.ReadableStream
+  ReadableStream: globalThis.ReadableStream,
+  CustomEvent: globalThis.CustomEvent
 });
 
 export * from './lib.js';

--- a/src/types/PlatformShim.ts
+++ b/src/types/PlatformShim.ts
@@ -27,6 +27,7 @@ interface PlatformShim {
     FormData: typeof FormData;
     File: typeof File;
     ReadableStream: typeof ReadableStream;
+    CustomEvent: typeof CustomEvent;
 }
 
 export default PlatformShim;


### PR DESCRIPTION
## Description

As CustomEvent is available in Chrome, Firefox and Deno for all versions the YouTube.js supports, we don't need the CustomEvent polyfill in the web or Deno builds. CustomEvent was only added to Node.js in version 19 and as YouTube.js supports Node 10 and up, we definitely need the CustomEvent polyfill for the node build.

https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent#browser_compatibility

I decided to move it to the Platform.shim, so that it's together with all other polyfills and also only gets included for the Node.js build. This also has the advantage that it no longer affects the global scope.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings