### PR TITLE
perf: Cleanup some unnecessary uses of `YTNode#key` and `Maybe`

### DIFF
--- a/src/core/clients/Music.ts
+++ b/src/core/clients/Music.ts
@@ -329,7 +329,7 @@ export default class Music {
     if (!page.contents)
       throw new InnertubeError('Unexpected response', page);
 
-    if (page.contents.item().key('type').string() === 'Message')
+    if (page.contents.item().type === 'Message')
       throw new InnertubeError(page.contents.item().as(Message).text.toString(), video_id);
 
     const section_list = page.contents.item().as(SectionList).contents;

--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -124,7 +124,7 @@ export default class MusicResponsiveListItem extends YTNode {
   }
 
   #parseOther() {
-    this.title = this.flex_columns.first().key('title').instanceof(Text).toString();
+    this.title = this.flex_columns.first().title.toString();
 
     if (this.endpoint) {
       this.item_type = 'endpoint';
@@ -134,7 +134,7 @@ export default class MusicResponsiveListItem extends YTNode {
   }
 
   #parseVideoOrSong() {
-    const is_video = this.flex_columns.at(1)?.key('title').instanceof(Text).runs?.some((run) => run.text.match(/(.*?) views/));
+    const is_video = this.flex_columns.at(1)?.title.runs?.some((run) => run.text.match(/(.*?) views/));
     if (is_video) {
       this.item_type = 'video';
       this.#parseVideo();
@@ -146,10 +146,10 @@ export default class MusicResponsiveListItem extends YTNode {
 
   #parseSong() {
     this.id = this.#playlist_item_data.video_id || this.endpoint?.payload?.videoId;
-    this.title = this.flex_columns.first().key('title').instanceof(Text).toString();
+    this.title = this.flex_columns.first().title.toString();
 
-    const duration_text = this.flex_columns.at(1)?.key('title').instanceof(Text).runs?.find(
-      (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns.first()?.key('title').instanceof(Text)?.toString();
+    const duration_text = this.flex_columns.at(1)?.title.runs?.find(
+      (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns.first()?.title?.toString();
 
     if (duration_text) {
       this.duration = {
@@ -159,12 +159,12 @@ export default class MusicResponsiveListItem extends YTNode {
     }
 
     const album_run =
-      this.flex_columns.at(1)?.key('title').instanceof(Text).runs?.find(
+      this.flex_columns.at(1)?.title.runs?.find(
         (run) =>
           (isTextRun(run) && run.endpoint) &&
           run.endpoint.payload.browseId.startsWith('MPR')
       ) ||
-      this.flex_columns.at(2)?.key('title').instanceof(Text).runs?.find(
+      this.flex_columns.at(2)?.title.runs?.find(
         (run) =>
           (isTextRun(run) && run.endpoint) &&
           run.endpoint.payload.browseId.startsWith('MPR')
@@ -178,7 +178,7 @@ export default class MusicResponsiveListItem extends YTNode {
       };
     }
 
-    const artist_runs = this.flex_columns.at(1)?.key('title').instanceof(Text).runs?.filter(
+    const artist_runs = this.flex_columns.at(1)?.title.runs?.filter(
       (run) => (isTextRun(run) && run.endpoint) && run.endpoint.payload.browseId.startsWith('UC')
     );
 
@@ -193,10 +193,10 @@ export default class MusicResponsiveListItem extends YTNode {
 
   #parseVideo() {
     this.id = this.#playlist_item_data.video_id;
-    this.title = this.flex_columns.first().key('title').instanceof(Text).toString();
-    this.views = this.flex_columns.at(1)?.key('title').instanceof(Text).runs?.find((run) => run.text.match(/(.*?) views/))?.toString();
+    this.title = this.flex_columns.first().title.toString();
+    this.views = this.flex_columns.at(1)?.title.runs?.find((run) => run.text.match(/(.*?) views/))?.toString();
 
-    const author_runs = this.flex_columns.at(1)?.key('title').instanceof(Text).runs?.filter(
+    const author_runs = this.flex_columns.at(1)?.title.runs?.filter(
       (run) =>
         (isTextRun(run) && run.endpoint) &&
         run.endpoint.payload.browseId.startsWith('UC')
@@ -212,8 +212,8 @@ export default class MusicResponsiveListItem extends YTNode {
       });
     }
 
-    const duration_text = this.flex_columns[1].key('title').instanceof(Text).runs?.find(
-      (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns.first()?.key('title').instanceof(Text).runs?.find((run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text;
+    const duration_text = this.flex_columns[1].title.runs?.find(
+      (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns.first()?.title.runs?.find((run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text;
 
     if (duration_text) {
       this.duration = {
@@ -225,14 +225,14 @@ export default class MusicResponsiveListItem extends YTNode {
 
   #parseArtist() {
     this.id = this.endpoint?.payload?.browseId;
-    this.name = this.flex_columns.first().key('title').instanceof(Text).toString();
-    this.subtitle = this.flex_columns.at(1)?.key('title').instanceof(Text);
+    this.name = this.flex_columns.first().title.toString();
+    this.subtitle = this.flex_columns.at(1)?.title;
     this.subscribers = this.subtitle?.runs?.find((run) => (/^(\d*\.)?\d+[M|K]? subscribers?$/i).test(run.text))?.text || '';
   }
 
   #parseLibraryArtist() {
-    this.name = this.flex_columns.first().key('title').instanceof(Text).toString();
-    this.subtitle = this.flex_columns.at(1)?.key('title').instanceof(Text);
+    this.name = this.flex_columns.first().title.toString();
+    this.subtitle = this.flex_columns.at(1)?.title;
     this.song_count = this.subtitle?.runs?.find((run) => (/^\d+(,\d+)? songs?$/i).test(run.text))?.text || '';
   }
 
@@ -240,7 +240,7 @@ export default class MusicResponsiveListItem extends YTNode {
     this.id = this.endpoint?.payload?.browseId;
     this.title = this.flex_columns.first().title.toString();
 
-    const author_run = this.flex_columns.at(1)?.key('title').instanceof(Text).runs?.find(
+    const author_run = this.flex_columns.at(1)?.title.runs?.find(
       (run) =>
         (isTextRun(run) && run.endpoint) &&
         run.endpoint.payload.browseId.startsWith('UC')
@@ -254,7 +254,7 @@ export default class MusicResponsiveListItem extends YTNode {
       };
     }
 
-    this.year = this.flex_columns.at(1)?.key('title').instanceof(Text).runs?.find(
+    this.year = this.flex_columns.at(1)?.title.runs?.find(
       (run) => (/^[12][0-9]{3}$/).test(run.text)
     )?.text;
   }
@@ -263,12 +263,12 @@ export default class MusicResponsiveListItem extends YTNode {
     this.id = this.endpoint?.payload?.browseId;
     this.title = this.flex_columns.first().title.toString();
 
-    const item_count_run = this.flex_columns.at(1)?.key('title')
-      .instanceof(Text).runs?.find((run) => run.text.match(/\d+ (song|songs)/));
+    const item_count_run = this.flex_columns.at(1)?.title
+      .runs?.find((run) => run.text.match(/\d+ (song|songs)/));
 
     this.item_count = item_count_run ? item_count_run.text : undefined;
 
-    const author_run = this.flex_columns.at(1)?.key('title').instanceof(Text).runs?.find(
+    const author_run = this.flex_columns.at(1)?.title.runs?.find(
       (run) =>
         (isTextRun(run) && run.endpoint) &&
         run.endpoint.payload.browseId.startsWith('UC')

--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -10,6 +10,7 @@ import ExpandableTab from '../classes/ExpandableTab.js';
 import SectionList from '../classes/SectionList.js';
 import Tab from '../classes/Tab.js';
 import PageHeader from '../classes/PageHeader.js';
+import TwoColumnBrowseResults from '../classes/TwoColumnBrowseResults.js';
 
 import Feed from '../../core/mixins/Feed.js';
 import FilterableFeed from '../../core/mixins/FilterableFeed.js';
@@ -53,7 +54,7 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
 
     this.subscribe_button = this.page.header_memo?.getType(SubscribeButton).first();
 
-    this.current_tab = this.page.contents?.item().key('tabs').parsed().array().filterType(Tab, ExpandableTab).get({ selected: true });
+    this.current_tab = this.page.contents?.item().as(TwoColumnBrowseResults).tabs.array().filterType(Tab, ExpandableTab).get({ selected: true });
   }
 
   /**

--- a/src/parser/ytmusic/HomeFeed.ts
+++ b/src/parser/ytmusic/HomeFeed.ts
@@ -29,7 +29,7 @@ class HomeFeed {
     if (!tab)
       throw new InnertubeError('Could not find Home tab.');
 
-    if (tab.key('content').isNull()) {
+    if (tab.content === null) {
       if (!this.#page.continuation_contents)
         throw new InnertubeError('Continuation did not have any content.');
 

--- a/src/parser/ytmusic/Library.ts
+++ b/src/parser/ytmusic/Library.ts
@@ -164,8 +164,7 @@ class LibraryContinuation {
 
     this.contents = this.#page.continuation_contents.as(MusicShelfContinuation, GridContinuation);
 
-    this.#continuation = this.#page.continuation_contents?.key('continuation').isNull()
-      ? null : this.#page.continuation_contents?.key('continuation').string();
+    this.#continuation = this.contents.continuation || null;
   }
 
   async getContinuation(): Promise<LibraryContinuation> {

--- a/src/parser/ytmusic/TrackInfo.ts
+++ b/src/parser/ytmusic/TrackInfo.ts
@@ -86,7 +86,7 @@ class TrackInfo extends MediaInfo {
 
     const page = await target_tab.endpoint.call(this.actions, { client: 'YTMUSIC', parse: true });
 
-    if (page.contents?.item().key('type').string() === 'Message')
+    if (page.contents?.item().type === 'Message')
       return page.contents.item().as(Message);
 
     if (!page.contents)


### PR DESCRIPTION
We can't get rid of `YTNode#key` and `Maybe` completely (would be cool as the keep names esbuild setting, adds a bunch of bloat to the provided bundles and prevents function inlining), as it's needed if you use the runtime node generator with typescript projects, but we can definitely reduce where it is used. Additionally direct property accesses are slightly faster anyway and we have the type safety thanks to typescript.

I didn't make the changes in a couple of places:
- `PlaylistManager`, requires being logged in to check the types
- `Library.sections`, requires logging in to check what type `Shelf.content` is there
- `LiveChat.getItemMenu`, would require changing the exported `ChatItemWithMenu` type, which contains the `LiveChatViewerEngagementMessage` which doesn't have a `menu_endpoint` in the code (not sure if it's just missing in YouTube.js or doesn't actually have one, but was accidentally added to the `ChatItemWithMenu` type)