### PR TITLE
feat(Session): Add fallback for session data retrieval

### DIFF
--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -217,7 +217,7 @@ export default class Session extends EventEmitterLike {
   ) {
     let session_data: SessionData;
 
-    let session_args = { lang, location, time_zone: tz, device_category, client_name, enable_safety_mode, visitor_data };
+    const session_args = { lang, location, time_zone: tz, device_category, client_name, enable_safety_mode, visitor_data };
 
     if (generate_session_locally) {
       session_data = this.#generateSessionData(session_args);
@@ -271,7 +271,7 @@ export default class Session extends EventEmitterLike {
 
     const api_version = `v${ytcfg[0][0][6]}`;
 
-    const [[device_info], api_key] = ytcfg;
+    const [ [ device_info ], api_key ] = ytcfg;
 
     const context: Context = {
       client: {


### PR DESCRIPTION
Should have added this when we first implemented session data retrieval to be honest, it makes a request to YouTube's service worker and the data there can change or the request can just fail.

<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->