### PR TITLE
chore(parser): Remove extra Array.from call

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -509,7 +509,7 @@ export default class Parser {
     return this.ignore_list.has(classname);
   }
 
-  static #rt_nodes = new Map<string, YTNodeConstructor>(Array.from(Object.entries(YTNodes)));
+  static #rt_nodes = new Map<string, YTNodeConstructor>(Object.entries(YTNodes));
   static #dynamic_nodes = new Map<string, YTNodeConstructor>();
 
   static getParserByName(classname: string) {


### PR DESCRIPTION
As `Object#entries` already returns an array, we don't need to wrap it in a call to `Array#from`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries