### PR TITLE
feat(toDash): Add audio track labels to the manifest when available

### DIFF
--- a/src/utils/FormatUtils.ts
+++ b/src/utils/FormatUtils.ts
@@ -363,7 +363,12 @@ class FormatUtils {
             this.#el(document, 'Role', {
               schemeIdUri: 'urn:mpeg:dash:role:2011',
               value: role
-            })
+            }),
+            this.#el(document, 'Label', {
+              id: set_id.toString()
+            }, [
+              document.createTextNode(first_format.audio_track?.display_name as string)
+            ])
           );
 
           const set = this.#el(document, 'AdaptationSet', {
@@ -371,7 +376,9 @@ class FormatUtils {
             mimeType: mime_types[i].split(';')[0],
             startWithSAP: '1',
             subsegmentAlignment: 'true',
-            lang: first_format.language as string
+            lang: first_format.language as string,
+            // Non-standard attribute used by shaka instead of the standard Label element
+            label: first_format.audio_track?.display_name as string
           }, children);
 
           period.appendChild(set);


### PR DESCRIPTION
This pull request adds the audio track labels provided by YouTube to the DASH manifest. It supports both the standard Label element as well as the non-standard label attribute that shaka uses (https://github.com/shaka-project/shaka-player/issues/5019).