### PR TITLE
feat(UpdateViewerShipAction): Add `original_view_count` and `unlabeled_view_count_value`

### DIFF
--- a/src/parser/classes/livechat/UpdateViewershipAction.ts
+++ b/src/parser/classes/livechat/UpdateViewershipAction.ts
@@ -7,6 +7,8 @@ export default class UpdateViewershipAction extends YTNode {
 
   view_count: Text;
   extra_short_view_count: Text;
+  original_view_count: Number;
+  unlabeled_view_count_value: Text;
   is_live: boolean;
 
   constructor(data: RawNode) {
@@ -14,6 +16,8 @@ export default class UpdateViewershipAction extends YTNode {
     const view_count_renderer = data.viewCount.videoViewCountRenderer;
     this.view_count = new Text(view_count_renderer.viewCount);
     this.extra_short_view_count = new Text(view_count_renderer.extraShortViewCount);
+    this.original_view_count = parseInt(view_count_renderer.originalViewCount);
+    this.unlabeled_view_count_value = new Text(view_count_renderer.unlabeledViewCountValue);
     this.is_live = view_count_renderer.isLive;
   }
 }


### PR DESCRIPTION
`original_view_count` contains the number of current viewers as a number
`unlabeled_view_count_value` contains the formatted number of current viewers without the "watching now" text