### PR TITLE
refactor(constants): Use namespace import internally

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -20,7 +20,7 @@ import { AccountManager, InteractionManager, PlaylistManager } from './core/mana
 import { Feed, TabbedFeed } from './core/mixins/index.js';
 
 import Proto from './proto/index.js';
-import Constants from './utils/Constants.js';
+import * as Constants from './utils/Constants.js';
 import { InnertubeError, generateRandomString, throwIfMissing } from './utils/Utils.js';
 
 import {

--- a/src/core/OAuth.ts
+++ b/src/core/OAuth.ts
@@ -1,4 +1,4 @@
-import Constants from '../utils/Constants.js';
+import * as Constants from '../utils/Constants.js';
 import { OAuthError, Platform } from '../utils/Utils.js';
 import type Session from './Session.js';
 

--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -1,6 +1,6 @@
 import { Platform, getRandomUserAgent, getStringBetweenStrings, PlayerError } from '../utils/Utils.js';
 
-import Constants from '../utils/Constants.js';
+import * as Constants from '../utils/Constants.js';
 
 import type { ICache } from '../types/Cache.js';
 import type { FetchFunction } from '../types/PlatformShim.js';

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -1,4 +1,4 @@
-import Constants, { CLIENTS } from '../utils/Constants.js';
+import * as Constants from '../utils/Constants.js';
 import EventEmitterLike from '../utils/EventEmitterLike.js';
 import Actions from './Actions.js';
 import Player from './Player.js';
@@ -325,7 +325,7 @@ export default class Session extends EventEmitterLike {
         screenWidthPoints: 1920,
         visitorData: Proto.encodeVisitorData(visitor_id, Math.floor(Date.now() / 1000)),
         clientName: options.client_name,
-        clientVersion: CLIENTS.WEB.VERSION,
+        clientVersion: Constants.CLIENTS.WEB.VERSION,
         osName: 'Windows',
         osVersion: '10.0',
         platform: options.device_category.toUpperCase(),
@@ -343,7 +343,7 @@ export default class Session extends EventEmitterLike {
       }
     };
 
-    return { context, api_key: CLIENTS.WEB.API_KEY, api_version: CLIENTS.WEB.API_VERSION };
+    return { context, api_key: Constants.CLIENTS.WEB.API_KEY, api_version: Constants.CLIENTS.WEB.API_VERSION };
   }
 
   async signIn(credentials?: Credentials): Promise<void> {

--- a/src/core/clients/Studio.ts
+++ b/src/core/clients/Studio.ts
@@ -1,5 +1,5 @@
 import Proto from '../../proto/index.js';
-import { Constants } from '../../utils/index.js';
+import * as Constants from '../../utils/Constants.js';
 import { InnertubeError, MissingParamError, Platform } from '../../utils/Utils.js';
 
 import type { UpdateVideoMetadataOptions, UploadedVideoMetadataOptions } from '../../types/Clients.js';

--- a/src/core/mixins/MediaInfo.ts
+++ b/src/core/mixins/MediaInfo.ts
@@ -1,6 +1,6 @@
 import type { ApiResponse } from '../Actions.js';
 import type Actions from '../Actions.js';
-import Constants from '../../utils/Constants.js';
+import * as Constants from '../../utils/Constants.js';
 import type { DownloadOptions, FormatFilter, FormatOptions, URLTransformer } from '../../utils/FormatUtils.js';
 import FormatUtils from '../../utils/FormatUtils.js';
 import { InnertubeError } from '../../utils/Utils.js';

--- a/src/parser/classes/misc/Author.ts
+++ b/src/parser/classes/misc/Author.ts
@@ -1,4 +1,4 @@
-import Constants from '../../../utils/Constants.js';
+import * as Constants from '../../../utils/Constants.js';
 import type { YTNode} from '../../helpers.js';
 import { observe, type ObservedArray } from '../../helpers.js';
 import Parser, { type RawNode } from '../../index.js';

--- a/src/parser/ytmusic/TrackInfo.ts
+++ b/src/parser/ytmusic/TrackInfo.ts
@@ -1,7 +1,7 @@
 import type Actions from '../../core/Actions.js';
 import type { ApiResponse } from '../../core/Actions.js';
 
-import Constants from '../../utils/Constants.js';
+import * as Constants from '../../utils/Constants.js';
 import { InnertubeError } from '../../utils/Utils.js';
 
 import AutomixPreviewVideo from '../classes/AutomixPreviewVideo.js';

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -78,11 +78,3 @@ export const INNERTUBE_HEADERS_BASE = Object.freeze({
   'accept-encoding': 'gzip, deflate',
   'content-type': 'application/json'
 });
-
-export default {
-  URLS,
-  OAUTH,
-  CLIENTS,
-  STREAM_HEADERS,
-  INNERTUBE_HEADERS_BASE
-};

--- a/src/utils/FormatUtils.ts
+++ b/src/utils/FormatUtils.ts
@@ -5,7 +5,7 @@ import type Format from '../parser/classes/misc/Format.js';
 import type AudioOnlyPlayability from '../parser/classes/AudioOnlyPlayability.js';
 import type { YTNode } from '../parser/helpers.js';
 
-import { Constants } from './index.js';
+import * as Constants from './Constants.js';
 import { getStringBetweenStrings, InnertubeError, Platform, streamToIterable } from './Utils.js';
 
 export type URLTransformer = (url: URL) => URL;

--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -1,7 +1,7 @@
 import type { Context } from '../core/Session.js';
 import type Session from '../core/Session.js';
 import type { FetchFunction } from '../types/PlatformShim.js';
-import Constants from './Constants.js';
+import * as Constants from './Constants.js';
 import {
   Platform,
   generateSidAuth,


### PR DESCRIPTION
As we already use a namespace export to export the constants outside the library, we can use namespace imports to import them internally too, which improves the bundle sizes a bit, without a breaking change.

| Bundle | Before | After |
| --- | --- | --- |
| `node.cjs` | `678.3kb` | `677.2kb` |
| `browser.js` | `893.3kb` | `892.2kb` |
| `browser.min.js` | `479.6kb` | `479.2kb` |