### PR TITLE
feat(PlaylistVideo): Extract video_info and accessibility_label texts

### DIFF
--- a/src/parser/classes/PlaylistVideo.ts
+++ b/src/parser/classes/PlaylistVideo.ts
@@ -22,6 +22,8 @@ class PlaylistVideo extends YTNode {
   is_playable: boolean;
   menu: Menu | null;
   upcoming;
+  video_info: Text;
+  accessibility_label?: string;
 
   duration: {
     text: string;
@@ -40,6 +42,8 @@ class PlaylistVideo extends YTNode {
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
     this.is_playable = data.isPlayable;
     this.menu = Parser.parseItem(data.menu, Menu);
+    this.video_info = new Text(data.videoInfo);
+    this.accessibility_label = data.title.accessibility.accessibilityData.label;
 
     const upcoming = data.upcomingEventData && Number(`${data.upcomingEventData.startTime}000`);
     if (upcoming) {


### PR DESCRIPTION
## Description

Unfortunately playlist videos don't have fields for the uploaded date or number of views. Instead they are in the video info property. The video info property contains text runs that can consist of the short view count and uploaded date, the number of people watching the live stream or be empty.

This pull request also extracts the accessibility label string, which among other things contains the exact number of video views (thanks @AudricV for pointing that out). One important thing to note, is that said string is language dependant, so any library user wanting to parse it will have to keep that in mind, also 0 views are shown as `no views`.

Here are a couple of playlists to see the different values of those properties:
Normal videos: https://www.youtube.com/playlist?list=PL8mG-RkN2uTypNLvzSMJZjjztzVatqgQ6
Some upcoming videos: https://www.youtube.com/playlist?list=PLAWO6dmnJ7Oxne23Iv14NbOcXeRv2eLYz
Live videos: https://www.youtube.com/playlist?list=PL6NdkXsPL07IFb3kA-m9QNY8oUMctNM3i

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings