### PR TITLE
Add support for YouTube Music mood filters

### DIFF
--- a/src/parser/ytmusic/HomeFeed.ts
+++ b/src/parser/ytmusic/HomeFeed.ts
@@ -39,8 +39,7 @@ class HomeFeed {
       return;
     }
 
-    const section_list = tab.content?.as(SectionList);
-    this.header = section_list?.header?.as(ChipCloud);
+    this.header = tab.content?.as(SectionList).header?.as(ChipCloud);
     this.#continuation = tab.content?.as(SectionList).continuation;
     this.sections = tab.content?.as(SectionList).contents.as(MusicCarouselShelf, MusicTastebuilderShelf);
   }

--- a/src/parser/ytmusic/HomeFeed.ts
+++ b/src/parser/ytmusic/HomeFeed.ts
@@ -61,7 +61,7 @@ class HomeFeed {
   }
 
   get filters(): string[] {
-    return this.header?.chips?.as(ChipCloudChip).map((chip: ChipCloudChip) => chip.text) || [];
+    return this.header?.chips?.as(ChipCloudChip).map((chip) => chip.text) || [];
   }
 
   get has_continuation(): boolean {

--- a/src/parser/ytmusic/HomeFeed.ts
+++ b/src/parser/ytmusic/HomeFeed.ts
@@ -60,6 +60,29 @@ class HomeFeed {
     return new HomeFeed(response, this.#actions);
   }
 
+  async applyFilter(target_filter: string | ChipCloudChip): Promise<HomeFeed> {
+    let cloud_chip: ChipCloudChip | undefined;
+
+    if (typeof target_filter === 'string') {
+      cloud_chip = this.header?.chips?.as(ChipCloudChip).get({ text: target_filter });
+      if (!cloud_chip)
+        throw new InnertubeError('Could not find filter with given name.', { available_filters: this.filters });
+    } else if (target_filter?.is(ChipCloudChip)) {
+      cloud_chip = target_filter;
+    }
+
+    if (!cloud_chip)
+      throw new InnertubeError('Invalid filter', { available_filters: this.filters });
+
+    if (cloud_chip?.is_selected) return this;
+
+    if (!cloud_chip.endpoint)
+      throw new InnertubeError('Selected filter does not have an endpoint.');
+
+    const response = await cloud_chip.endpoint.call(this.#actions, { client: 'YTMUSIC' });
+    return new HomeFeed(response, this.#actions);
+  }
+
   get filters(): string[] {
     return this.header?.chips?.as(ChipCloudChip).map((chip) => chip.text) || [];
   }

--- a/src/parser/ytmusic/HomeFeed.ts
+++ b/src/parser/ytmusic/HomeFeed.ts
@@ -9,6 +9,8 @@ import type { ApiResponse } from '../../core/Actions.js';
 import type { ObservedArray } from '../helpers.js';
 import type { IBrowseResponse } from '../types/ParsedResponse.js';
 import { InnertubeError } from '../../utils/Utils.js';
+import ChipCloud from '../classes/ChipCloud.js';
+import ChipCloudChip from '../classes/ChipCloudChip.js';
 
 class HomeFeed {
   #page: IBrowseResponse;
@@ -16,6 +18,7 @@ class HomeFeed {
   #continuation?: string;
 
   sections?: ObservedArray<MusicCarouselShelf | MusicTastebuilderShelf>;
+  header?: ChipCloud;
 
   constructor(response: ApiResponse, actions: Actions) {
     this.#actions = actions;
@@ -36,6 +39,8 @@ class HomeFeed {
       return;
     }
 
+    const section_list = tab.content?.as(SectionList);
+    this.header = section_list?.header?.as(ChipCloud);
     this.#continuation = tab.content?.as(SectionList).continuation;
     this.sections = tab.content?.as(SectionList).contents.as(MusicCarouselShelf, MusicTastebuilderShelf);
   }
@@ -53,6 +58,10 @@ class HomeFeed {
     });
 
     return new HomeFeed(response, this.#actions);
+  }
+
+  get filters(): string[] {
+    return this.header?.chips?.as(ChipCloudChip).map((chip: ChipCloudChip) => chip.text) || [];
   }
 
   get has_continuation(): boolean {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -296,6 +296,13 @@ describe('YouTube.js Tests', () => {
         expect(incremental_continuation.sections).toBeDefined();
         expect(incremental_continuation.sections?.length).toBeGreaterThan(0);
       });
+      
+      test('HomeFeed#applyFilter', async () => {
+        home = await home.applyFilter(home.filters[1]);
+        expect(home).toBeDefined();
+        expect(home.sections).toBeDefined();
+        expect(home.sections?.length).toBeGreaterThan(0);
+      });
     });
 
     test('Innertube#music.getExplore', async () => {


### PR DESCRIPTION
## Proposed changes
- Add `filters` and `applyFilter` methods to `ytmusic.HomeFeed`, which allows results to be filtered by mood.

## Testing

```js
import { Innertube } from "youtubei.js";

const yt = await Innertube.create();

const home = await yt.music.getHomeFeed();

console.log(home.filters); // [ 'Workout', 'Relax', 'Energize', 'Commute', 'Focus' ]

console.log(await home.applyFilter('Relax')) // instance of `HomeFeed`

```

## Notes

`HomeFeed.applyFilter` is almost exactly the same as `Search.applyFilter`. I'd like to avoid this code duplication by using an inherited base class in the `ytmusic` classes. I think this would also provide some structure to the classes in this directory, as they implement the same kinds of methods e.g. `has_continuation`, `getContinuation`, `applyFilter`, `filters`... However I didn't want to make an invasive change without discussion.