### PR TITLE
feat(YouTube Playlist): Add subtitle and fix author optionality

### DIFF
--- a/src/parser/classes/PlaylistHeader.ts
+++ b/src/parser/classes/PlaylistHeader.ts
@@ -8,9 +8,10 @@ export default class PlaylistHeader extends YTNode {
 
   id: string;
   title: Text;
+  subtitle: Text | null;
   stats: Text[];
   brief_stats: Text[];
-  author: Author;
+  author: Author | null;
   description: Text;
   num_videos: Text;
   view_count: Text;
@@ -27,9 +28,10 @@ export default class PlaylistHeader extends YTNode {
     super();
     this.id = data.playlistId;
     this.title = new Text(data.title);
+    this.subtitle = data.subtitle ? new Text(data.subtitle) : null;
     this.stats = data.stats.map((stat: RawNode) => new Text(stat));
     this.brief_stats = data.briefStats.map((stat: RawNode) => new Text(stat));
-    this.author = new Author({ ...data.ownerText, navigationEndpoint: data.ownerEndpoint }, data.ownerBadges, null);
+    this.author = data.ownerText || data.ownerEndpoint ? new Author({ ...data.ownerText, navigationEndpoint: data.ownerEndpoint }, data.ownerBadges, null) : null;
     this.description = new Text(data.descriptionText);
     this.num_videos = new Text(data.numVideosText);
     this.view_count = new Text(data.viewCountText);

--- a/src/parser/youtube/Playlist.ts
+++ b/src/parser/youtube/Playlist.ts
@@ -36,6 +36,7 @@ class Playlist extends Feed<IBrowseResponse> {
     this.info = {
       ...this.page.metadata?.item().as(PlaylistMetadata),
       ...{
+        subtitle: header.subtitle,
         author: secondary_info?.owner?.as(VideoOwner).author ?? header?.author,
         thumbnails: primary_info?.thumbnail_renderer?.as(PlaylistVideoThumbnail, PlaylistCustomThumbnail).thumbnail as Thumbnail[],
         total_items: this.#getStat(0, primary_info),


### PR DESCRIPTION
With the addition of the releases channel tab, it is now a lot easier to stumble across auto-generated album playlists. Unlike normal playlists, these album ones don't seem to be tied to a specific channel. Instead of having channel information (thumbnail, name, link id, etc), they have a subtitle in this format: `{artist/artists separated by commas} • Album`.

This pull request adds support for these playlists, so that YouTube.js no longer provides an empty Author object.

Example playlists:
One artist: https://www.youtube.com/playlist?list=OLAK5uy_lM3m05hKVY9vbzZH5lJpVKZKUQ-v_iTz4
Two artists: https://www.youtube.com/playlist?list=OLAK5uy_mYnfMbIG74obySLdWtKKGj_MJ-YZqVTu0