### PR TITLE
feat(Channel): Support getting about with PageHeader

### DIFF
--- a/src/parser/classes/DescriptionPreviewView.ts
+++ b/src/parser/classes/DescriptionPreviewView.ts
@@ -1,5 +1,6 @@
 import { YTNode } from '../helpers.js';
-import type { RawNode } from '../index.js';
+import { Parser, type RawNode } from '../index.js';
+import EngagementPanelSectionList from './EngagementPanelSectionList.js';
 import Text from './misc/Text.js';
 
 export default class DescriptionPreviewView extends YTNode {
@@ -9,6 +10,16 @@ export default class DescriptionPreviewView extends YTNode {
   max_lines: number;
   truncation_text: Text;
   always_show_truncation_text: boolean;
+  more_endpoint?: {
+    show_engagement_panel_endpoint: {
+      engagement_panel: EngagementPanelSectionList | null,
+      engagement_panel_popup_type: string;
+      identifier: {
+        surface: string,
+        tag: string
+      }
+    }
+  };
 
   constructor(data: RawNode) {
     super();
@@ -17,5 +28,20 @@ export default class DescriptionPreviewView extends YTNode {
     this.max_lines = parseInt(data.maxLines);
     this.truncation_text = Text.fromAttributed(data.truncationText);
     this.always_show_truncation_text = !!data.alwaysShowTruncationText;
+
+    if (data.rendererContext.commandContext?.onTap?.innertubeCommand?.showEngagementPanelEndpoint) {
+      const endpoint = data.rendererContext.commandContext?.onTap?.innertubeCommand?.showEngagementPanelEndpoint;
+
+      this.more_endpoint = {
+        show_engagement_panel_endpoint: {
+          engagement_panel: Parser.parseItem(endpoint.engagementPanel, EngagementPanelSectionList),
+          engagement_panel_popup_type: endpoint.engagementPanelPresentationConfigs.engagementPanelPopupPresentationConfig.popupType,
+          identifier: {
+            surface: endpoint.identifier.surface,
+            tag: endpoint.identifier.tag
+          }
+        }
+      };
+    }
   }
 }

--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -196,10 +196,13 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
     if (this.hasTabWithURL('about')) {
       const tab = await this.getTabByURL('about');
       return tab.memo.getType(ChannelAboutFullMetadata)[0];
-    } else if (this.header?.is(C4TabbedHeader) && this.header.tagline) {
+    }
 
-      if (this.header.tagline.more_endpoint instanceof NavigationEndpoint) {
-        const response = await this.header.tagline.more_endpoint.call(this.actions);
+    const tagline = this.header?.is(C4TabbedHeader) && this.header.tagline;
+
+    if (tagline || this.header?.is(PageHeader) && this.header.content?.description) {
+      if (tagline && tagline.more_endpoint instanceof NavigationEndpoint) {
+        const response = await tagline.more_endpoint.call(this.actions);
 
         const tab = new TabbedFeed<IBrowseResponse>(this.actions, response, false);
         return tab.memo.getType(ChannelAboutFullMetadata)[0];
@@ -271,7 +274,9 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
 
   get has_about(): boolean {
     // Game topic channels still have an about tab, user channels have switched to the popup
-    return this.hasTabWithURL('about') || !!(this.header?.is(C4TabbedHeader) && this.header.tagline?.more_endpoint);
+    return this.hasTabWithURL('about') ||
+      !!(this.header?.is(C4TabbedHeader) && this.header.tagline?.more_endpoint) ||
+      !!(this.header?.is(PageHeader) && this.header.content?.description?.more_endpoint);
   }
 
   get has_search(): boolean {


### PR DESCRIPTION
This is a follow up to #577.

Turns out that it is possible to get the about popup for user channels with a `PageHeader` header, it's buried in `rendererContext.commandContext` though, which usually only contains tracking data.

In the mean time I've also realised that it is possible to get the channel avatar from the channel metadata, so while it's not in the header at least it is still available.

A lot of the structure here is pretty similar to the one in `ChannelTagline`, so at some point it might be worth refactoring that out into it's own class, to reduce the duplicate code.