### PR TITLE
fix(http): android tv http client missing `clientName`

### DIFF
--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -169,6 +169,7 @@ export default class HTTPClient {
         ctx.client.androidSdkVersion = Constants.CLIENTS.ANDROID.SDK_VERSION;
         break;
       case 'TV_EMBEDDED':
+        ctx.client.clientName = Constants.CLIENTS.TV_EMBEDDED.NAME;
         ctx.client.clientVersion = Constants.CLIENTS.TV_EMBEDDED.VERSION;
         ctx.client.clientScreen = 'EMBED';
         ctx.thirdParty = { embedUrl: Constants.URLS.YT_BASE };


### PR DESCRIPTION
# fix(http) android tv http client missing `clientName`

## Description

Fixes https://github.com/LuanRT/YouTube.js/issues/369#issuecomment-1480327454

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings