### PR TITLE
feat(VideoInfo): support iOS client

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -42,7 +42,7 @@ import type { DownloadOptions, FormatOptions } from './utils/FormatUtils.js';
 
 export type InnertubeConfig = SessionOptions;
 
-export type InnerTubeClient = 'WEB' | 'ANDROID' | 'YTMUSIC_ANDROID' | 'YTMUSIC' | 'YTSTUDIO_ANDROID' | 'TV_EMBEDDED' | 'YTKIDS'
+export type InnerTubeClient = 'WEB' | 'iOS' | 'ANDROID' | 'YTMUSIC_ANDROID' | 'YTMUSIC' | 'YTSTUDIO_ANDROID' | 'TV_EMBEDDED' | 'YTKIDS';
 
 export type SearchFilters = Partial<{
   upload_date: 'all' | 'hour' | 'today' | 'week' | 'month' | 'year';

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -33,6 +33,12 @@ export const OAUTH = Object.freeze({
   })
 });
 export const CLIENTS = Object.freeze({
+  iOS: {
+    NAME: 'iOS',
+    VERSION: '18.06.35',
+    USER_AGENT: 'com.google.ios.youtube/18.06.35 (iPhone; CPU iPhone OS 14_4 like Mac OS X; en_US)',
+    DEVICE_MODEL: 'iPhone10,6'
+  },
   WEB: {
     NAME: 'WEB',
     VERSION: '2.20230622.06.00',

--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -95,6 +95,8 @@ export default class HTTPClient {
       if (Platform.shim.server) {
         if (n_body.context.client.clientName === 'ANDROID' || n_body.context.client.clientName === 'ANDROID_MUSIC') {
           request_headers.set('User-Agent', Constants.CLIENTS.ANDROID.USER_AGENT);
+        } else if (n_body.context.client.clientName === 'iOS') {
+          request_headers.set('User-Agent', Constants.CLIENTS.iOS.USER_AGENT);
         }
       }
 
@@ -139,7 +141,8 @@ export default class HTTPClient {
     // Check if 2xx
     if (response.ok) {
       return response;
-    } throw new InnertubeError(`Request to ${response.url} failed with status ${response.status}`, await response.text());
+    }
+    throw new InnertubeError(`Request to ${response.url} failed with status ${response.status}`, await response.text());
   }
 
   #adjustContext(ctx: Context, client: string): void {
@@ -157,6 +160,12 @@ export default class HTTPClient {
     }
 
     switch (client) {
+      case 'iOS':
+        ctx.client.deviceModel = Constants.CLIENTS.iOS.DEVICE_MODEL;
+        ctx.client.clientVersion = Constants.CLIENTS.iOS.VERSION;
+        ctx.client.clientName = Constants.CLIENTS.iOS.NAME;
+        ctx.client.platform = 'MOBILE';
+        break;
       case 'YTMUSIC':
         ctx.client.clientVersion = Constants.CLIENTS.YTMUSIC.VERSION;
         ctx.client.clientName = Constants.CLIENTS.YTMUSIC.NAME;


### PR DESCRIPTION
Leveraging [f4e0f30](https://github.com/LuanRT/YouTube.js/commit/f4e0f30e6e94b347b28d67d9a86284ea2d23ee15) as my true north, this PR adds support for HLS streaming with an iOS user agent. The user agent is 100% reliable. I've been using it in my Mac/iPad/iPhone client for a number of months now and it always generates the `hls_manifest_url`.