### PR TITLE
perf: Cache deciphered n-params by info response

### DIFF
--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -10,6 +10,7 @@ import type { FetchFunction } from '../types/PlatformShim.js';
  */
 export default class Player {
   #nsig_sc;
+  #nsig_cache;
   #sig_sc;
   #sig_sc_timestamp;
   #player_id;
@@ -21,6 +22,8 @@ export default class Player {
     this.#sig_sc_timestamp = signature_timestamp;
 
     this.#player_id = player_id;
+
+    this.#nsig_cache = new Map<string, string>();
   }
 
   static async create(cache: ICache | undefined, fetch: FetchFunction = Platform.shim.fetch): Promise<Player> {
@@ -66,7 +69,7 @@ export default class Player {
     return await Player.fromSource(cache, sig_timestamp, sig_sc, nsig_sc, player_id);
   }
 
-  decipher(url?: string, signature_cipher?: string, cipher?: string): string {
+  decipher(url?: string, signature_cipher?: string, cipher?: string, this_response_nsig_cache?: Map<string, string>): string {
     url = url || signature_cipher || cipher;
 
     if (!url)
@@ -93,15 +96,23 @@ export default class Player {
     const n = url_components.searchParams.get('n');
 
     if (n) {
-      const nsig = Platform.shim.eval(this.#nsig_sc, {
-        nsig: n
-      });
+      let nsig;
 
-      if (typeof nsig !== 'string')
-        throw new PlayerError('Failed to decipher nsig');
+      if (this_response_nsig_cache && this_response_nsig_cache.has(n)) {
+        nsig = this_response_nsig_cache.get(n) as string;
+      } else {
+        nsig = Platform.shim.eval(this.#nsig_sc, {
+          nsig: n
+        });
 
-      if (nsig.startsWith('enhanced_except_')) {
-        console.warn('Warning:\nCould not transform nsig, download may be throttled.\nChanging the InnerTube client to "ANDROID" might help!');
+        if (typeof nsig !== 'string')
+          throw new PlayerError('Failed to decipher nsig');
+
+        if (nsig.startsWith('enhanced_except_')) {
+          console.warn('Warning:\nCould not transform nsig, download may be throttled.\nChanging the InnerTube client to "ANDROID" might help!');
+        } else if (this_response_nsig_cache) {
+          this_response_nsig_cache.set(n, nsig);
+        }
       }
 
       url_components.searchParams.set('n', nsig);

--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -3,6 +3,8 @@ import { InnertubeError } from '../../../utils/Utils.js';
 import type { RawNode } from '../../index.js';
 
 export default class Format {
+  #this_response_nsig_cache?: Map<string, string>;
+
   itag: number;
   mime_type: string;
   is_type_otf: boolean;
@@ -52,7 +54,11 @@ export default class Format {
     matrix_coefficients?: string;
   };
 
-  constructor(data: RawNode) {
+  constructor(data: RawNode, this_response_nsig_cache?: Map<string, string>) {
+    if (this_response_nsig_cache) {
+      this.#this_response_nsig_cache = this_response_nsig_cache;
+    }
+
     this.itag = data.itag;
     this.mime_type = data.mimeType;
     this.is_type_otf = data.type === 'FORMAT_STREAM_TYPE_OTF';
@@ -122,6 +128,6 @@ export default class Format {
    */
   decipher(player: Player | undefined): string {
     if (!player) throw new InnertubeError('Cannot decipher format, this session appears to have no valid player.');
-    return player.decipher(this.url, this.signature_cipher, this.cipher);
+    return player.decipher(this.url, this.signature_cipher, this.cipher, this.#this_response_nsig_cache);
   }
 }


### PR DESCRIPTION
Currently for web responses at least, the `adaptiveFormats` and the `formats` each share one n-param value (two in total), per `/player` call (`Innertube#getInfo` and `Innertube#getBasicInfo` in YouTube.js). This pull request introduces a response level cache, meaning that calling `.decipher` on `Format` objects from the same response multiple times, will now use the already deciphered n-param, as long as it is the same as one of the ones in the cache. The way it is designed, it doesn't make any assumptions on the number of n-param values, so if YouTube starts using a unique one for every URL, this code will continue to work, it will just make the cache useless.

In my testing this resulted in the `toDash` function being on average more than 50% faster.