### PR TITLE
perf: Use named Parser import, to allow bundlers to create direct function references

### DIFF
--- a/docs/updating-the-parser.md
+++ b/docs/updating-the-parser.md
@@ -31,7 +31,7 @@ For example, suppose we have found a new renderer named `verticalListRenderer`. 
 > `../classes/VerticalList.ts`
 
 ```ts
-import Parser, { RawNode } from '../index.js';
+import { Parser, RawNode } from '../index.js';
 import { YTNode } from '../helpers.js';
 
 export default class VerticalList extends YTNode {

--- a/src/core/Actions.ts
+++ b/src/core/Actions.ts
@@ -1,4 +1,4 @@
-import Parser, { NavigateAction } from '../parser/index.js';
+import { Parser, NavigateAction } from '../parser/index.js';
 import { InnertubeError } from '../utils/Utils.js';
 
 import type Session from './Session.js';

--- a/src/core/clients/Kids.ts
+++ b/src/core/clients/Kids.ts
@@ -1,4 +1,4 @@
-import Parser from '../../parser/index.js';
+import { Parser } from '../../parser/index.js';
 import Channel from '../../parser/ytkids/Channel.js';
 import HomeFeed from '../../parser/ytkids/HomeFeed.js';
 import Search from '../../parser/ytkids/Search.js';

--- a/src/core/mixins/Feed.ts
+++ b/src/core/mixins/Feed.ts
@@ -1,5 +1,5 @@
 import type { Memo, ObservedArray, SuperParsedResult, YTNode } from '../../parser/helpers.js';
-import Parser, { ReloadContinuationItemsCommand } from '../../parser/index.js';
+import { Parser, ReloadContinuationItemsCommand } from '../../parser/index.js';
 import { concatMemos, InnertubeError } from '../../utils/Utils.js';
 import type Actions from '../Actions.js';
 

--- a/src/core/mixins/MediaInfo.ts
+++ b/src/core/mixins/MediaInfo.ts
@@ -6,7 +6,7 @@ import * as FormatUtils from '../../utils/FormatUtils.js';
 import { InnertubeError } from '../../utils/Utils.js';
 import type Format from '../../parser/classes/misc/Format.js';
 import type { INextResponse, IPlayerResponse } from '../../parser/index.js';
-import Parser from '../../parser/index.js';
+import { Parser } from '../../parser/index.js';
 import type { DashOptions } from '../../types/DashOptions.js';
 import PlayerStoryboardSpec from '../../parser/classes/PlayerStoryboardSpec.js';
 import { getStreamingInfo } from '../../utils/StreamingInfo.js';

--- a/src/parser/classes/AccountItemSection.ts
+++ b/src/parser/classes/AccountItemSection.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import AccountItemSectionHeader from './AccountItemSectionHeader.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/AccountSectionList.ts
+++ b/src/parser/classes/AccountSectionList.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import AccountChannel from './AccountChannel.js';
 import AccountItemSection from './AccountItemSection.js';
 

--- a/src/parser/classes/BackstagePost.ts
+++ b/src/parser/classes/BackstagePost.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import CommentActionButtons from './comments/CommentActionButtons.js';

--- a/src/parser/classes/BackstagePostThread.ts
+++ b/src/parser/classes/BackstagePostThread.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { YTNode } from '../helpers.js';
 
 export default class BackstagePostThread extends YTNode {

--- a/src/parser/classes/BrowseFeedActions.ts
+++ b/src/parser/classes/BrowseFeedActions.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class BrowseFeedActions extends YTNode {

--- a/src/parser/classes/C4TabbedHeader.ts
+++ b/src/parser/classes/C4TabbedHeader.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import ChannelHeaderLinks from './ChannelHeaderLinks.js';
 import ChannelHeaderLinksView from './ChannelHeaderLinksView.js';

--- a/src/parser/classes/Card.ts
+++ b/src/parser/classes/Card.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { YTNode } from '../helpers.js';
 
 export default class Card extends YTNode {

--- a/src/parser/classes/CardCollection.ts
+++ b/src/parser/classes/CardCollection.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 
 export default class CardCollection extends YTNode {

--- a/src/parser/classes/CarouselHeader.ts
+++ b/src/parser/classes/CarouselHeader.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class CarouselHeader extends YTNode {

--- a/src/parser/classes/CarouselItem.ts
+++ b/src/parser/classes/CarouselItem.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 import Thumbnail from './misc/Thumbnail.js';
 

--- a/src/parser/classes/CarouselLockup.ts
+++ b/src/parser/classes/CarouselLockup.ts
@@ -1,6 +1,6 @@
 import { type ObservedArray, YTNode } from '../helpers.js';
 import InfoRow from './InfoRow.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import CompactVideo from './CompactVideo.js';
 
 export default class CarouselLockup extends YTNode {

--- a/src/parser/classes/Channel.ts
+++ b/src/parser/classes/Channel.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import SubscribeButton from './SubscribeButton.js';

--- a/src/parser/classes/ChannelAboutFullMetadata.ts
+++ b/src/parser/classes/ChannelAboutFullMetadata.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/ChannelFeaturedContent.ts
+++ b/src/parser/classes/ChannelFeaturedContent.ts
@@ -1,5 +1,5 @@
 import { type ObservedArray, YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 
 export default class ChannelFeaturedContent extends YTNode {

--- a/src/parser/classes/ChannelSubMenu.ts
+++ b/src/parser/classes/ChannelSubMenu.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 
 export default class ChannelSubMenu extends YTNode {

--- a/src/parser/classes/ChipCloud.ts
+++ b/src/parser/classes/ChipCloud.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import ChipCloudChip from './ChipCloudChip.js';
 

--- a/src/parser/classes/CompactChannel.ts
+++ b/src/parser/classes/CompactChannel.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Menu from './menus/Menu.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/CompactMovie.ts
+++ b/src/parser/classes/CompactMovie.ts
@@ -1,6 +1,6 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Author from './misc/Author.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/CompactVideo.ts
+++ b/src/parser/classes/CompactVideo.ts
@@ -1,6 +1,6 @@
 import { timeToSeconds } from '../../utils/Utils.js';
 import { YTNode, type ObservedArray, type SuperParsedResult } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Menu from './menus/Menu.js';
 import MetadataBadge from './MetadataBadge.js';
 import Author from './misc/Author.js';

--- a/src/parser/classes/ConfirmDialog.ts
+++ b/src/parser/classes/ConfirmDialog.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 import Button from './Button.js';
 import { YTNode } from '../helpers.js';

--- a/src/parser/classes/ContinuationItem.ts
+++ b/src/parser/classes/ContinuationItem.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 

--- a/src/parser/classes/ConversationBar.ts
+++ b/src/parser/classes/ConversationBar.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Message from './Message.js';
 
 export default class ConversationBar extends YTNode {

--- a/src/parser/classes/CopyLink.ts
+++ b/src/parser/classes/CopyLink.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 
 export default class CopyLink extends YTNode {

--- a/src/parser/classes/CreatePlaylistDialog.ts
+++ b/src/parser/classes/CreatePlaylistDialog.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import Dropdown from './Dropdown.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/DecoratedPlayerBar.ts
+++ b/src/parser/classes/DecoratedPlayerBar.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Button from './Button.js';
 import MultiMarkersPlayerBar from './MultiMarkersPlayerBar.js';
 

--- a/src/parser/classes/DefaultPromoPanel.ts
+++ b/src/parser/classes/DefaultPromoPanel.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/Dropdown.ts
+++ b/src/parser/classes/Dropdown.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import DropdownItem from './DropdownItem.js';
 
 export default class Dropdown extends YTNode {

--- a/src/parser/classes/Element.ts
+++ b/src/parser/classes/Element.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import ChildElement from './misc/ChildElement.js';
 import { type ObservedArray, YTNode, observe } from '../helpers.js';
 

--- a/src/parser/classes/EmergencyOnebox.ts
+++ b/src/parser/classes/EmergencyOnebox.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Menu from './menus/Menu.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/EndScreenVideo.ts
+++ b/src/parser/classes/EndScreenVideo.ts
@@ -1,5 +1,5 @@
 import { type ObservedArray, YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Author from './misc/Author.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';

--- a/src/parser/classes/Endscreen.ts
+++ b/src/parser/classes/Endscreen.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class Endscreen extends YTNode {

--- a/src/parser/classes/EndscreenElement.ts
+++ b/src/parser/classes/EndscreenElement.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Thumbnail from './misc/Thumbnail.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/EngagementPanelSectionList.ts
+++ b/src/parser/classes/EngagementPanelSectionList.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import ContinuationItem from './ContinuationItem.js';
 import EngagementPanelTitleHeader from './EngagementPanelTitleHeader.js';
 import MacroMarkersList from './MacroMarkersList.js';

--- a/src/parser/classes/ExpandableMetadata.ts
+++ b/src/parser/classes/ExpandableMetadata.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import HorizontalCardList from './HorizontalCardList.js';
 import HorizontalList from './HorizontalList.js';

--- a/src/parser/classes/ExpandableTab.ts
+++ b/src/parser/classes/ExpandableTab.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 
 export default class ExpandableTab extends YTNode {

--- a/src/parser/classes/ExpandedShelfContents.ts
+++ b/src/parser/classes/ExpandedShelfContents.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class ExpandedShelfContents extends YTNode {

--- a/src/parser/classes/FeedFilterChipBar.ts
+++ b/src/parser/classes/FeedFilterChipBar.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import ChipCloudChip from './ChipCloudChip.js';
 
 export default class FeedFilterChipBar extends YTNode {

--- a/src/parser/classes/GameCard.ts
+++ b/src/parser/classes/GameCard.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class GameCard extends YTNode {
   static type = 'GameCard';

--- a/src/parser/classes/Grid.ts
+++ b/src/parser/classes/Grid.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class Grid extends YTNode {
   static type = 'Grid';

--- a/src/parser/classes/GridChannel.ts
+++ b/src/parser/classes/GridChannel.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Author from './misc/Author.js';
 import Text from './misc/Text.js';
 import NavigationEndpoint from './NavigationEndpoint.js';

--- a/src/parser/classes/GridMix.ts
+++ b/src/parser/classes/GridMix.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';

--- a/src/parser/classes/GridMovie.ts
+++ b/src/parser/classes/GridMovie.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import MetadataBadge from './MetadataBadge.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/GridPlaylist.ts
+++ b/src/parser/classes/GridPlaylist.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Author from './misc/Author.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';

--- a/src/parser/classes/GridVideo.ts
+++ b/src/parser/classes/GridVideo.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Menu from './menus/Menu.js';
 import Author from './misc/Author.js';

--- a/src/parser/classes/Heatmap.ts
+++ b/src/parser/classes/Heatmap.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import HeatMarker from './HeatMarker.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 

--- a/src/parser/classes/HorizontalCardList.ts
+++ b/src/parser/classes/HorizontalCardList.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 import SearchRefinementCard from './SearchRefinementCard.js';
 import Button from './Button.js';

--- a/src/parser/classes/HorizontalList.ts
+++ b/src/parser/classes/HorizontalList.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class HorizontalList extends YTNode {

--- a/src/parser/classes/HorizontalMovieList.ts
+++ b/src/parser/classes/HorizontalMovieList.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 import Button from './Button.js';
 

--- a/src/parser/classes/InfoPanelContainer.ts
+++ b/src/parser/classes/InfoPanelContainer.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import InfoPanelContent from './InfoPanelContent.js';
 import Menu from './menus/Menu.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/InteractiveTabbedHeader.ts
+++ b/src/parser/classes/InteractiveTabbedHeader.ts
@@ -5,7 +5,7 @@ import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';
 
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class InteractiveTabbedHeader extends YTNode {
   static type = 'InteractiveTabbedHeader';

--- a/src/parser/classes/ItemSection.ts
+++ b/src/parser/classes/ItemSection.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import ItemSectionHeader from './ItemSectionHeader.js';
 import ItemSectionTabbedHeader from './ItemSectionTabbedHeader.js';
 import CommentsHeader from './comments/CommentsHeader.js';

--- a/src/parser/classes/ItemSectionTabbedHeader.ts
+++ b/src/parser/classes/ItemSectionTabbedHeader.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import ItemSectionTab from './ItemSectionTab.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/LiveChat.ts
+++ b/src/parser/classes/LiveChat.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 
 export default class LiveChat extends YTNode {

--- a/src/parser/classes/LiveChatDialog.ts
+++ b/src/parser/classes/LiveChatDialog.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/LiveChatHeader.ts
+++ b/src/parser/classes/LiveChatHeader.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import SortFilterSubMenu from './SortFilterSubMenu.js';
 import Menu from './menus/Menu.js';

--- a/src/parser/classes/LiveChatItemList.ts
+++ b/src/parser/classes/LiveChatItemList.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 
 export default class LiveChatItemList extends YTNode {

--- a/src/parser/classes/LiveChatMessageInput.ts
+++ b/src/parser/classes/LiveChatMessageInput.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';

--- a/src/parser/classes/LiveChatParticipant.ts
+++ b/src/parser/classes/LiveChatParticipant.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';
 

--- a/src/parser/classes/LiveChatParticipantsList.ts
+++ b/src/parser/classes/LiveChatParticipantsList.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import LiveChatParticipant from './LiveChatParticipant.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/MerchandiseShelf.ts
+++ b/src/parser/classes/MerchandiseShelf.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class MerchandiseShelf extends YTNode {
   static type = 'MerchandiseShelf';

--- a/src/parser/classes/MetadataRowContainer.ts
+++ b/src/parser/classes/MetadataRowContainer.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class MetadataRowContainer extends YTNode {

--- a/src/parser/classes/MetadataScreen.ts
+++ b/src/parser/classes/MetadataScreen.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { YTNode } from '../helpers.js';
 
 export default class MetadataScreen extends YTNode {

--- a/src/parser/classes/Movie.ts
+++ b/src/parser/classes/Movie.ts
@@ -1,6 +1,6 @@
 import { timeToSeconds } from '../../utils/Utils.js';
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Menu from './menus/Menu.js';
 import Author from './misc/Author.js';

--- a/src/parser/classes/MultiMarkersPlayerBar.ts
+++ b/src/parser/classes/MultiMarkersPlayerBar.ts
@@ -1,6 +1,6 @@
 import { YTNode, observe, type ObservedArray } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Chapter from './Chapter.js';
 import Heatmap from './Heatmap.js';
 

--- a/src/parser/classes/MusicCardShelf.ts
+++ b/src/parser/classes/MusicCardShelf.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import Menu from './menus/Menu.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/MusicCarouselShelf.ts
+++ b/src/parser/classes/MusicCarouselShelf.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 import MusicCarouselShelfBasicHeader from './MusicCarouselShelfBasicHeader.js';
 import MusicMultiRowListItem from './MusicMultiRowListItem.js';

--- a/src/parser/classes/MusicCarouselShelfBasicHeader.ts
+++ b/src/parser/classes/MusicCarouselShelfBasicHeader.ts
@@ -1,5 +1,5 @@
 import { type ObservedArray, YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import IconLink from './IconLink.js';
 import MusicThumbnail from './MusicThumbnail.js';

--- a/src/parser/classes/MusicDetailHeader.ts
+++ b/src/parser/classes/MusicDetailHeader.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import type NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';
 import type TextRun from './misc/TextRun.js';

--- a/src/parser/classes/MusicEditablePlaylistDetailHeader.ts
+++ b/src/parser/classes/MusicEditablePlaylistDetailHeader.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { YTNode } from '../helpers.js';
 
 export default class MusicEditablePlaylistDetailHeader extends YTNode {

--- a/src/parser/classes/MusicElementHeader.ts
+++ b/src/parser/classes/MusicElementHeader.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Element from './Element.js';
 import { YTNode } from '../helpers.js';
 

--- a/src/parser/classes/MusicHeader.ts
+++ b/src/parser/classes/MusicHeader.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { YTNode } from '../helpers.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/MusicImmersiveHeader.ts
+++ b/src/parser/classes/MusicImmersiveHeader.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import MusicThumbnail from './MusicThumbnail.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/MusicItemThumbnailOverlay.ts
+++ b/src/parser/classes/MusicItemThumbnailOverlay.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import MusicPlayButton from './MusicPlayButton.js';
 import { YTNode } from '../helpers.js';
 

--- a/src/parser/classes/MusicPlaylistShelf.ts
+++ b/src/parser/classes/MusicPlaylistShelf.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import MusicResponsiveListItem from './MusicResponsiveListItem.js';
 
 export default class MusicPlaylistShelf extends YTNode {

--- a/src/parser/classes/MusicQueue.ts
+++ b/src/parser/classes/MusicQueue.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import PlaylistPanel from './PlaylistPanel.js';
 import { YTNode } from '../helpers.js';
 

--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -5,7 +5,7 @@ import { isTextRun, timeToSeconds } from '../../utils/Utils.js';
 import type { ObservedArray } from '../helpers.js';
 import type { RawNode } from '../index.js';
 
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import MusicItemThumbnailOverlay from './MusicItemThumbnailOverlay.js';
 import MusicResponsiveListItemFixedColumn from './MusicResponsiveListItemFixedColumn.js';
 import MusicResponsiveListItemFlexColumn from './MusicResponsiveListItemFlexColumn.js';

--- a/src/parser/classes/MusicShelf.ts
+++ b/src/parser/classes/MusicShelf.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import MusicResponsiveListItem from './MusicResponsiveListItem.js';
 import NavigationEndpoint from './NavigationEndpoint.js';

--- a/src/parser/classes/MusicSideAlignedItem.ts
+++ b/src/parser/classes/MusicSideAlignedItem.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class MusicSideAlignedItem extends YTNode {
   static type = 'MusicSideAlignedItem';

--- a/src/parser/classes/MusicSortFilterButton.ts
+++ b/src/parser/classes/MusicSortFilterButton.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import MusicMultiSelectMenu from './menus/MusicMultiSelectMenu.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/MusicTastebuilderShelf.ts
+++ b/src/parser/classes/MusicTastebuilderShelf.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Button from './Button.js';
 import Text from './misc/Text.js';
 import MusicTastebuilderShelfThumbnail from './MusicTastebuilderShelfThumbnail.js';

--- a/src/parser/classes/MusicTwoRowItem.ts
+++ b/src/parser/classes/MusicTwoRowItem.ts
@@ -1,7 +1,7 @@
 // TODO: Refactor this.
 
 import { YTNode, type SuperParsedResult } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import MusicItemThumbnailOverlay from './MusicItemThumbnailOverlay.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Menu from './menus/Menu.js';

--- a/src/parser/classes/MusicVisualHeader.ts
+++ b/src/parser/classes/MusicVisualHeader.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Menu from './menus/Menu.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';

--- a/src/parser/classes/NavigationEndpoint.ts
+++ b/src/parser/classes/NavigationEndpoint.ts
@@ -1,7 +1,7 @@
 import type Actions from '../../core/Actions.js';
 import type { ApiResponse } from '../../core/Actions.js';
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import type { IParsedResponse } from '../types/ParsedResponse.js';
 import CreatePlaylistDialog from './CreatePlaylistDialog.js';
 import OpenPopupAction from './actions/OpenPopupAction.js';

--- a/src/parser/classes/Notification.ts
+++ b/src/parser/classes/Notification.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';
 import NavigationEndpoint from './NavigationEndpoint.js';

--- a/src/parser/classes/PageHeader.ts
+++ b/src/parser/classes/PageHeader.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import PageHeaderView from './PageHeaderView.js';
 
 export default class PageHeader extends YTNode {

--- a/src/parser/classes/PageHeaderView.ts
+++ b/src/parser/classes/PageHeaderView.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import ContentPreviewImageView from './ContentPreviewImageView.js';
 import DynamicTextView from './DynamicTextView.js';
 

--- a/src/parser/classes/PlayerAnnotationsExpanded.ts
+++ b/src/parser/classes/PlayerAnnotationsExpanded.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Thumbnail from './misc/Thumbnail.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 

--- a/src/parser/classes/PlayerErrorMessage.ts
+++ b/src/parser/classes/PlayerErrorMessage.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';

--- a/src/parser/classes/PlayerOverlay.ts
+++ b/src/parser/classes/PlayerOverlay.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import DecoratedPlayerBar from './DecoratedPlayerBar.js';
 import PlayerOverlayAutoplay from './PlayerOverlayAutoplay.js';

--- a/src/parser/classes/PlayerOverlayAutoplay.ts
+++ b/src/parser/classes/PlayerOverlayAutoplay.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import Author from './misc/Author.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/Playlist.ts
+++ b/src/parser/classes/Playlist.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import PlaylistCustomThumbnail from './PlaylistCustomThumbnail.js';
 import PlaylistVideoThumbnail from './PlaylistVideoThumbnail.js';

--- a/src/parser/classes/PlaylistHeader.ts
+++ b/src/parser/classes/PlaylistHeader.ts
@@ -1,6 +1,6 @@
 import Text from './misc/Text.js';
 import Author from './misc/Author.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { YTNode } from '../helpers.js';
 
 export default class PlaylistHeader extends YTNode {

--- a/src/parser/classes/PlaylistPanel.ts
+++ b/src/parser/classes/PlaylistPanel.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import AutomixPreviewVideo from './AutomixPreviewVideo.js';
 import PlaylistPanelVideo from './PlaylistPanelVideo.js';
 import PlaylistPanelVideoWrapper from './PlaylistPanelVideoWrapper.js';

--- a/src/parser/classes/PlaylistPanelVideo.ts
+++ b/src/parser/classes/PlaylistPanelVideo.ts
@@ -1,6 +1,6 @@
 import { timeToSeconds } from '../../utils/Utils.js';
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';
 import type TextRun from './misc/TextRun.js';

--- a/src/parser/classes/PlaylistPanelVideoWrapper.ts
+++ b/src/parser/classes/PlaylistPanelVideoWrapper.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode, observe } from '../helpers.js';
 import PlaylistPanelVideo from './PlaylistPanelVideo.js';
 

--- a/src/parser/classes/PlaylistSidebar.ts
+++ b/src/parser/classes/PlaylistSidebar.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class PlaylistSidebar extends YTNode {

--- a/src/parser/classes/PlaylistSidebarPrimaryInfo.ts
+++ b/src/parser/classes/PlaylistSidebarPrimaryInfo.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/PlaylistSidebarSecondaryInfo.ts
+++ b/src/parser/classes/PlaylistSidebarSecondaryInfo.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class PlaylistSidebarSecondaryInfo extends YTNode {
   static type = 'PlaylistSidebarSecondaryInfo';

--- a/src/parser/classes/PlaylistVideo.ts
+++ b/src/parser/classes/PlaylistVideo.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import ThumbnailOverlayTimeStatus from './ThumbnailOverlayTimeStatus.js';
 import Menu from './menus/Menu.js';

--- a/src/parser/classes/PlaylistVideoList.ts
+++ b/src/parser/classes/PlaylistVideoList.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class PlaylistVideoList extends YTNode {

--- a/src/parser/classes/PostMultiImage.ts
+++ b/src/parser/classes/PostMultiImage.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import BackstageImage from './BackstageImage.js';
 import { YTNode } from '../helpers.js';
 

--- a/src/parser/classes/ProductList.ts
+++ b/src/parser/classes/ProductList.ts
@@ -1,7 +1,7 @@
 import type { ObservedArray} from '../helpers.js';
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 
 export default class ProductList extends YTNode {
   static type = 'ProductList';

--- a/src/parser/classes/ProductListItem.ts
+++ b/src/parser/classes/ProductListItem.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import { Text, Thumbnail } from '../misc.js';
 import Button from './Button.js';
 import NavigationEndpoint from './NavigationEndpoint.js';

--- a/src/parser/classes/ProfileColumn.ts
+++ b/src/parser/classes/ProfileColumn.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class ProfileColumn extends YTNode {
   static type = 'ProfileColumn';

--- a/src/parser/classes/ProfileColumnStats.ts
+++ b/src/parser/classes/ProfileColumnStats.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class ProfileColumnStats extends YTNode {

--- a/src/parser/classes/RecognitionShelf.ts
+++ b/src/parser/classes/RecognitionShelf.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { YTNode } from '../helpers.js';
 import Button from './Button.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/ReelShelf.ts
+++ b/src/parser/classes/ReelShelf.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/RelatedChipCloud.ts
+++ b/src/parser/classes/RelatedChipCloud.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { YTNode } from '../helpers.js';
 
 export default class RelatedChipCloud extends YTNode {

--- a/src/parser/classes/RichGrid.ts
+++ b/src/parser/classes/RichGrid.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class RichGrid extends YTNode {

--- a/src/parser/classes/RichItem.ts
+++ b/src/parser/classes/RichItem.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { YTNode } from '../helpers.js';
 
 export default class RichItem extends YTNode {

--- a/src/parser/classes/RichMetadataRow.ts
+++ b/src/parser/classes/RichMetadataRow.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class RichMetadataRow extends YTNode {

--- a/src/parser/classes/RichSection.ts
+++ b/src/parser/classes/RichSection.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class RichSection extends YTNode {
   static type = 'RichSection';

--- a/src/parser/classes/RichShelf.ts
+++ b/src/parser/classes/RichShelf.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/SearchBox.ts
+++ b/src/parser/classes/SearchBox.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/SearchSubMenu.ts
+++ b/src/parser/classes/SearchSubMenu.ts
@@ -1,6 +1,6 @@
 import { type ObservedArray, YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Text from './misc/Text.js';
 import SearchFilterGroup from './SearchFilterGroup.js';
 import ToggleButton from './ToggleButton.js';

--- a/src/parser/classes/SearchSuggestionsSection.ts
+++ b/src/parser/classes/SearchSuggestionsSection.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class SearchSuggestionsSection extends YTNode {

--- a/src/parser/classes/SecondarySearchContainer.ts
+++ b/src/parser/classes/SecondarySearchContainer.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 
 export default class SecondarySearchContainer extends YTNode {

--- a/src/parser/classes/SectionList.ts
+++ b/src/parser/classes/SectionList.ts
@@ -1,5 +1,5 @@
 import { type ObservedArray, YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class SectionList extends YTNode {
   static type = 'SectionList';

--- a/src/parser/classes/SegmentedLikeDislikeButton.ts
+++ b/src/parser/classes/SegmentedLikeDislikeButton.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Button from './Button.js';
 import ToggleButton from './ToggleButton.js';
 

--- a/src/parser/classes/SettingsOptions.ts
+++ b/src/parser/classes/SettingsOptions.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import ChannelOptions from './ChannelOptions.js';
 import CopyLink from './CopyLink.js';
 import Dropdown from './Dropdown.js';

--- a/src/parser/classes/SettingsSidebar.ts
+++ b/src/parser/classes/SettingsSidebar.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import CompactLink from './CompactLink.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/Shelf.ts
+++ b/src/parser/classes/Shelf.ts
@@ -1,5 +1,5 @@
 import Text from './misc/Text.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import { YTNode } from '../helpers.js';
 import Button from './Button.js';

--- a/src/parser/classes/SingleColumnBrowseResults.ts
+++ b/src/parser/classes/SingleColumnBrowseResults.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Tab from './Tab.js';
 
 export default class SingleColumnBrowseResults extends YTNode {

--- a/src/parser/classes/SingleColumnMusicWatchNextResults.ts
+++ b/src/parser/classes/SingleColumnMusicWatchNextResults.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class SingleColumnMusicWatchNextResults extends YTNode {
   static type = 'SingleColumnMusicWatchNextResults';

--- a/src/parser/classes/SlimOwner.ts
+++ b/src/parser/classes/SlimOwner.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import SubscribeButton from './SubscribeButton.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/SlimVideoMetadata.ts
+++ b/src/parser/classes/SlimVideoMetadata.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 
 export default class SlimVideoMetadata extends YTNode {

--- a/src/parser/classes/StructuredDescriptionContent.ts
+++ b/src/parser/classes/StructuredDescriptionContent.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import ExpandableVideoDescriptionBody from './ExpandableVideoDescriptionBody.js';
 import HorizontalCardList from './HorizontalCardList.js';
 import VideoDescriptionHeader from './VideoDescriptionHeader.js';

--- a/src/parser/classes/SubFeedSelector.ts
+++ b/src/parser/classes/SubFeedSelector.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 import SubFeedOption from './SubFeedOption.js';

--- a/src/parser/classes/SubscribeButton.ts
+++ b/src/parser/classes/SubscribeButton.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import SubscriptionNotificationToggleButton from './SubscriptionNotificationToggleButton.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/SubscriptionNotificationToggleButton.ts
+++ b/src/parser/classes/SubscriptionNotificationToggleButton.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type SuperParsedResult, YTNode } from '../helpers.js';
 
 export default class SubscriptionNotificationToggleButton extends YTNode {

--- a/src/parser/classes/Tab.ts
+++ b/src/parser/classes/Tab.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import SectionList from './SectionList.js';
 import MusicQueue from './MusicQueue.js';

--- a/src/parser/classes/Tabbed.ts
+++ b/src/parser/classes/Tabbed.ts
@@ -1,5 +1,5 @@
 import { YTNode, type SuperParsedResult } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class Tabbed extends YTNode {
   static type = 'Tabbed';

--- a/src/parser/classes/TabbedSearchResults.ts
+++ b/src/parser/classes/TabbedSearchResults.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { type ObservedArray, YTNode } from '../helpers.js';
 import Tab from './Tab.js';
 

--- a/src/parser/classes/TopicChannelDetails.ts
+++ b/src/parser/classes/TopicChannelDetails.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import SubscribeButton from './SubscribeButton.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/Transcript.ts
+++ b/src/parser/classes/Transcript.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import TranscriptSearchPanel from './TranscriptSearchPanel.js';
 
 export default class Transcript extends YTNode {

--- a/src/parser/classes/TranscriptFooter.ts
+++ b/src/parser/classes/TranscriptFooter.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import SortFilterSubMenu from './SortFilterSubMenu.js';
 
 export default class TranscriptFooter extends YTNode {

--- a/src/parser/classes/TranscriptSearchBox.ts
+++ b/src/parser/classes/TranscriptSearchBox.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Button from './Button.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import { Text } from '../misc.js';

--- a/src/parser/classes/TranscriptSearchPanel.ts
+++ b/src/parser/classes/TranscriptSearchPanel.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import TranscriptFooter from './TranscriptFooter.js';
 import TranscriptSearchBox from './TranscriptSearchBox.js';
 import TranscriptSegmentList from './TranscriptSegmentList.js';

--- a/src/parser/classes/TranscriptSegmentList.ts
+++ b/src/parser/classes/TranscriptSegmentList.ts
@@ -1,7 +1,7 @@
 import type { ObservedArray } from '../helpers.js';
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import { Text } from '../misc.js';
 import TranscriptSectionHeader from './TranscriptSectionHeader.js';
 import TranscriptSegment from './TranscriptSegment.js';

--- a/src/parser/classes/TwoColumnBrowseResults.ts
+++ b/src/parser/classes/TwoColumnBrowseResults.ts
@@ -1,5 +1,5 @@
 import { YTNode, type SuperParsedResult } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class TwoColumnBrowseResults extends YTNode {
   static type = 'TwoColumnBrowseResults';

--- a/src/parser/classes/TwoColumnSearchResults.ts
+++ b/src/parser/classes/TwoColumnSearchResults.ts
@@ -1,5 +1,5 @@
 import { YTNode, type SuperParsedResult } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class TwoColumnSearchResults extends YTNode {
   static type = 'TwoColumnSearchResults';

--- a/src/parser/classes/TwoColumnWatchNextResults.ts
+++ b/src/parser/classes/TwoColumnWatchNextResults.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Menu from './menus/Menu.js';
 import Author from './misc/Author.js';

--- a/src/parser/classes/UniversalWatchCard.ts
+++ b/src/parser/classes/UniversalWatchCard.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 
 export default class UniversalWatchCard extends YTNode {

--- a/src/parser/classes/UploadTimeFactoid.ts
+++ b/src/parser/classes/UploadTimeFactoid.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Factoid from './Factoid.js';
 
 export default class UploadTimeFactoid extends YTNode {

--- a/src/parser/classes/UpsellDialog.ts
+++ b/src/parser/classes/UpsellDialog.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/VerticalList.ts
+++ b/src/parser/classes/VerticalList.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 
 export default class VerticalList extends YTNode {

--- a/src/parser/classes/VerticalWatchCardList.ts
+++ b/src/parser/classes/VerticalWatchCardList.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/Video.ts
+++ b/src/parser/classes/Video.ts
@@ -1,6 +1,6 @@
 import { timeToSeconds } from '../../utils/Utils.js';
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import ExpandableMetadata from './ExpandableMetadata.js';
 import MetadataBadge from './MetadataBadge.js';
 import NavigationEndpoint from './NavigationEndpoint.js';

--- a/src/parser/classes/VideoDescriptionCourseSection.ts
+++ b/src/parser/classes/VideoDescriptionCourseSection.ts
@@ -1,7 +1,7 @@
 import type { ObservedArray} from '../helpers.js';
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import StructuredDescriptionPlaylistLockup from './StructuredDescriptionPlaylistLockup.js';
 import Text from './misc/Text.js';
 

--- a/src/parser/classes/VideoDescriptionHeader.ts
+++ b/src/parser/classes/VideoDescriptionHeader.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { Text, Thumbnail } from '../misc.js';
 import Factoid from './Factoid.js';
 import NavigationEndpoint from './NavigationEndpoint.js';

--- a/src/parser/classes/VideoDescriptionInfocardsSection.ts
+++ b/src/parser/classes/VideoDescriptionInfocardsSection.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 import { YTNode } from '../helpers.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/VideoDescriptionMusicSection.ts
+++ b/src/parser/classes/VideoDescriptionMusicSection.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import { Text } from '../misc.js';
 import CarouselLockup from './CarouselLockup.js';
 

--- a/src/parser/classes/VideoDescriptionTranscriptSection.ts
+++ b/src/parser/classes/VideoDescriptionTranscriptSection.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import { Text } from '../misc.js';
 import Button from './Button.js';
 

--- a/src/parser/classes/VideoPrimaryInfo.ts
+++ b/src/parser/classes/VideoPrimaryInfo.ts
@@ -1,7 +1,7 @@
 import type { ObservedArray } from '../helpers.js';
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import MetadataBadge from './MetadataBadge.js';
 import Menu from './menus/Menu.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/VideoSecondaryInfo.ts
+++ b/src/parser/classes/VideoSecondaryInfo.ts
@@ -1,4 +1,4 @@
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
 import Button from './Button.js';
 import VideoOwner from './VideoOwner.js';

--- a/src/parser/classes/ViewCountFactoid.ts
+++ b/src/parser/classes/ViewCountFactoid.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Factoid from './Factoid.js';
 
 export default class ViewCountFactoid extends YTNode {

--- a/src/parser/classes/WatchCardHeroVideo.ts
+++ b/src/parser/classes/WatchCardHeroVideo.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
 
 export default class WatchCardHeroVideo extends YTNode {

--- a/src/parser/classes/WatchCardSectionSequence.ts
+++ b/src/parser/classes/WatchCardSectionSequence.ts
@@ -1,6 +1,6 @@
 import type { ObservedArray} from '../helpers.js';
 import { YTNode } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 
 export default class WatchCardSectionSequence extends YTNode {
   static type = 'WatchCardSectionSequence';

--- a/src/parser/classes/WatchNextEndScreen.ts
+++ b/src/parser/classes/WatchNextEndScreen.ts
@@ -1,5 +1,5 @@
 import { YTNode, type ObservedArray } from '../helpers.js';
-import Parser, { type RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
 import EndScreenPlaylist from './EndScreenPlaylist.js';
 import EndScreenVideo from './EndScreenVideo.js';
 import Text from './misc/Text.js';

--- a/src/parser/classes/actions/AppendContinuationItemsAction.ts
+++ b/src/parser/classes/actions/AppendContinuationItemsAction.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import type { RawNode } from '../../index.js';
 import type { ObservedArray } from '../../helpers.js';
 import { YTNode } from '../../helpers.js';

--- a/src/parser/classes/actions/OpenPopupAction.ts
+++ b/src/parser/classes/actions/OpenPopupAction.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
 

--- a/src/parser/classes/actions/UpdateEngagementPanelAction.ts
+++ b/src/parser/classes/actions/UpdateEngagementPanelAction.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Transcript from '../Transcript.js';
 
 export default class UpdateEngagementPanelAction extends YTNode {

--- a/src/parser/classes/comments/Comment.ts
+++ b/src/parser/classes/comments/Comment.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 
 import Author from '../misc/Author.js';
 import Text from '../misc/Text.js';

--- a/src/parser/classes/comments/CommentActionButtons.ts
+++ b/src/parser/classes/comments/CommentActionButtons.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Button from '../Button.js';
 import ToggleButton from '../ToggleButton.js';
 import CreatorHeart from './CreatorHeart.js';

--- a/src/parser/classes/comments/CommentDialog.ts
+++ b/src/parser/classes/comments/CommentDialog.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Button from '../Button.js';
 import Text from '../misc/Text.js';
 import Thumbnail from '../misc/Thumbnail.js';

--- a/src/parser/classes/comments/CommentReplies.ts
+++ b/src/parser/classes/comments/CommentReplies.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Button from '../Button.js';
 import Thumbnail from '../misc/Thumbnail.js';
 

--- a/src/parser/classes/comments/CommentReplyDialog.ts
+++ b/src/parser/classes/comments/CommentReplyDialog.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Button from '../Button.js';
 import Text from '../misc/Text.js';
 import Thumbnail from '../misc/Thumbnail.js';

--- a/src/parser/classes/comments/CommentSimplebox.ts
+++ b/src/parser/classes/comments/CommentSimplebox.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Button from '../Button.js';
 import Text from '../misc/Text.js';
 import Thumbnail from '../misc/Thumbnail.js';

--- a/src/parser/classes/comments/CommentThread.ts
+++ b/src/parser/classes/comments/CommentThread.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Button from '../Button.js';
 import ContinuationItem from '../ContinuationItem.js';
 import Comment from './Comment.js';

--- a/src/parser/classes/comments/CommentsHeader.ts
+++ b/src/parser/classes/comments/CommentsHeader.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import SortFilterSubMenu from '../SortFilterSubMenu.js';
 import Text from '../misc/Text.js';
 import Thumbnail from '../misc/Thumbnail.js';

--- a/src/parser/classes/comments/EmojiPicker.ts
+++ b/src/parser/classes/comments/EmojiPicker.ts
@@ -1,6 +1,6 @@
 import { type ObservedArray, YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Text from '../misc/Text.js';
 
 export default class EmojiPicker extends YTNode {

--- a/src/parser/classes/livechat/AddBannerToLiveChatCommand.ts
+++ b/src/parser/classes/livechat/AddBannerToLiveChatCommand.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import LiveChatBanner from './items/LiveChatBanner.js';
 
 export default class AddBannerToLiveChatCommand extends YTNode {

--- a/src/parser/classes/livechat/AddChatItemAction.ts
+++ b/src/parser/classes/livechat/AddChatItemAction.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
 

--- a/src/parser/classes/livechat/AddLiveChatTickerItemAction.ts
+++ b/src/parser/classes/livechat/AddLiveChatTickerItemAction.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
 

--- a/src/parser/classes/livechat/LiveChatActionPanel.ts
+++ b/src/parser/classes/livechat/LiveChatActionPanel.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import { type SuperParsedResult, YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
 

--- a/src/parser/classes/livechat/ReplaceChatItemAction.ts
+++ b/src/parser/classes/livechat/ReplaceChatItemAction.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
 

--- a/src/parser/classes/livechat/ReplayChatItemAction.ts
+++ b/src/parser/classes/livechat/ReplayChatItemAction.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import { type ObservedArray, YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
 

--- a/src/parser/classes/livechat/ShowLiveChatActionPanelAction.ts
+++ b/src/parser/classes/livechat/ShowLiveChatActionPanelAction.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import LiveChatActionPanel from './LiveChatActionPanel.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';

--- a/src/parser/classes/livechat/ShowLiveChatDialogAction.ts
+++ b/src/parser/classes/livechat/ShowLiveChatDialogAction.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
 

--- a/src/parser/classes/livechat/ShowLiveChatTooltipCommand.ts
+++ b/src/parser/classes/livechat/ShowLiveChatTooltipCommand.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
 

--- a/src/parser/classes/livechat/UpdateLiveChatPollAction.ts
+++ b/src/parser/classes/livechat/UpdateLiveChatPollAction.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
 

--- a/src/parser/classes/livechat/items/LiveChatAutoModMessage.ts
+++ b/src/parser/classes/livechat/items/LiveChatAutoModMessage.ts
@@ -1,4 +1,4 @@
-import Parser from '../../../index.js';
+import { Parser } from '../../../index.js';
 import Button from '../../Button.js';
 import NavigationEndpoint from '../../NavigationEndpoint.js';
 import Text from '../../misc/Text.js';

--- a/src/parser/classes/livechat/items/LiveChatBanner.ts
+++ b/src/parser/classes/livechat/items/LiveChatBanner.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../../../helpers.js';
 import type { RawNode } from '../../../index.js';
-import Parser from '../../../index.js';
+import { Parser } from '../../../index.js';
 import LiveChatBannerHeader from './LiveChatBannerHeader.js';
 
 export default class LiveChatBanner extends YTNode {

--- a/src/parser/classes/livechat/items/LiveChatBannerHeader.ts
+++ b/src/parser/classes/livechat/items/LiveChatBannerHeader.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../../../helpers.js';
 import type { RawNode } from '../../../index.js';
-import Parser from '../../../index.js';
+import { Parser } from '../../../index.js';
 import Button from '../../Button.js';
 import Text from '../../misc/Text.js';
 

--- a/src/parser/classes/livechat/items/LiveChatBannerPoll.ts
+++ b/src/parser/classes/livechat/items/LiveChatBannerPoll.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../../../helpers.js';
 import type { RawNode } from '../../../index.js';
-import Parser from '../../../index.js';
+import { Parser } from '../../../index.js';
 import Button from '../../Button.js';
 import Text from '../../misc/Text.js';
 import Thumbnail from '../../misc/Thumbnail.js';

--- a/src/parser/classes/livechat/items/LiveChatProductItem.ts
+++ b/src/parser/classes/livechat/items/LiveChatProductItem.ts
@@ -1,4 +1,4 @@
-import Parser from '../../../index.js';
+import { Parser } from '../../../index.js';
 import { YTNode } from '../../../helpers.js';
 import type { RawNode } from '../../../index.js';
 

--- a/src/parser/classes/livechat/items/LiveChatTextMessage.ts
+++ b/src/parser/classes/livechat/items/LiveChatTextMessage.ts
@@ -1,6 +1,6 @@
 import { type ObservedArray, YTNode } from '../../../helpers.js';
 import type { RawNode } from '../../../index.js';
-import Parser from '../../../index.js';
+import { Parser } from '../../../index.js';
 import Button from '../../Button.js';
 import NavigationEndpoint from '../../NavigationEndpoint.js';
 import Author from '../../misc/Author.js';

--- a/src/parser/classes/livechat/items/LiveChatTickerPaidMessageItem.ts
+++ b/src/parser/classes/livechat/items/LiveChatTickerPaidMessageItem.ts
@@ -1,5 +1,5 @@
 import Author from '../../misc/Author.js';
-import Parser from '../../../index.js';
+import { Parser } from '../../../index.js';
 import NavigationEndpoint from '../../NavigationEndpoint.js';
 import Text from '../../misc/Text.js';
 

--- a/src/parser/classes/livechat/items/LiveChatViewerEngagementMessage.ts
+++ b/src/parser/classes/livechat/items/LiveChatViewerEngagementMessage.ts
@@ -1,4 +1,4 @@
-import Parser from '../../../index.js';
+import { Parser } from '../../../index.js';
 import { LiveChatMessageBase } from './LiveChatTextMessage.js';
 import type { RawNode } from '../../../index.js';
 import type { YTNode } from '../../../helpers.js';

--- a/src/parser/classes/livechat/items/PollHeader.ts
+++ b/src/parser/classes/livechat/items/PollHeader.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../../../helpers.js';
 import type { RawNode } from '../../../index.js';
-import Parser from '../../../index.js';
+import { Parser } from '../../../index.js';
 import Button from '../../Button.js';
 import Text from '../../misc/Text.js';
 import Thumbnail from '../../misc/Thumbnail.js';

--- a/src/parser/classes/menus/Menu.ts
+++ b/src/parser/classes/menus/Menu.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import type { ObservedArray} from '../../helpers.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';

--- a/src/parser/classes/menus/MenuPopup.ts
+++ b/src/parser/classes/menus/MenuPopup.ts
@@ -1,7 +1,7 @@
 import type { ObservedArray} from '../../helpers.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import MenuNavigationItem from './MenuNavigationItem.js';
 import MenuServiceItem from './MenuServiceItem.js';
 

--- a/src/parser/classes/menus/MultiPageMenu.ts
+++ b/src/parser/classes/menus/MultiPageMenu.ts
@@ -1,6 +1,6 @@
 import { YTNode, type SuperParsedResult } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 
 export default class MultiPageMenu extends YTNode {
   static type = 'MultiPageMenu';

--- a/src/parser/classes/menus/MultiPageMenuNotificationSection.ts
+++ b/src/parser/classes/menus/MultiPageMenuNotificationSection.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import { type SuperParsedResult, YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
 

--- a/src/parser/classes/menus/MusicMultiSelectMenu.ts
+++ b/src/parser/classes/menus/MusicMultiSelectMenu.ts
@@ -1,7 +1,7 @@
 import type { ObservedArray} from '../../helpers.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Text from '../misc/Text.js';
 import MusicMenuItemDivider from './MusicMenuItemDivider.js';
 import MusicMultiSelectMenuItem from './MusicMultiSelectMenuItem.js';

--- a/src/parser/classes/menus/SimpleMenuHeader.ts
+++ b/src/parser/classes/menus/SimpleMenuHeader.ts
@@ -1,7 +1,7 @@
 import type { SuperParsedResult} from '../../helpers.js';
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Text from '../misc/Text.js';
 
 export default class SimpleMenuHeader extends YTNode {

--- a/src/parser/classes/misc/Author.ts
+++ b/src/parser/classes/misc/Author.ts
@@ -1,7 +1,7 @@
 import * as Constants from '../../../utils/Constants.js';
 import type { YTNode} from '../../helpers.js';
 import { observe, type ObservedArray } from '../../helpers.js';
-import Parser, { type RawNode } from '../../index.js';
+import { Parser, type RawNode } from '../../index.js';
 import type NavigationEndpoint from '../NavigationEndpoint.js';
 import Text from './Text.js';
 import type TextRun from './TextRun.js';

--- a/src/parser/classes/ytkids/AnchoredSection.ts
+++ b/src/parser/classes/ytkids/AnchoredSection.ts
@@ -1,6 +1,6 @@
 import { YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import NavigationEndpoint from '../NavigationEndpoint.js';
 import SectionList from '../SectionList.js';
 

--- a/src/parser/classes/ytkids/KidsBlocklistPicker.ts
+++ b/src/parser/classes/ytkids/KidsBlocklistPicker.ts
@@ -1,7 +1,7 @@
 import Text from '../misc/Text.js';
 import { YTNode } from '../../helpers.js';
 import Button from '../Button.js';
-import Parser, { type RawNode } from '../../index.js';
+import { Parser, type RawNode } from '../../index.js';
 import KidsBlocklistPickerItem from './KidsBlocklistPickerItem.js';
 
 export default class KidsBlocklistPicker extends YTNode {

--- a/src/parser/classes/ytkids/KidsBlocklistPickerItem.ts
+++ b/src/parser/classes/ytkids/KidsBlocklistPickerItem.ts
@@ -1,6 +1,6 @@
 import Text from '../misc/Text.js';
 import { YTNode } from '../../helpers.js';
-import Parser, { type RawNode } from '../../index.js';
+import { Parser, type RawNode } from '../../index.js';
 import ToggleButton from '../ToggleButton.js';
 import Thumbnail from '../misc/Thumbnail.js';
 import type Actions from '../../../core/Actions.js';

--- a/src/parser/classes/ytkids/KidsCategoriesHeader.ts
+++ b/src/parser/classes/ytkids/KidsCategoriesHeader.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import Button from '../Button.js';
 import KidsCategoryTab from './KidsCategoryTab.js';
 import { type ObservedArray, YTNode } from '../../helpers.js';

--- a/src/parser/classes/ytkids/KidsHomeScreen.ts
+++ b/src/parser/classes/ytkids/KidsHomeScreen.ts
@@ -1,4 +1,4 @@
-import Parser from '../../index.js';
+import { Parser } from '../../index.js';
 import AnchoredSection from './AnchoredSection.js';
 import { type ObservedArray, YTNode } from '../../helpers.js';
 import type { RawNode } from '../../index.js';

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -8,5 +8,3 @@ export * as YTMusic from './ytmusic/index.js';
 export * as YTKids from './ytkids/index.js';
 export * as Helpers from './helpers.js';
 export * as Generator from './generator.js';
-import * as Parser from './parser.js';
-export default Parser;

--- a/src/parser/youtube/AccountInfo.ts
+++ b/src/parser/youtube/AccountInfo.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import type { ApiResponse } from '../../core/Actions.js';
 import type { IParsedResponse } from '../types/ParsedResponse.js';
 

--- a/src/parser/youtube/Analytics.ts
+++ b/src/parser/youtube/Analytics.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Element from '../classes/Element.js';
 import type { ApiResponse } from '../../core/Actions.js';
 import type { IBrowseResponse } from '../types/ParsedResponse.js';

--- a/src/parser/youtube/Comments.ts
+++ b/src/parser/youtube/Comments.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import type Actions from '../../core/Actions.js';
 import type { ApiResponse } from '../../core/Actions.js';
 import { InnertubeError } from '../../utils/Utils.js';

--- a/src/parser/youtube/LiveChat.ts
+++ b/src/parser/youtube/LiveChat.ts
@@ -1,5 +1,5 @@
 import EventEmitter from '../../utils/EventEmitterLike.js';
-import Parser, { LiveChatContinuation } from '../index.js';
+import { Parser, LiveChatContinuation } from '../index.js';
 import type VideoInfo from './VideoInfo.js';
 import SmoothedQueue from './SmoothedQueue.js';
 

--- a/src/parser/youtube/NotificationsMenu.ts
+++ b/src/parser/youtube/NotificationsMenu.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 
 import ContinuationItem from '../classes/ContinuationItem.js';
 import SimpleMenuHeader from '../classes/menus/SimpleMenuHeader.js';

--- a/src/parser/youtube/Settings.ts
+++ b/src/parser/youtube/Settings.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import { InnertubeError } from '../../utils/Utils.js';
 
 import CompactLink from '../classes/CompactLink.js';

--- a/src/parser/youtube/TimeWatched.ts
+++ b/src/parser/youtube/TimeWatched.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import ItemSection from '../classes/ItemSection.js';
 import SectionList from '../classes/SectionList.js';
 import SingleColumnBrowseResults from '../classes/SingleColumnBrowseResults.js';

--- a/src/parser/youtube/TranscriptInfo.ts
+++ b/src/parser/youtube/TranscriptInfo.ts
@@ -1,7 +1,7 @@
 import type Actions from '../../core/Actions.js';
 import { type ApiResponse } from '../../core/Actions.js';
 import type { IGetTranscriptResponse } from '../index.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import Transcript from '../classes/Transcript.js';
 
 export default class TranscriptInfo {

--- a/src/parser/ytmusic/Album.ts
+++ b/src/parser/ytmusic/Album.ts
@@ -1,6 +1,6 @@
 import type { ApiResponse } from '../../core/Actions.js';
 import type { ObservedArray } from '../helpers.js';
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 
 import MicroformatData from '../classes/MicroformatData.js';
 import MusicCarouselShelf from '../classes/MusicCarouselShelf.js';

--- a/src/parser/ytmusic/Artist.ts
+++ b/src/parser/ytmusic/Artist.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import type Actions from '../../core/Actions.js';
 import type { ApiResponse } from '../../core/Actions.js';
 import { InnertubeError } from '../../utils/Utils.js';

--- a/src/parser/ytmusic/Explore.ts
+++ b/src/parser/ytmusic/Explore.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 
 import Grid from '../classes/Grid.js';
 import MusicCarouselShelf from '../classes/MusicCarouselShelf.js';

--- a/src/parser/ytmusic/HomeFeed.ts
+++ b/src/parser/ytmusic/HomeFeed.ts
@@ -1,4 +1,4 @@
-import Parser, { SectionListContinuation } from '../index.js';
+import { Parser, SectionListContinuation } from '../index.js';
 import MusicCarouselShelf from '../classes/MusicCarouselShelf.js';
 import SectionList from '../classes/SectionList.js';
 import SingleColumnBrowseResults from '../classes/SingleColumnBrowseResults.js';

--- a/src/parser/ytmusic/Library.ts
+++ b/src/parser/ytmusic/Library.ts
@@ -1,4 +1,4 @@
-import Parser, { GridContinuation, MusicShelfContinuation, SectionListContinuation } from '../index.js';
+import { Parser, GridContinuation, MusicShelfContinuation, SectionListContinuation } from '../index.js';
 import type Actions from '../../core/Actions.js';
 import type { ApiResponse } from '../../core/Actions.js';
 

--- a/src/parser/ytmusic/Playlist.ts
+++ b/src/parser/ytmusic/Playlist.ts
@@ -1,4 +1,4 @@
-import Parser, { MusicPlaylistShelfContinuation, SectionListContinuation } from '../index.js';
+import { Parser, MusicPlaylistShelfContinuation, SectionListContinuation } from '../index.js';
 
 import MusicCarouselShelf from '../classes/MusicCarouselShelf.js';
 import MusicDetailHeader from '../classes/MusicDetailHeader.js';

--- a/src/parser/ytmusic/Recap.ts
+++ b/src/parser/ytmusic/Recap.ts
@@ -1,4 +1,4 @@
-import Parser from '../index.js';
+import { Parser } from '../index.js';
 import type Actions from '../../core/Actions.js';
 import type { ApiResponse } from '../../core/Actions.js';
 

--- a/src/parser/ytmusic/Search.ts
+++ b/src/parser/ytmusic/Search.ts
@@ -1,6 +1,6 @@
 import type Actions from '../../core/Actions.js';
 import { InnertubeError } from '../../utils/Utils.js';
-import Parser, { MusicShelfContinuation } from '../index.js';
+import { Parser, MusicShelfContinuation } from '../index.js';
 
 import ChipCloud from '../classes/ChipCloud.js';
 import ChipCloudChip from '../classes/ChipCloudChip.js';

--- a/src/platform/lib.ts
+++ b/src/platform/lib.ts
@@ -2,7 +2,6 @@ import Innertube from '../Innertube.js';
 
 export * from '../core/index.js';
 export * from '../parser/index.js';
-export { default as Parser } from '../parser/index.js';
 export * as Proto from '../proto/index.js';
 export * as Types from '../types/index.js';
 export * from '../utils/index.js';


### PR DESCRIPTION
Currently YouTube.js uses a default export to export the Parser functions and the imports that default export, instead of the namespace export/import. Why is that a problem? Because namespace imports are special, the object they give you is special and known as a "module namespace object" (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#module_namespace_object), which gets treated specially by bundlers, but because we are exporting said object with `default` we are telling the bundler we want it to be treated as a normal object instead. The result is larger bundles and potentially slower code as you are calling functions on an object, instead of calling the function directly.

These changes have a very minimal impact on the bundles provided by YouTube.js because of an esbuild limitation (it doesn't handle re-exported namespaces well, see: https://github.com/evanw/esbuild/issues/1420) but for anyone using deno, ES modules on node or the web export, will benefit from it, FreeTube for example saves `4337` bytes. This will also help anyone importing the `Parser` from YouTube.js and using it in their own code, as they'll get the direct function referencing benefits too.

YouTube.js bundles size changes:
| File | Decrease |
| --- | --- |
| `browser.js` | `-66` bytes |
| `browser.js.map` | `-50` bytes |
| `browser.min.js` | `-41` bytes |
| `browser.min.js.map` | `-85` bytes |
| `node.cjs` | `-66` bytes |
| `node.cjs.map` | `-52` bytes |

So what exactly happens in FreeTube that it shaves off `4337` bytes. The screenshots below were taken with terser-webpack-plugin, patched to set terser's deprecated beautify option to true, the size measurements were taken without that modification. You may want to click on the screenshots to open them in a new tab, so that you can see them bigger.

As we can see on this screenshot, instead of parseResponse being referenced/called directly, it is called on an object `PD`.
![before](https://github.com/LuanRT/YouTube.js/assets/48293849/5a2025af-829e-4fbe-9032-d21b377b2911)
If we look at what `PD` is, it's just a variable assignment so a bit boring, but `e` is more interesting.
![before-variable](https://github.com/LuanRT/YouTube.js/assets/48293849/6c8862a4-fb69-417e-b265-7e2dd901844b)
Looks like `e` is an object containing named references referencing the actual parser functions. That's not what we want, but is what is caused by the default export and the use of it, we told the bundler that we don't care abou the module namespace object's special status, instead we want to use it as a normal object, so the bundler complies.
![before-barrel](https://github.com/LuanRT/YouTube.js/assets/48293849/89a091dc-fecd-4833-8426-18ebf9f8115f)

So how does the situation look afterwards? Well that object disappeared from the output and the parseResponse function is now directly referenced/called, in this case `_E`.
![after](https://github.com/LuanRT/YouTube.js/assets/48293849/4d6ec394-6223-4899-a6d6-33efa42e66a6)

While that might not seem like a big change, the parser function are used in a lot of places in YouTube.js (just look at how many files I had to modify for this change), so that smalll change adds up quickly.