### PR TITLE
feat: use `overrides` instead of `--legacy-peer-deps`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
-      - run: npm ci --legacy-peer-deps
+      - run: npm ci
       - run: npm run lint

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: "16.x"
       - name: Build for Deno
         run: |
-          npm ci --legacy-peer-deps
+          npm ci
           npm run build:deno
         if: ${{ steps.release.outputs.release_created }}
       - name: Move Deno files
@@ -55,7 +55,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - name: Publish package to npmjs
         run: |
-          npm ci --legacy-peer-deps
+          npm ci
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
-      - run: npm ci --legacy-peer-deps
+      - run: npm ci
       - run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -6715,7 +6715,8 @@
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "aggregate-error": {
       "version": "4.0.1",
@@ -7909,7 +7910,8 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "28.0.2",
@@ -9097,7 +9099,8 @@
     },
     "ts-transformer-inline-file": {
       "version": "0.2.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "tslib": {
       "version": "2.6.1"

--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
     "tslib": "^2.5.0",
     "undici": "^5.19.1"
   },
+  "overrides": {
+    "typescript": "^5.0.0"
+  },
   "devDependencies": {
     "@types/glob": "^8.1.0",
     "@types/jest": "^28.1.7",


### PR DESCRIPTION
- Resolves the peer dependency conflict issue caused by #509.