### PR TITLE
fix(parser): Fix Video.is_live on channel pages

### DIFF
--- a/src/parser/classes/Video.ts
+++ b/src/parser/classes/Video.ts
@@ -6,6 +6,7 @@ import Thumbnail from './misc/Thumbnail.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import MetadataBadge from './MetadataBadge.js';
 import ExpandableMetadata from './ExpandableMetadata.js';
+import ThumbnailOverlayTimeStatus from './ThumbnailOverlayTimeStatus.js';
 
 import { timeToSeconds } from '../../utils/Utils.js';
 import { YTNode } from '../helpers.js';
@@ -98,7 +99,7 @@ class Video extends YTNode {
     return this.badges.some((badge) => {
       if (badge.style === 'BADGE_STYLE_TYPE_LIVE_NOW' || badge.label === 'LIVE')
         return true;
-    });
+    }) || this.thumbnail_overlays.firstOfType(ThumbnailOverlayTimeStatus)?.style === 'LIVE';
   }
 
   get is_upcoming(): boolean | undefined {


### PR DESCRIPTION
## Description

Videos on channel pages show their live status in the thumbnail overlay instead of in a badge, this pull request adds support for that while allow it to still work correctly with search results.

https://www.youtube.com/@LofiGirl/streams

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings