### PR TITLE
Fix broken README links

### DIFF
--- a/examples/comments/README.md
+++ b/examples/comments/README.md
@@ -62,4 +62,4 @@ Returns original InnerTube response (sanitized).
 **Returns:** `ParsedResponse`
 
 ## Example
-See [`index.ts`]('./index.ts').
+See [`index.ts`](./index.ts).

--- a/examples/livechat/README.md
+++ b/examples/livechat/README.md
@@ -109,4 +109,4 @@ Sends a message.
 **Returns:** `Promise<ObservedArray<AddChatItemAction>>`
 
 ## Example
-See [`index.ts`]('./index.ts').
+See [`index.ts`](./index.ts).


### PR DESCRIPTION
There were apostrophes in the links which caused them to produce 404s. See the issues by clicking the bottommost link (`See index.ts here`):

- https://github.com/LuanRT/YouTube.js/tree/main/examples/comments
- https://github.com/LuanRT/YouTube.js/tree/main/examples/livechat