### PR TITLE
[Attempt] Fix for shelf type in Library

### DIFF
--- a/src/parser/classes/ItemSection.ts
+++ b/src/parser/classes/ItemSection.ts
@@ -19,7 +19,7 @@ export default class ItemSection extends YTNode {
     this.contents = Parser.parseArray(data.contents);
 
     if (data.targetId || data.sectionIdentifier) {
-      this.target_id = data.target_id || data.sectionIdentifier;
+      this.target_id = data.targetId || data.sectionIdentifier;
     }
 
     if (data.continuations) {


### PR DESCRIPTION
Attempt to fix #637 
From what I can see, only the history and playlists have ids (`library-recent` and `library-playlists-shelf`)
I don't know how to identify `WATCH_LATER`,  `LIKE`, or `CONTENT_CUT`. Those sections will still return undefined when accessed from their respective properties