### PR TITLE
fix(bundles): Use ESM tslib build for the browser bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "build:esm": "npx tsc",
     "build:deno": "npx cpy ./src ./deno && npx cpy ./package.json ./deno && npx replace \".js';\" \".ts';\" ./deno -r && npx replace '.js\";' '.ts\";' ./deno -r && npx replace \"'linkedom';\" \"'https://esm.sh/linkedom';\" ./deno -r && npx replace \"'jintr';\" \"'https://esm.sh/jintr';\" ./deno -r && npx replace \"new Jinter.default\" \"new Jinter\" ./deno -r",
     "bundle:node": "npx esbuild ./dist/src/platform/node.js --bundle --target=node10 --keep-names --format=cjs --platform=node --outfile=./bundle/node.cjs --external:jintr --external:undici --external:linkedom --external:tslib --sourcemap --banner:js=\"/* eslint-disable */\"",
-    "bundle:browser": "npx esbuild ./dist/src/platform/web.js --banner:js=\"/* eslint-disable */\" --bundle --target=chrome58 --keep-names --format=esm --sourcemap --define:global=globalThis --outfile=./bundle/browser.js --platform=browser",
+    "bundle:browser": "npx esbuild ./dist/src/platform/web.js --banner:js=\"/* eslint-disable */\" --bundle --target=chrome58 --keep-names --format=esm --sourcemap --define:global=globalThis --conditions=module --outfile=./bundle/browser.js --platform=browser",
     "bundle:browser:prod": "npm run bundle:browser -- --outfile=./bundle/browser.min.js --minify",
     "prepare": "npm run build",
     "watch": "npx tsc --watch"


### PR DESCRIPTION
tslib is weird. The esbuild version that YouTube.js uses, isn't able to automatically pick the correct tslib build to bundle into the browser bundles, so it uses the commonjs one, which isn't treeshakable. This makes it pick the correct one, reducing the size of the bundles:

| Bundle | Before | After |
| --- | --- | --- |
| `browser.js` | `893.3kb` | `875.8kb` |
| `browser.min.js` | `479.6kb` | `471.7kb` |

More recent versions of esbuild added support for tslib's weirdness, however they now aggressively preserve comments while bundling (previously they only preserved webpack's magic comments), so that tools like vite can add magic comments without esbuild stripping them. Unfortunately that means that it blows up the sizes of the `node.cjs` and `browser.js` bundles, because newer esbuild versions keep **all** of the jsdoc comments 😔. The `browser.min.js` bundle isn't affected by that, as part of the mimification process is striping comments.
Doesn't look like there is a sensible way to disable that behaviour.