### PR TITLE
feat(VideoDetails): Add is_post_live_dvr property

### DIFF
--- a/src/parser/classes/misc/VideoDetails.ts
+++ b/src/parser/classes/misc/VideoDetails.ts
@@ -18,6 +18,7 @@ export default class VideoDetails {
   is_live_content: boolean;
   is_upcoming: boolean;
   is_crawlable: boolean;
+  is_post_live_dvr: boolean;
 
   constructor(data: RawNode) {
     this.id = data.videoId;
@@ -35,6 +36,7 @@ export default class VideoDetails {
     this.is_live = !!data.isLive;
     this.is_live_content = !!data.isLiveContent;
     this.is_upcoming = !!data.isUpcoming;
+    this.is_post_live_dvr = !!data.isPostLiveDvr;
     this.is_crawlable = !!data.isCrawlable;
   }
 }


### PR DESCRIPTION
Just after a live stream has finished, before YouTube has processed it into a normal video, it's a post-live DVR. The reason this property is useful is that those videos have to be treated differently than an normal one, as they just have the live stream segments. So yes they need a special manifest too but after spending ages trying to get it working with video.js, I found out that video.js doesn't support self-initializing DASH segments (segments where the initialization data is in the segment, instead of in a chunk right at the start), so we'll just be using YouTube's HLS manifest for them in FreeTube.