### PR TITLE
feat(Session): Add on_behalf_of_user session option

### DIFF
--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -63,6 +63,7 @@ export interface Context {
   user: {
     enableSafetyMode: boolean;
     lockedSafetyMode: boolean;
+    onBehalfOfUser?: string;
   };
   thirdParty?: {
     embedUrl: string;
@@ -84,6 +85,10 @@ export interface SessionOptions {
    * Only works if you are signed in with cookies.
    */
   account_index?: number;
+  /**
+   * Specify the Page ID of the YouTube profile/channel to use, if the logged-in account has multiple profiles.
+   */
+  on_behalf_of_user?: string;
   /**
    * Specifies whether to retrieve the JS player. Disabling this will make session creation faster.
    * **NOTE:** Deciphering formats is not possible without the JS player.
@@ -193,7 +198,8 @@ export default class Session extends EventEmitterLike {
       options.device_category,
       options.client_type,
       options.timezone,
-      options.fetch
+      options.fetch,
+      options.on_behalf_of_user
     );
 
     return new Session(
@@ -213,11 +219,12 @@ export default class Session extends EventEmitterLike {
     device_category: DeviceCategory = 'desktop',
     client_name: ClientType = ClientType.WEB,
     tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
-    fetch: FetchFunction = Platform.shim.fetch
+    fetch: FetchFunction = Platform.shim.fetch,
+    on_behalf_of_user?: string
   ) {
     let session_data: SessionData;
 
-    const session_args = { lang, location, time_zone: tz, device_category, client_name, enable_safety_mode, visitor_data };
+    const session_args = { lang, location, time_zone: tz, device_category, client_name, enable_safety_mode, visitor_data, on_behalf_of_user };
 
     if (generate_session_locally) {
       session_data = this.#generateSessionData(session_args);
@@ -241,6 +248,7 @@ export default class Session extends EventEmitterLike {
     client_name: string;
     enable_safety_mode: boolean;
     visitor_data: string;
+    on_behalf_of_user?: string;
   }, fetch: FetchFunction = Platform.shim.fetch): Promise<SessionData> {
     const url = new URL('/sw.js_data', Constants.URLS.YT_BASE);
 
@@ -300,7 +308,8 @@ export default class Session extends EventEmitterLike {
       },
       user: {
         enableSafetyMode: options.enable_safety_mode,
-        lockedSafetyMode: false
+        lockedSafetyMode: false,
+        onBehalfOfUser: options.on_behalf_of_user
       }
     };
 
@@ -315,6 +324,7 @@ export default class Session extends EventEmitterLike {
     client_name: string;
     enable_safety_mode: boolean;
     visitor_data: string;
+    on_behalf_of_user?: string;
   }): SessionData {
     let visitor_id = generateRandomString(11);
 
@@ -347,7 +357,8 @@ export default class Session extends EventEmitterLike {
       },
       user: {
         enableSafetyMode: options.enable_safety_mode,
-        lockedSafetyMode: false
+        lockedSafetyMode: false,
+        onBehalfOfUser: options.on_behalf_of_user
       }
     };
 


### PR DESCRIPTION
This adds support for manually specifying the `onBehalfOfUser` property in the session's `Context.user`, which specifies which channel to use if multiple users are associated with the logged-in account. This can be optionally specified when creating an `Innertube` instance in the same way as `account_id` is. I think this is only relevant if you're using a cookie session.

Profiles are identified with what might be called a "Page ID":  when I use the account switcher in the YouTube UI to switch profiles, it's the I see in a redirect URL like `https://www.youtube.com/signin?action_handle_signin=true&authuser=0&pageid=<THIS CHANNEL ID>`, where we can see it referred to as `pageid`.

<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->