### PR TITLE
fix(Format): Extract correct audio language from captions

### DIFF
--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -105,11 +105,10 @@ class VideoInfo extends MediaInfo {
         // The combined formats only exist for the default language, even for videos with multiple audio tracks
         // So we can copy the language from the default audio track to the combined formats
         this.streaming_data.formats.forEach((format) => format.language = default_audio_track.language);
-      } else if (typeof this.captions?.default_audio_track_index !== 'undefined' && this.captions?.audio_tracks && this.captions.caption_tracks) {
+      } else if (this.captions?.caption_tracks && this.captions?.caption_tracks.length > 0) {
         // For videos with a single audio track and captions, we can use the captions to figure out the language of the audio and combined formats
-        const audioTrack = this.captions.audio_tracks[this.captions.default_audio_track_index];
-        const index = audioTrack.default_caption_track_index || 0;
-        const language_code = this.captions.caption_tracks[index].language_code;
+        const auto_generated_caption_track = this.captions.caption_tracks.find((caption) => caption.kind === 'asr');
+        const language_code = auto_generated_caption_track?.language_code;
 
         this.streaming_data.adaptive_formats.forEach((format) => {
           if (format.has_audio) {


### PR DESCRIPTION
Turns out the properties I was using before, are influenced by the language you request the page in and have nothing to do with the language of the audio. Instead we need to check the language of the auto-generated captions track, because that is generated in the language of the audio, yt-dlp does the same.

The video provided in https://github.com/LuanRT/YouTube.js/discussions/488 can be used to demonstrate the issue with the code below. It previously printed `en` but will correctly print `ru`, with this change. The video in question is in Russion, but because it has an English caption track and we requested the page in English, YouTube makes the English caption track the default.

```js
import { Innertube } from './dist/src/platform/node.js';

const session = await Innertube.create({ lang: 'en' })
const info = await session.getBasicInfo('ID7VkY6cMRQ')

console.log(info.streaming_data.formats[0].language)
```

This fixes bugs in these pull requests #470 and #445.