### PR TITLE
feat(toDash): Add color information

### DIFF
--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -46,6 +46,12 @@ export default class Format {
   is_descriptive?: boolean;
   is_original?: boolean;
 
+  color_info?: {
+    primaries?: string;
+    transfer_characteristics?: string;
+    matrix_coefficients?: string;
+  };
+
   constructor(data: RawNode) {
     this.itag = data.itag;
     this.mime_type = data.mimeType;
@@ -80,6 +86,12 @@ export default class Format {
     this.loudness_db = data.loudnessDb;
     this.has_audio = !!data.audioBitrate || !!data.audioQuality;
     this.has_video = !!data.qualityLabel;
+
+    this.color_info = data.colorInfo ? {
+      primaries: data.colorInfo.primaries?.replace('COLOR_PRIMARIES_', ''),
+      transfer_characteristics: data.colorInfo.transferCharacteristics?.replace('COLOR_TRANSFER_CHARACTERISTICS_', ''),
+      matrix_coefficients: data.colorInfo.matrixCoefficients?.replace('COLOR_MATRIX_COEFFICIENTS_', '')
+    } : undefined;
 
     if (this.has_audio) {
       const args = new URLSearchParams(this.cipher || this.signature_cipher);


### PR DESCRIPTION
This pull request adds the color information to the DASH manifest when available, this informs the player about things like HDR streams, shaka for example uses this to add `HDR` to the labels for HDR streams.

https://github.com/shaka-project/shaka-player/commit/3f9eadeaaf5d3a4b4e20c6e05dbad3fc4b4b5f3c