### PR TITLE
fix(Format): Fix `is_original` always being `true`

### DIFF
--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -104,7 +104,7 @@ export default class Format {
       this.language = xtags?.find((x: string) => x.startsWith('lang='))?.split('=')[1] || null;
       this.is_dubbed = audio_content === 'dubbed';
       this.is_descriptive = audio_content === 'descriptive';
-      this.is_original = audio_content === 'original' || !this.is_dubbed || !this.is_descriptive;
+      this.is_original = audio_content === 'original' || (!this.is_dubbed && !this.is_descriptive);
 
       if (Reflect.has(data, 'audioTrack')) {
         this.audio_track = {


### PR DESCRIPTION
Due to a mistake in the boolean logic, the is_original property in the `Format` class was always been set to `true`, regardless of whether it is actually dubbed or descriptive.