### PR TITLE
chore(Constants): Update web client version

### DIFF
--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -41,7 +41,7 @@ export const CLIENTS = Object.freeze({
   },
   WEB: {
     NAME: 'WEB',
-    VERSION: '2.20230622.06.00',
+    VERSION: '2.20240111.09.00',
     API_KEY: 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
     API_VERSION: 'v1',
     STATIC_VISITOR_ID: '6zpwvWUNAco'


### PR DESCRIPTION
YouTube.js sending an old client version is the cause of the HTTP 500 errors that YouTube was returning, it also resulted in YouTube not returning the profile picture and banner for user channels in the PageHeader.