### PR TITLE
fix(proto): Fix visitor data base64url decoding

### DIFF
--- a/src/proto/index.ts
+++ b/src/proto/index.ts
@@ -22,7 +22,7 @@ export function encodeVisitorData(id: string, timestamp: number): string {
 }
 
 export function decodeVisitorData(visitor_data: string): VisitorData.Type {
-  const data = VisitorData.decodeBinary(base64ToU8(decodeURIComponent(visitor_data)));
+  const data = VisitorData.decodeBinary(base64ToU8(decodeURIComponent(visitor_data).replace(/-/g, '+').replace(/_/g, '/')));
   return data;
 }
 


### PR DESCRIPTION
Currently creating an Innertube instance with visitor data that contains an underscore throws an error. This pull request fixes that by properly decoding the base64url encoded value (the reverse of the operations we do for encoding).