### PR TITLE
feat(Channel): Support PageHeader being used on user channels

### DIFF
--- a/src/parser/classes/AttributionView.ts
+++ b/src/parser/classes/AttributionView.ts
@@ -2,15 +2,16 @@ import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
 import Text from './misc/Text.js';
 
-export default class DynamicTextView extends YTNode {
-  static type = 'DynamicTextView';
+export default class AttributionView extends YTNode {
+  static type = 'AttributionView';
 
   text: Text;
-  max_lines: number;
+  suffix: Text;
 
   constructor(data: RawNode) {
     super();
+
     this.text = Text.fromAttributed(data.text);
-    this.max_lines = parseInt(data.maxLines);
+    this.suffix = Text.fromAttributed(data.suffix);
   }
 }

--- a/src/parser/classes/DescriptionPreviewView.ts
+++ b/src/parser/classes/DescriptionPreviewView.ts
@@ -1,0 +1,21 @@
+import { YTNode } from '../helpers.js';
+import type { RawNode } from '../index.js';
+import Text from './misc/Text.js';
+
+export default class DescriptionPreviewView extends YTNode {
+  static type = 'DescriptionPreviewView';
+
+  description: Text;
+  max_lines: number;
+  truncation_text: Text;
+  always_show_truncation_text: boolean;
+
+  constructor(data: RawNode) {
+    super();
+
+    this.description = Text.fromAttributed(data.description);
+    this.max_lines = parseInt(data.maxLines);
+    this.truncation_text = Text.fromAttributed(data.truncationText);
+    this.always_show_truncation_text = !!data.alwaysShowTruncationText;
+  }
+}

--- a/src/parser/classes/ModalWithTitleAndButton.ts
+++ b/src/parser/classes/ModalWithTitleAndButton.ts
@@ -1,0 +1,19 @@
+import { YTNode } from '../helpers.js';
+import { Parser, type RawNode } from '../index.js';
+import Button from './Button.js';
+import Text from './misc/Text.js';
+
+export default class ModalWithTitleAndButton extends YTNode {
+  static type = 'ModalWithTitleAndButton';
+
+  title: Text;
+  content: Text;
+  button: Button | null;
+
+  constructor(data: RawNode) {
+    super();
+    this.title = new Text(data.title);
+    this.content = new Text(data.content);
+    this.button = Parser.parseItem(data.button, Button);
+  }
+}

--- a/src/parser/classes/NavigationEndpoint.ts
+++ b/src/parser/classes/NavigationEndpoint.ts
@@ -4,6 +4,7 @@ import { YTNode } from '../helpers.js';
 import { Parser, type RawNode } from '../index.js';
 import type { IParsedResponse } from '../types/ParsedResponse.js';
 import CreatePlaylistDialog from './CreatePlaylistDialog.js';
+import type ModalWithTitleAndButton from './ModalWithTitleAndButton.js';
 import OpenPopupAction from './actions/OpenPopupAction.js';
 
 export default class NavigationEndpoint extends YTNode {
@@ -11,7 +12,10 @@ export default class NavigationEndpoint extends YTNode {
 
   payload;
   dialog?: CreatePlaylistDialog | YTNode | null;
+  modal?: ModalWithTitleAndButton | YTNode | null;
   open_popup?: OpenPopupAction | null;
+
+  next_endpoint?: NavigationEndpoint;
 
   metadata: {
     url?: string;
@@ -41,6 +45,13 @@ export default class NavigationEndpoint extends YTNode {
       this.dialog = Parser.parseItem(this.payload.dialog || this.payload.content);
     }
 
+    if (Reflect.has(this.payload, 'modal')) {
+      this.modal = Parser.parseItem(this.payload.modal);
+    }
+
+    if (Reflect.has(this.payload, 'nextEndpoint')) {
+      this.next_endpoint = new NavigationEndpoint(this.payload.nextEndpoint);
+    }
 
     if (data?.serviceEndpoint) {
       data = data.serviceEndpoint;

--- a/src/parser/classes/PageHeaderView.ts
+++ b/src/parser/classes/PageHeaderView.ts
@@ -5,6 +5,8 @@ import ContentPreviewImageView from './ContentPreviewImageView.js';
 import DecoratedAvatarView from './DecoratedAvatarView.js';
 import DynamicTextView from './DynamicTextView.js';
 import FlexibleActionsView from './FlexibleActionsView.js';
+import DescriptionPreviewView from './DescriptionPreviewView.js';
+import AttributionView from './AttributionView.js';
 
 export default class PageHeaderView extends YTNode {
   static type = 'PageHeaderView';
@@ -13,6 +15,8 @@ export default class PageHeaderView extends YTNode {
   image: ContentPreviewImageView | DecoratedAvatarView | null;
   metadata: ContentMetadataView | null;
   actions: FlexibleActionsView | null;
+  description: DescriptionPreviewView | null;
+  attributation: AttributionView | null;
 
   constructor(data: RawNode) {
     super();
@@ -20,5 +24,7 @@ export default class PageHeaderView extends YTNode {
     this.image = Parser.parseItem(data.image, [ ContentPreviewImageView, DecoratedAvatarView ]);
     this.metadata = Parser.parseItem(data.metadata, ContentMetadataView);
     this.actions = Parser.parseItem(data.actions, FlexibleActionsView);
+    this.description = Parser.parseItem(data.description, DescriptionPreviewView);
+    this.attributation = Parser.parseItem(data.attributation, AttributionView);
   }
 }

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -20,6 +20,7 @@ export { default as AnalyticsVodCarouselCard } from './classes/analytics/Analyti
 export { default as CtaGoToCreatorStudio } from './classes/analytics/CtaGoToCreatorStudio.js';
 export { default as DataModelSection } from './classes/analytics/DataModelSection.js';
 export { default as StatRow } from './classes/analytics/StatRow.js';
+export { default as AttributionView } from './classes/AttributionView.js';
 export { default as AudioOnlyPlayability } from './classes/AudioOnlyPlayability.js';
 export { default as AutomixPreviewVideo } from './classes/AutomixPreviewVideo.js';
 export { default as AvatarView } from './classes/AvatarView.js';
@@ -97,6 +98,7 @@ export { default as CreatePlaylistDialog } from './classes/CreatePlaylistDialog.
 export { default as DecoratedAvatarView } from './classes/DecoratedAvatarView.js';
 export { default as DecoratedPlayerBar } from './classes/DecoratedPlayerBar.js';
 export { default as DefaultPromoPanel } from './classes/DefaultPromoPanel.js';
+export { default as DescriptionPreviewView } from './classes/DescriptionPreviewView.js';
 export { default as DidYouMean } from './classes/DidYouMean.js';
 export { default as DislikeButtonView } from './classes/DislikeButtonView.js';
 export { default as DownloadButton } from './classes/DownloadButton.js';
@@ -231,6 +233,7 @@ export { default as MetadataRowHeader } from './classes/MetadataRowHeader.js';
 export { default as MetadataScreen } from './classes/MetadataScreen.js';
 export { default as MicroformatData } from './classes/MicroformatData.js';
 export { default as Mix } from './classes/Mix.js';
+export { default as ModalWithTitleAndButton } from './classes/ModalWithTitleAndButton.js';
 export { default as Movie } from './classes/Movie.js';
 export { default as MovingThumbnail } from './classes/MovingThumbnail.js';
 export { default as MultiMarkersPlayerBar } from './classes/MultiMarkersPlayerBar.js';


### PR DESCRIPTION
YouTube seems to be A/B testing using PageHeader on user channels. This pull request adds support for the new fields.

Currently YouTube isn't returning any profile pictures (the `image` property that is populated on the `@gaming` and `@music` channels isn't returned for user channels) or banners in the `PageHeader` for user channels and there is currently no way to request the about tab, unless you manually create the protobuf and request.
That's the least of the problems though, as channels that are verified or have more than 100k subscribers consistently return `Internal Server Error` responses if you have a visitor ID that is affected by the A/B test, so if you want to test this pull request, you are best to do so on smaller channels.

Here is some visitor data that has the A/B test: `CgtWLXItUVZDN2JzYyjL_oStBg%3D%3D`