### PR TITLE
fix(Channel)!: Remove `getChannels()` and `has_channels`, as YouTube removed the tab

### DIFF
--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -185,11 +185,6 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
     return new Channel(this.actions, tab.page, true);
   }
 
-  async getChannels(): Promise<Channel> {
-    const tab = await this.getTabByURL('channels');
-    return new Channel(this.actions, tab.page, true);
-  }
-
   /**
    * Retrieves the about page.
    * Note that this does not return a new {@link Channel} object.
@@ -243,10 +238,6 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
 
   get has_community(): boolean {
     return this.hasTabWithURL('community');
-  }
-
-  get has_channels(): boolean {
-    return this.hasTabWithURL('channels');
   }
 
   get has_about(): boolean {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -208,14 +208,6 @@ describe('YouTube.js Tests', () => {
         expect(community.posts.length).toBeGreaterThan(0);
       });
 
-      test('Channel#getChannels', async () => {
-        const channels = await channel.getChannels();
-        expect(channels).toBeDefined();
-        expect(channels.current_tab).toBeDefined();
-        expect(channels.current_tab?.content).toBeDefined();
-        expect(channels.channels.length).toBeGreaterThan(0);
-      });
-
       test('Channel#getAbout', async () => {
         const about = await channel.getAbout();
         expect(about).toBeDefined();


### PR DESCRIPTION
YouTube removed the "Channels" tab on channels, so this pull request removes the `getChannels()` method and `has_channels`
getter from the `YT.Channel` class, as they are no longer useful. The featured channels are now shown on the channel home tab. To get them you can use the `channels` getter on the home tab of the channel. Please note that some channel owners might not have added that section to their home page yet, so you won't be able to get the featured channels for those channels. The home tab is the default tab that is returned when you call `InnerTube#getChannel()`, you can also access that tab by calling `getHome()` on a `YT.Channel` object.