### PR TITLE
fix(toDash): Generate unique Representation ids

### DIFF
--- a/src/utils/FormatUtils.ts
+++ b/src/utils/FormatUtils.ts
@@ -428,8 +428,15 @@ class FormatUtils {
     const url = new URL(format.decipher(player));
     url.searchParams.set('cpn', cpn || '');
 
+    let id;
+    if (format.audio_track) {
+      id = `${format.itag?.toString()}-${format.audio_track.id}`;
+    } else {
+      id = format.itag?.toString();
+    }
+
     const representation = this.#el(document, 'Representation', {
-      id: format.itag?.toString(),
+      id,
       codecs,
       bandwidth: format.bitrate?.toString(),
       audioSamplingRate: format.audio_sample_rate?.toString()


### PR DESCRIPTION
## Description

It looks like video.js changed something on their end since I added support for multiple audio tracks to the DASH manifest, now it seems to require unique ids for all representations, otherwise it just silently fails to switch audio tracks :(.

This was tested in FreeTube with video.js, hopefully this doesn't break shaka (I couldn't find anything in the spec that mandated that the ids consist of only digits, so I'm not expecting anything to break).

Here is a video that can be used as a test, it contains 3 English audio tracks, the main one, one with the interviewee dubbed and a third one with audio descriptions: https://youtu.be/Kn56bMZ9OE8

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings