### PR TITLE
fix(OAuth): client identity matching

### DIFF
--- a/src/core/OAuth.ts
+++ b/src/core/OAuth.ts
@@ -96,7 +96,7 @@ export default class OAuth {
       client_id: this.#identity.client_id,
       scope: Constants.OAUTH.SCOPE,
       device_id: Platform.shim.uuidv4(),
-      model_name: Constants.OAUTH.MODEL_NAME
+      device_model: Constants.OAUTH.MODEL_NAME
     };
 
     const response = await this.#session.http.fetch_function(new URL('/o/oauth2/device/code', Constants.URLS.YT_BASE), {

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -29,7 +29,7 @@ export const OAUTH = Object.freeze({
   }),
   REGEX: Object.freeze({
     AUTH_SCRIPT: /<script id="base-js" src="(.*?)" nonce=".*?"><\/script>/,
-    CLIENT_IDENTITY: /.+?={};var .+?={clientId:"(?<client_id>.+?)",.+?:"(?<client_secret>.+?)"},/
+    CLIENT_IDENTITY: /var .+?={clientId:"(?<client_id>.+?)",.+?:"(?<client_secret>.+?)".+?}/
   })
 });
 export const CLIENTS = Object.freeze({


### PR DESCRIPTION
YouTube seems to have changed their Auth script which breaks  `OAuth#getClientIdentity()`. The Client Identity regex used to match against the body of the script is bound to fail. The result is blocking of the entire process while the regex tries futilely to find a match.

This PR fixes the Client Identity matching part. From what I see, the request payload for device code also seems to have changed. Instead of `model_name`, it's now `device_model`:

![image](https://github.com/LuanRT/YouTube.js/assets/55383971/2b650b83-a9b3-4c40-a93e-fe7466960c92)

So I have included this change in the PR too.