### PR TITLE
fix(PlayerEndpoint): Use different player params

### DIFF
--- a/src/core/endpoints/PlayerEndpoint.ts
+++ b/src/core/endpoints/PlayerEndpoint.ts
@@ -38,7 +38,7 @@ export function build(opts: PlayerEndpointOptions): IPlayerRequest {
       client: opts.client,
       playlistId: opts.playlist_id,
       // Workaround streaming URLs returning 403 when using Android clients and throttling in web clients.
-      params: '8AEB'
+      params: 'CgIQBg=='
     }
   };
 }

--- a/src/core/endpoints/PlayerEndpoint.ts
+++ b/src/core/endpoints/PlayerEndpoint.ts
@@ -38,7 +38,7 @@ export function build(opts: PlayerEndpointOptions): IPlayerRequest {
       client: opts.client,
       playlistId: opts.playlist_id,
       // Workaround streaming URLs returning 403 when using Android clients and throttling in web clients.
-      params: 'CgIQBg=='
+      params: '2AMBCgIQBg'
     }
   };
 }


### PR DESCRIPTION
YouTube is removing stories, so the current player params will full stop working very soon.
This pull request switches to the ones that yt-dlp is using: https://github.com/yt-dlp/yt-dlp/commit/81ca451480051d7ce1a31c017e005358345a9149