### PR TITLE
feat(Format): Support caption tracks in adaptive formats

### DIFF
--- a/src/utils/FormatUtils.ts
+++ b/src/utils/FormatUtils.ts
@@ -169,9 +169,9 @@ export function chooseFormat(options: FormatOptions, streaming_data?: IStreaming
   if (requires_audio && !requires_video) {
     const audio_only = candidates.filter((format) => {
       if (language !== 'original') {
-        return !format.has_video && format.language === language;
+        return !format.has_video && !format.has_text && format.language === language;
       }
-      return !format.has_video && format.is_original;
+      return !format.has_video && !format.has_text && format.is_original;
 
     });
     if (audio_only.length > 0) {


### PR DESCRIPTION
Live streams that have captions, have them listed in the `adaptiveFormats` instead of the captions tracklist renderer. This pull request adds support for those. The caption track streams themselves are MP4 files that contain subtitles in YouTube's srv3 xml format.

https://youtube.com/@NBCNews/streams tends to regularly have live streams with captions. (unfortunately setting the search filters to live and CC, returns a bunch of live streams that are tagged with CC but don't have any subtitles or captions, so I just had to keep looking until I found videos with them).