### PR TITLE
fix(generator): Output Parser.parseItem() calls with one valid type, without the array

### DIFF
--- a/src/parser/generator.ts
+++ b/src/parser/generator.ts
@@ -448,12 +448,12 @@ export function toParser(key: string, inference_type: InferenceType, key_path: s
   switch (inference_type.type) {
     case 'renderer':
       {
-        parser = `Parser.parseItem(${key_path.join('.')}.${key}, [ ${inference_type.renderers.map((type) => `YTNodes.${type}`).join(', ')} ])`;
+        parser = `Parser.parseItem(${key_path.join('.')}.${key}, ${toParserValidTypes(inference_type.renderers)})`;
       }
       break;
     case 'renderer_list':
       {
-        parser = `Parser.parse(${key_path.join('.')}.${key}, true, [ ${inference_type.renderers.map((type) => `YTNodes.${type}`).join(', ')} ])`;
+        parser = `Parser.parse(${key_path.join('.')}.${key}, true, ${toParserValidTypes(inference_type.renderers)})`;
       }
       break;
     case 'object':
@@ -489,6 +489,14 @@ export function toParser(key: string, inference_type: InferenceType, key_path: s
   if (inference_type.optional)
     return `Reflect.has(${key_path.join('.')}, '${key}') ? ${parser} : undefined`;
   return parser;
+}
+
+function toParserValidTypes(types: string[]) {
+  if (types.length === 1) {
+    return `YTNodes.${types[0]}`;
+  }
+
+  return `[ ${types.map((type) => `YTNodes.${type}`).join(', ')} ]`;
 }
 
 function accessDataFromKeyPath(root: any, key_path: string[]) {


### PR DESCRIPTION
When there is only one valid type being passed to `Parser.parseItem` or `Parser.parse`, it can be passed directly without being wrapped in an array, this pull request changes the generated output to only use an array when it is needed.

```js
// before
this.abc = Parser.parseItem(data.abc, [ YTNodes.AbcView ])
this.abc2 = Parser.parseItem(data.abc2, [ YTNodes.AbcView, YTNodes.AbcdView ])

// afterwards
this.abc = Parser.parseItem(data.abc, YTNodes.AbcView)
this.abc2 = Parser.parseItem(data.abc2, [ YTNodes.AbcView, YTNodes.AbcdView ])
```