### PR TITLE
refactor(Playlist): Ignore `ContinuationItem` nodes from `SectionList#contents`

### DIFF
--- a/src/parser/classes/PlaylistVideo.ts
+++ b/src/parser/classes/PlaylistVideo.ts
@@ -23,6 +23,7 @@ export default class PlaylistVideo extends YTNode {
   upcoming?: Date;
   video_info: Text;
   accessibility_label?: string;
+  style?: string;
 
   duration: {
     text: string;
@@ -43,6 +44,10 @@ export default class PlaylistVideo extends YTNode {
     this.menu = Parser.parseItem(data.menu, Menu);
     this.video_info = new Text(data.videoInfo);
     this.accessibility_label = data.title.accessibility.accessibilityData.label;
+
+    if (Reflect.has(data, 'style')) {
+      this.style = data.style;
+    }
 
     const upcoming = data.upcomingEventData && Number(`${data.upcomingEventData.startTime}000`);
     if (upcoming) {


### PR DESCRIPTION
This should address some issues where the library would fetch the wrong continuation or even empty continuations.

**NOTE**: The solution in https://github.com/LuanRT/YouTube.js/commit/987f50604a0163f9a07091ce787995c6f6fddb75 no longer applies after this PR is merged, as empty continuations were all in `SectionList#contents`.  If you had any code in place to handle that error, it is safe to remove it after this PR is merged.

## Other related changes
1. Added `style` to `PlaylistVideo`. This helps identifying if the video is just a recommendation (`PLAYLIST_VIDEO_RENDERER_STYLE_RECOMMENDED_VIDEO`) or part of the playlist. 

2. `Playlist#items` can only return `PlaylistVideo` nodes now. Its return type is`ObservedArray<PlaylistVideo>`.