### PR TITLE
chore(MediaInfo): Throw helpful errors when calling toDash or download for live and Post-Live DVR videos

### DIFF
--- a/src/core/mixins/MediaInfo.ts
+++ b/src/core/mixins/MediaInfo.ts
@@ -46,16 +46,16 @@ export default class MediaInfo {
    * @returns DASH manifest
    */
   async toDash(url_transformer?: URLTransformer, format_filter?: FormatFilter, options: DashOptions = { include_thumbnails: false }): Promise<string> {
-    const playerResponse = this.#page[0];
+    const player_response = this.#page[0];
 
-    if (playerResponse.video_details && (playerResponse.video_details.is_live || playerResponse.video_details.is_post_live_dvr)) {
-      throw new InnertubeError('Generating DASH manifests for live and Post-Live-DVR videos, is not supported. Please use the DASH and HLS manifests provided by YouTube in `streaming_data.dash_manifest_url` and `streaming_data.hls_manifest_url` instead.');
+    if (player_response.video_details && (player_response.video_details.is_live || player_response.video_details.is_post_live_dvr)) {
+      throw new InnertubeError('Generating DASH manifests for live and Post-Live-DVR videos is not supported. Please use the DASH and HLS manifests provided by YouTube in `streaming_data.dash_manifest_url` and `streaming_data.hls_manifest_url` instead.');
     }
 
     let storyboards;
 
-    if (options.include_thumbnails && playerResponse.storyboards?.is(PlayerStoryboardSpec)) {
-      storyboards = playerResponse.storyboards;
+    if (options.include_thumbnails && player_response.storyboards?.is(PlayerStoryboardSpec)) {
+      storyboards = player_response.storyboards;
     }
 
     return FormatUtils.toDash(this.streaming_data, url_transformer, format_filter, this.#cpn, this.#actions.session.player, this.#actions, storyboards);
@@ -89,10 +89,10 @@ export default class MediaInfo {
    * @param options - Download options.
    */
   async download(options: DownloadOptions = {}): Promise<ReadableStream<Uint8Array>> {
-    const playerResponse = this.#page[0];
+    const player_response = this.#page[0];
 
-    if (playerResponse.video_details && (playerResponse.video_details.is_live || playerResponse.video_details.is_post_live_dvr)) {
-      throw new InnertubeError('Downloading is not supported for live and Post-Live-DVR videos, as they are split up into 5 second segments that are individual files, which require using a tool like ffmpeg to stitch them together, so they cannot be returned in a single stream.');
+    if (player_response.video_details && (player_response.video_details.is_live || player_response.video_details.is_post_live_dvr)) {
+      throw new InnertubeError('Downloading is not supported for live and Post-Live-DVR videos, as they are split up into 5 second segments that are individual files, which require using a tool such as ffmpeg to stitch them together, so they cannot be returned in a single stream.');
     }
 
     return FormatUtils.download(options, this.#actions, this.playability_status, this.streaming_data, this.#actions.session.player, this.cpn);


### PR DESCRIPTION
YouTube.js doesn't support generating DASH manifest for live and Post-Live-DVR videos, so now we'll throw an error that points people towards using the dash_manifest_url and hls_manifest_url that are already provided by YouTube.

YouTube.js also doesn't support downloading those videos, because they consist of 5 segment chunks that are all individual files, so they require stitching together with ffmpeg and can't just be written back to back into the same file.

closes #518