### PR TITLE
feat(Format): Populate audio language from captions when available

### DIFF
--- a/src/parser/classes/PlayerCaptionsTracklist.ts
+++ b/src/parser/classes/PlayerCaptionsTracklist.ts
@@ -17,10 +17,10 @@ export default class PlayerCaptionsTracklist extends YTNode {
   audio_tracks?: {
     audio_track_id: string;
     captions_initial_state: string;
-    default_caption_track_index: number;
+    default_caption_track_index?: number;
     has_default_track: boolean;
     visibility: string;
-    caption_track_indices: number;
+    caption_track_indices: number[];
   }[];
 
   default_audio_track_index?: number;

--- a/src/utils/FormatUtils.ts
+++ b/src/utils/FormatUtils.ts
@@ -491,6 +491,11 @@ class FormatUtils {
           this.#hoistNumberAttributeIfPossible(set, mime_objects[i], 'audioSamplingRate', 'audio_sample_rate', hoisted);
 
           this.#hoistAudioChannelsIfPossible(document, set, mime_objects[i], hoisted);
+
+          const language = mime_objects[i][0].language;
+          if (language) {
+            set.setAttribute('lang', language);
+          }
         } else {
           set.setAttribute('maxPlayoutRate', '1');
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,5 +1,5 @@
 import { createWriteStream, existsSync } from 'node:fs';
-import { Innertube, IBrowseResponse, Utils, YT, YTMusic, YTNodes } from '../bundle/node.cjs';
+import { Innertube, Utils, YT, YTMusic, YTNodes } from '../bundle/node.cjs';
 
 describe('YouTube.js Tests', () => {
   let innertube: Innertube; 
@@ -18,6 +18,30 @@ describe('YouTube.js Tests', () => {
       const info = await innertube.getBasicInfo('bUHZ2k9DYHY');
       expect(info.basic_info.id).toBe('bUHZ2k9DYHY');
     });
+
+    describe('Innertube#getBasicInfo', () => {
+      test('Format#language multiple audio tracks', async () => {
+        const info = await innertube.getBasicInfo('Kn56bMZ9OE8')
+        expect(info.streaming_data).toBeDefined()
+
+        const default_track_format = info.streaming_data?.adaptive_formats.find(format => format.audio_track?.audio_is_default)
+        expect(default_track_format).toBeDefined()
+        expect(default_track_format?.language).toBe('en')
+
+        // check that the language is properly propagated to the non-dash formats
+        expect(info.streaming_data?.formats[0].language).toBe('en')
+      })
+
+      test('Format#language single audio track with captions', async () => {
+        const info = await innertube.getBasicInfo('gisdyTBMNyQ')
+        expect(info.streaming_data).toBeDefined()
+
+        const audio_format = info.streaming_data?.adaptive_formats.find(format => format.has_audio)
+        expect(audio_format).toBeDefined()
+        expect(audio_format?.language).toBe('en')
+        expect(info.streaming_data?.formats[0].language).toBe('en')
+      })
+    })
 
     test('Innertube#search', async () => {
       const search = await innertube.search('Anton Petrov');


### PR DESCRIPTION
For single audio track videos we currently don't have any language information, this pull request changes that to extract it from the audio track to caption mappsing that YouTube provides, when a video has captions. Additionally for videos with multiple audio tracks, this propagates the language of the default audio track to the non-DASH formats.

The goal of this pull request is to have the audio language available in a lot more situations, for videos with a single audio track without captions, it will still be unavailable unfortunately.