### PR TITLE
Add `getReleases` and `getPodcasts` to `Channel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ Retrieves contents for a given channel.
 - `<channel>#getShorts()`
 - `<channel>#getLiveStreams()`
 - `<channel>#getReleases()`
+- `<channel>#getPodcasts()`
 - `<channel>#getPlaylists()`
 - `<channel>#getHome()`
 - `<channel>#getCommunity()`

--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Retrieves contents for a given channel.
 - `<channel>#getVideos()`
 - `<channel>#getShorts()`
 - `<channel>#getLiveStreams()`
+- `<channel>#getReleases()`
 - `<channel>#getPlaylists()`
 - `<channel>#getHome()`
 - `<channel>#getCommunity()`

--- a/src/parser/classes/Playlist.ts
+++ b/src/parser/classes/Playlist.ts
@@ -1,6 +1,7 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
 import Parser, { type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
+import PlaylistCustomThumbnail from './PlaylistCustomThumbnail.js';
 import PlaylistVideoThumbnail from './PlaylistVideoThumbnail.js';
 import Author from './misc/Author.js';
 import Text from './misc/Text.js';
@@ -13,7 +14,7 @@ export default class Playlist extends YTNode {
   title: Text;
   author: Text | Author;
   thumbnails: Thumbnail[];
-  thumbnail_renderer?: PlaylistVideoThumbnail;
+  thumbnail_renderer?: PlaylistVideoThumbnail | PlaylistCustomThumbnail;
   video_count: Text;
   video_count_short: Text;
   first_videos: ObservedArray<YTNode>;
@@ -44,7 +45,7 @@ export default class Playlist extends YTNode {
     this.thumbnail_overlays = Parser.parseArray(data.thumbnailOverlays);
 
     if (Reflect.has(data, 'thumbnailRenderer')) {
-      this.thumbnail_renderer = Parser.parseItem(data.thumbnailRenderer, PlaylistVideoThumbnail) || undefined;
+      this.thumbnail_renderer = Parser.parseItem(data.thumbnailRenderer, [ PlaylistVideoThumbnail, PlaylistCustomThumbnail ]) || undefined;
     }
 
     if (Reflect.has(data, 'viewPlaylistText')) {

--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -163,6 +163,11 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
     return new Channel(this.actions, tab.page, true);
   }
 
+  async getReleases(): Promise<Channel> {
+    const tab = await this.getTabByURL('releases');
+    return new Channel(this.actions, tab.page, true);
+  }
+
   async getPlaylists(): Promise<Channel> {
     const tab = await this.getTabByURL('playlists');
     return new Channel(this.actions, tab.page, true);
@@ -215,6 +220,10 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
 
   get has_live_streams(): boolean {
     return this.hasTabWithURL('streams');
+  }
+
+  get has_releases(): boolean {
+    return this.hasTabWithURL('releases');
   }
 
   get has_playlists(): boolean {

--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -168,6 +168,11 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
     return new Channel(this.actions, tab.page, true);
   }
 
+  async getPodcasts(): Promise<Channel> {
+    const tab = await this.getTabByURL('podcasts');
+    return new Channel(this.actions, tab.page, true);
+  }
+
   async getPlaylists(): Promise<Channel> {
     const tab = await this.getTabByURL('playlists');
     return new Channel(this.actions, tab.page, true);
@@ -224,6 +229,10 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
 
   get has_releases(): boolean {
     return this.hasTabWithURL('releases');
+  }
+
+  get has_podcasts(): boolean {
+    return this.hasTabWithURL('podcasts');
   }
 
   get has_playlists(): boolean {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #410

This PR adds the channel methods `getReleases` and `getPodcasts`

It also fixes an issue with parsing some playlist thumbnails