### PR TITLE
refactor: fix inconsistencies in the guide endpoint nodes

### DIFF
--- a/src/parser/classes/GuideCollapsibleEntry.ts
+++ b/src/parser/classes/GuideCollapsibleEntry.ts
@@ -1,35 +1,19 @@
-import Text from './misc/Text.js';
-import { YTNode } from '../helpers.js';
 import Parser from '../parser.js';
+import GuideEntry from './GuideEntry.js';
+import type { RawNode } from '../index.js';
+import { YTNode } from '../helpers.js';
 
-class GuideCollapsibleEntry extends YTNode {
+export default class GuideCollapsibleEntry extends YTNode {
   static type = 'GuideCollapsibleEntry';
 
-  expander_item: {
-    title: string,
-    icon_type: string
-  };
-  collapser_item: {
-    title: string,
-    icon_type: string
-  };
+  expander_item: GuideEntry | null;
+  collapser_item: GuideEntry | null;
   expandable_items;
 
-  constructor(data: any) {
+  constructor(data: RawNode) {
     super();
-
-    this.expander_item = {
-      title: new Text(data.expanderItem.guideEntryRenderer.formattedTitle).toString(),
-      icon_type: data.expanderItem.guideEntryRenderer.icon.iconType
-    };
-
-    this.collapser_item = {
-      title: new Text(data.collapserItem.guideEntryRenderer.formattedTitle).toString(),
-      icon_type: data.collapserItem.guideEntryRenderer.icon.iconType
-    };
-
+    this.expander_item = Parser.parseItem(data.expanderItem, GuideEntry);
+    this.collapser_item = Parser.parseItem(data.collapserItem, GuideEntry);
     this.expandable_items = Parser.parseArray(data.expandableItems);
   }
 }
-
-export default GuideCollapsibleEntry;

--- a/src/parser/classes/GuideCollapsibleSectionEntry.ts
+++ b/src/parser/classes/GuideCollapsibleSectionEntry.ts
@@ -1,7 +1,8 @@
-import { YTNode } from '../helpers.js';
 import Parser from '../parser.js';
+import type { RawNode } from '../index.js';
+import { YTNode } from '../helpers.js';
 
-class GuideCollapsibleSectionEntry extends YTNode {
+export default class GuideCollapsibleSectionEntry extends YTNode {
   static type = 'GuideCollapsibleSectionEntry';
 
   header_entry;
@@ -9,15 +10,11 @@ class GuideCollapsibleSectionEntry extends YTNode {
   collapser_icon: string;
   section_items;
 
-  constructor(data: any) {
+  constructor(data: RawNode) {
     super();
-
     this.header_entry = Parser.parseItem(data.headerEntry);
     this.expander_icon = data.expanderIcon.iconType;
     this.collapser_icon = data.collapserIcon.iconType;
     this.section_items = Parser.parseArray(data.sectionItems);
-
   }
 }
-
-export default GuideCollapsibleSectionEntry;

--- a/src/parser/classes/GuideDownloadsEntry.ts
+++ b/src/parser/classes/GuideDownloadsEntry.ts
@@ -1,14 +1,13 @@
 import GuideEntry from './GuideEntry.js';
+import type { RawNode } from '../index.js';
 
-class GuideDownloadsEntry extends GuideEntry {
+export default class GuideDownloadsEntry extends GuideEntry {
   static type = 'GuideDownloadsEntry';
 
   always_show: boolean;
 
-  constructor(data: any) {
+  constructor(data: RawNode) {
     super(data.entryRenderer.guideEntryRenderer);
     this.always_show = !!data.alwaysShow;
   }
 }
-
-export default GuideDownloadsEntry;

--- a/src/parser/classes/GuideEntry.ts
+++ b/src/parser/classes/GuideEntry.ts
@@ -1,9 +1,11 @@
-import Text from './misc/Text.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
-import { YTNode } from '../helpers.js';
+import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';
 
-class GuideEntry extends YTNode {
+import { YTNode } from '../helpers.js';
+import type { RawNode } from '../index.js';
+
+export default class GuideEntry extends YTNode {
   static type = 'GuideEntry';
 
   title: Text;
@@ -13,21 +15,24 @@ class GuideEntry extends YTNode {
   badges?: any;
   is_primary: boolean;
 
-  constructor(data: any) {
+  constructor(data: RawNode) {
     super();
     this.title = new Text(data.formattedTitle);
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint || data.serviceEndpoint);
-    if (data.icon?.iconType) {
+
+    if (Reflect.has(data, 'icon') && Reflect.has(data.icon, 'iconType')) {
       this.icon_type = data.icon.iconType;
     }
-    if (data.thumbnail) {
+
+    if (Reflect.has(data, 'thumbnail')) {
       this.thumbnails = Thumbnail.fromResponse(data.thumbnail);
     }
-    if (data.badges) {
+
+    // (LuanRT) XXX: Check this property's data and parse it.
+    if (Reflect.has(data, 'badges')) {
       this.badges = data.badges;
     }
+
     this.is_primary = !!data.isPrimary;
   }
 }
-
-export default GuideEntry;

--- a/src/parser/classes/GuideSection.ts
+++ b/src/parser/classes/GuideSection.ts
@@ -1,20 +1,20 @@
 import Text from './misc/Text.js';
-import { YTNode } from '../helpers.js';
 import Parser from '../parser.js';
+import { YTNode } from '../helpers.js';
+import type { RawNode } from '../index.js';
 
-class GuideSection extends YTNode {
+export default class GuideSection extends YTNode {
   static type = 'GuideSection';
 
   title?: Text;
   items;
 
-  constructor(data: any) {
+  constructor(data: RawNode) {
     super();
-    if (data.formattedTitle) {
+    if (Reflect.has(data, 'formattedTitle')) {
       this.title = new Text(data.formattedTitle);
     }
+
     this.items = Parser.parseArray(data.items);
   }
 }
-
-export default GuideSection;

--- a/src/parser/classes/GuideSubscriptionsSection.ts
+++ b/src/parser/classes/GuideSubscriptionsSection.ts
@@ -1,7 +1,5 @@
 import GuideSection from './GuideSection.js';
 
-class GuideSubscriptionsSection extends GuideSection {
+export default class GuideSubscriptionsSection extends GuideSection {
   static type = 'GuideSubscriptionsSection';
 }
-
-export default GuideSubscriptionsSection;


### PR DESCRIPTION
This fixes a few inconsistencies in the `/guide` endpoint nodes (such as parsing props manually instead of leaving that for the parser).