### PR TITLE
fix(Format): Extracting audio language from captions

### DIFF
--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -108,8 +108,7 @@ class VideoInfo extends MediaInfo {
       } else if (typeof this.captions?.default_audio_track_index !== 'undefined' && this.captions?.audio_tracks && this.captions.caption_tracks) {
         // For videos with a single audio track and captions, we can use the captions to figure out the language of the audio and combined formats
         const audioTrack = this.captions.audio_tracks[this.captions.default_audio_track_index];
-        const defaultCaptionTrackIndex = audioTrack.default_caption_track_index;
-        const index = audioTrack.caption_track_indices[defaultCaptionTrackIndex ? defaultCaptionTrackIndex : 0];
+        const index = audioTrack.default_caption_track_index || 0;
         const language_code = this.captions.caption_tracks[index].language_code;
 
         this.streaming_data.adaptive_formats.forEach((format) => {


### PR DESCRIPTION
This pull request fixes a bug in #445. Turns out `caption_track_indices` is used to determine the order of the caption tracks in the UI, whereas `default_caption_track_index` refers to the original order of the caption tracks.

Noticed that the order can differ while digging into this video with broken audio track: https://youtu.be/UJeSWbR6W04 (the bug doesn't actually crop up for that video, as it has multiple audio tracks, so we don't need to dig around in the captions but it would have picked Portuguese instead of English for that video, if it did only have one audio track).