### PR TITLE
feat(ReelItem): Add accessibility label

### DIFF
--- a/src/parser/classes/ReelItem.ts
+++ b/src/parser/classes/ReelItem.ts
@@ -12,6 +12,7 @@ export default class ReelItem extends YTNode {
   thumbnails: Thumbnail[];
   views: Text;
   endpoint: NavigationEndpoint;
+  accessibility_label?: string;
 
   constructor(data: RawNode) {
     super();
@@ -20,5 +21,6 @@ export default class ReelItem extends YTNode {
     this.thumbnails = Thumbnail.fromResponse(data.thumbnail);
     this.views = new Text(data.viewCountText);
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
+    this.accessibility_label = data.accessibility.accessibilityData.label;
   }
 }


### PR DESCRIPTION
ReelItems unfortunately only have their duration in one place, the accessibility label in textual form. As parsing that information out is language dependent, it should be left up to library users to do.

An example for how to parse that can be found here: https://github.com/FreeTubeApp/FreeTube/blob/bd6fb416a8b6ba388321dcc20c3d7d89c744f0f1/src/renderer/helpers/api/local.js#L300

Some examples for the accessibility label in English taken from the shorts tab on the LTT channel:
- `These mice keep getting WEIRDER... - 59 seconds - play video`
- `How Low Can Our Resolution Go? - 1 minute - play video`
- `I just found out about Elon. #SHORTS - 1 minute, 1 second - play video` (I suspect this is a rounding error on YouTube's side, as the docs say shorts can only be up to 60 seconds long, https://support.google.com/youtube/answer/10059070?hl=en)