### PR TITLE
fix(VideoInfo): Use microformat view_count when videoDetails view_count is NaN

### DIFF
--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -83,7 +83,8 @@ class VideoInfo extends MediaInfo {
         is_family_safe: info.microformat?.is_family_safe,
         category: info.microformat?.is(PlayerMicroformat) ? info.microformat?.category : null,
         has_ypc_metadata: info.microformat?.is(PlayerMicroformat) ? info.microformat?.has_ypc_metadata : null,
-        start_timestamp: info.microformat?.is(PlayerMicroformat) ? info.microformat.start_timestamp : null
+        start_timestamp: info.microformat?.is(PlayerMicroformat) ? info.microformat.start_timestamp : null,
+        view_count: info.microformat?.is(PlayerMicroformat) && isNaN(info.video_details?.view_count as number) ? info.microformat.view_count : info.video_details?.view_count
       },
       like_count: undefined as number | undefined,
       is_liked: undefined as boolean | undefined,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Looks like YouTube removed the view count from the video details, as I'm not sure if it's just on my machine or for everyone, it still tries to use the view count from the video details first before falling back to the microformat one. I wonder if this didn't show up earlier because we were using a hardcoded visitor ID?