### PR TITLE
perf(Search): Speed up result parsing

### DIFF
--- a/src/parser/youtube/Search.ts
+++ b/src/parser/youtube/Search.ts
@@ -30,7 +30,7 @@ class Search extends Feed<ISearchResponse> {
     if (!contents)
       throw new InnertubeError('No contents found in search response');
 
-    this.results = contents.filterType(ItemSection).find((section) => section.contents && section.contents.length > 0)?.contents;
+    this.results = contents.find((content) => content.is(ItemSection) && content.contents && content.contents.length > 0)?.as(ItemSection).contents;
 
     this.refinements = this.page.refinements || [];
     this.estimated_results = this.page.estimated_results;


### PR DESCRIPTION
As we only need the first match, we can do the type check inside the `find` callback. Doing it like this skips iterating over the entire array with `filterType` and then again partially with `find`, as well as the creation of the array that `filterType` (wraps `Array.filter`) returns. Now it only has to iterate over the once and only until it finds a match.