### PR TITLE
fix(Utils): Properly parse timestamps with thousands separators

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -116,7 +116,7 @@ export function generateRandomString(length: number): string {
  * @returns seconds
  */
 export function timeToSeconds(time: string): number {
-  const params = time.split(':').map((param) => parseInt(param));
+  const params = time.split(':').map((param) => parseInt(param.replace(/\D/g, '')));
   switch (params.length) {
     case 1:
       return params[0];


### PR DESCRIPTION
## Description

Channels like Lofi Girl have 24/7 live streams, so when they end, the timestamps are massive https://www.youtube.com/@LofiGirl/streams, so long that they have a thousands separator for the hours. Currently the timestamp parsing can't handle the thousands separator. For this timestamp `20,843:43:51`, instead of seeing it as having `20843` hours it instead only takes the digits before the separator, so `20` hours, the result being that the seconds duration on Video objects is a lot smaller than it should be.

This pull request removes any non digit characters before parsing the strings into numbers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings