### PR TITLE
fix(web): slow downloads due to visitor data

### DIFF
--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -7,8 +7,8 @@ import Proto from '../proto/index.js';
 import type { ICache } from '../types/Cache.js';
 import type { FetchFunction } from '../types/PlatformShim.js';
 import HTTPClient from '../utils/HTTPClient.js';
-import type { DeviceCategory} from '../utils/Utils.js';
-import { getRandomUserAgent, InnertubeError, Platform, SessionError } from '../utils/Utils.js';
+import type { DeviceCategory } from '../utils/Utils.js';
+import { generateRandomString, getRandomUserAgent, InnertubeError, Platform, SessionError } from '../utils/Utils.js';
 import type { Credentials, OAuthAuthErrorEventHandler, OAuthAuthEventHandler, OAuthAuthPendingEventHandler } from './OAuth.js';
 import OAuth from './OAuth.js';
 
@@ -236,7 +236,7 @@ export default class Session extends EventEmitterLike {
   }, fetch: FetchFunction = Platform.shim.fetch): Promise<SessionData> {
     const url = new URL('/sw.js_data', Constants.URLS.YT_BASE);
 
-    let visitor_id = Constants.CLIENTS.WEB.STATIC_VISITOR_ID;
+    let visitor_id = generateRandomString(11);
 
     if (options.visitor_data) {
       const decoded_visitor_data = Proto.decodeVisitorData(options.visitor_data);
@@ -308,7 +308,7 @@ export default class Session extends EventEmitterLike {
     enable_safety_mode: boolean;
     visitor_data: string;
   }): SessionData {
-    let visitor_id = Constants.CLIENTS.WEB.STATIC_VISITOR_ID;
+    let visitor_id = generateRandomString(11);
 
     if (options.visitor_data) {
       const decoded_visitor_data = Proto.decodeVisitorData(options.visitor_data);

--- a/src/core/endpoints/PlayerEndpoint.ts
+++ b/src/core/endpoints/PlayerEndpoint.ts
@@ -8,11 +8,6 @@ export const PATH = '/player';
  * @returns The payload.
  */
 export function build(opts: PlayerEndpointOptions): IPlayerRequest {
-  const is_android =
-    opts.client === 'ANDROID' ||
-    opts.client === 'YTMUSIC_ANDROID' ||
-    opts.client === 'YTSTUDIO_ANDROID';
-
   return {
     playbackContext: {
       contentPlaybackContext: {
@@ -39,8 +34,8 @@ export function build(opts: PlayerEndpointOptions): IPlayerRequest {
     ...{
       client: opts.client,
       playlistId: opts.playlist_id,
-      // Workaround streaming URLs returning 403 when using Android clients.
-      params: is_android ? '8AEB' : opts.params
+      // Workaround streaming URLs returning 403 when using Android clients and throttling in web clients.
+      params: '8AEB'
     }
   };
 }


### PR DESCRIPTION
## What
YouTube now throttles clients (`WEB` only) that use shared visitor data tokens. This PR makes visitor ids (required to build a valid token) random again.

Thank you @itsmenewbie03 for reporting this issue.