### PR TITLE
fix(Search): Return search results even if there are ads

### DIFF
--- a/src/parser/youtube/Search.ts
+++ b/src/parser/youtube/Search.ts
@@ -30,7 +30,7 @@ class Search extends Feed<ISearchResponse> {
     if (!contents)
       throw new InnertubeError('No contents found in search response');
 
-    this.results = contents.firstOfType(ItemSection)?.contents;
+    this.results = contents.filterType(ItemSection).find((section) => section.contents && section.contents.length > 0)?.contents;
 
     this.refinements = this.page.refinements || [];
     this.estimated_results = this.page.estimated_results;


### PR DESCRIPTION
## Description

Currently YouTube.js always counts the first item section in the search response as the results, sometimes however the first item section contains ads, which means that YouTube.js doesn't return any search results. This pull request tries to find the first item section that has items.

Searching for "Marques Brownlee" with the type filter set to all, videos or channels, should make this bug show up (usually it appears for at least one of the three cases).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings