### PR TITLE
fix(Playlist): Add thumbnail_renderer on Playlist when response includes it

### DIFF
--- a/src/parser/classes/Playlist.ts
+++ b/src/parser/classes/Playlist.ts
@@ -1,6 +1,7 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
 import Parser, { type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
+import PlaylistVideoThumbnail from './PlaylistVideoThumbnail.js';
 import Author from './misc/Author.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';
@@ -12,6 +13,7 @@ export default class Playlist extends YTNode {
   title: Text;
   author: Text | Author;
   thumbnails: Thumbnail[];
+  thumbnail_renderer?: PlaylistVideoThumbnail;
   video_count: Text;
   video_count_short: Text;
   first_videos: ObservedArray<YTNode>;
@@ -40,6 +42,10 @@ export default class Playlist extends YTNode {
     this.badges = Parser.parseArray(data.ownerBadges);
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
     this.thumbnail_overlays = Parser.parseArray(data.thumbnailOverlays);
+
+    if (Reflect.has(data, 'thumbnailRenderer')) {
+      this.thumbnail_renderer = Parser.parseItem(data.thumbnailRenderer, PlaylistVideoThumbnail) || undefined;
+    }
 
     if (Reflect.has(data, 'viewPlaylistText')) {
       this.view_playlist = new Text(data.viewPlaylistText);


### PR DESCRIPTION
## Description:
PR add `thumbnail_renderer` to the Playlist YTNode. It is given in most response, but not all, so it is an optional prop.

## Changes:
- Add a new property to the Playlist YTNode called `thumbnail_renderer` of type `PlaylistVideoThumbnail | undefined`

## Related Issue:
Fixes: #423 

## Testing:

I tested the code by linking the library to Freetube and logging out the playlist object. The thumbnail_renderer is there when it is given in the response.
