### PR TITLE
fix(Playlist): Only try extracting the subtitle for the first page

### DIFF
--- a/src/parser/youtube/Playlist.ts
+++ b/src/parser/youtube/Playlist.ts
@@ -36,7 +36,7 @@ class Playlist extends Feed<IBrowseResponse> {
     this.info = {
       ...this.page.metadata?.item().as(PlaylistMetadata),
       ...{
-        subtitle: header.subtitle,
+        subtitle: header ? header.subtitle : null,
         author: secondary_info?.owner?.as(VideoOwner).author ?? header?.author,
         thumbnails: primary_info?.thumbnail_renderer?.as(PlaylistVideoThumbnail, PlaylistCustomThumbnail).thumbnail as Thumbnail[],
         total_items: this.#getStat(0, primary_info),


### PR DESCRIPTION
Playlist continuations don't have the header so we should only try extracting the subtitle for the first playlist page.

closes #464
bug introduced in #458, which added support for the subtitle