### PR TITLE
feat(toDash): Add `contentType` to audio and video adaption sets

### DIFF
--- a/src/utils/DashManifest.tsx
+++ b/src/utils/DashManifest.tsx
@@ -97,6 +97,7 @@ function DashManifest({
             lang={set.language}
             codecs={set.codecs}
             audioSamplingRate={set.audio_sample_rate}
+            contentType="audio"
           >
             {
               set.track_role &&
@@ -150,6 +151,7 @@ function DashManifest({
             codecs={set.codecs}
             maxPlayoutRate="1"
             frameRate={set.fps}
+            contentType="video"
           >
             {
               set.color_info.primaries &&


### PR DESCRIPTION
Specifying the contentType attribute saves video players a little bit of work while parsing the DASH manifest, because they can read that attribute to get the type instead of having to guess it from the mime type and codec.

Relevant lines in shaka-player:
https://github.com/shaka-project/shaka-player/blob/2a524bf51fc613b8ebddb5794524cbb3f6366d4b/lib/dash/dash_parser.js#L1311-L1326