### PR TITLE
feat(MusicResponsiveListItem): make flex/fixed cols public

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,4 +1,5 @@
 import { Memo } from '../parser/helpers.js';
+import { EmojiRun, TextRun } from '../parser/misc.js';
 import PlatformShim, { FetchFunction } from '../types/PlatformShim.js';
 import userAgents from './user-agents.js';
 
@@ -221,4 +222,8 @@ export function u8ToBase64(u8: Uint8Array): string {
 
 export function base64ToU8(base64: string): Uint8Array {
   return new Uint8Array(atob(base64).split('').map((char) => char.charCodeAt(0)));
+}
+
+export function isTextRun(run: TextRun | EmojiRun): run is TextRun {
+  return !('emoji' in run);
 }


### PR DESCRIPTION
This PR makes the flex/fixed column props in the `MusicResponsiveListItem` node public, thus allowing users to parse the data as they wish. 

### Example
```ts
import { Innertube, UniversalCache } from 'youtubei.js';

(async () => {
  const yt = await Innertube.create({ cache: new UniversalCache(false), generate_session_locally: true });

  const search = await yt.music.search('Mac Miller - Right', { type: 'song' });
  console.log('Flex columns:', search.contents.first().contents.first().flex_columns);
  console.log('Fixed columns:', search.contents.first().contents.first().fixed_columns);
})();
```

Closes #381