### PR TITLE
fix(android): workaround streaming URLs returning 403

### DIFF
--- a/src/core/endpoints/PlayerEndpoint.ts
+++ b/src/core/endpoints/PlayerEndpoint.ts
@@ -8,6 +8,11 @@ export const PATH = '/player';
  * @returns The payload.
  */
 export function build(opts: PlayerEndpointOptions): IPlayerRequest {
+  const is_android =
+    opts.client === 'ANDROID' ||
+    opts.client === 'YTMUSIC_ANDROID' ||
+    opts.client === 'YTSTUDIO_ANDROID';
+
   return {
     playbackContext: {
       contentPlaybackContext: {
@@ -33,7 +38,9 @@ export function build(opts: PlayerEndpointOptions): IPlayerRequest {
     videoId: opts.video_id,
     ...{
       client: opts.client,
-      playlistId: opts.playlist_id
+      playlistId: opts.playlist_id,
+      // Workaround streaming URLs returning 403 when using Android clients.
+      params: is_android ? '8AEB' : opts.params
     }
   };
 }

--- a/src/types/Endpoints.ts
+++ b/src/types/Endpoints.ts
@@ -23,8 +23,9 @@ export interface IPlayerRequest {
   videoId: string;
   racyCheckOk: boolean;
   contentCheckOk: boolean;
-  client?: InnerTubeClient;
   playlistId?: string;
+  params?: string;
+  client?: InnerTubeClient;
 }
 
 export type PlayerEndpointOptions = {
@@ -44,6 +45,10 @@ export type PlayerEndpointOptions = {
    * The playlist ID.
    */
   playlist_id?: string;
+  /**
+   * Additional protobuf parameters.
+   */
+  params?: string;
 }
 
 export type NextEndpointOptions = {


### PR DESCRIPTION
Related: https://github.com/iv-org/invidious/issues/3771, https://github.com/unixfox/invidious-custom/issues/60, https://github.com/microg/GmsCore/issues/1870, https://github.com/TeamNewPipe/NewPipe/issues/9038