### PR TITLE
chore(HTTPClient): Add X-Youtube-Client-Name and remove X-Origin headers

### DIFF
--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -34,12 +34,14 @@ export const OAUTH = Object.freeze({
 });
 export const CLIENTS = Object.freeze({
   iOS: {
+    NAME_ID: '5',
     NAME: 'iOS',
     VERSION: '18.06.35',
     USER_AGENT: 'com.google.ios.youtube/18.06.35 (iPhone; CPU iPhone OS 14_4 like Mac OS X; en_US)',
     DEVICE_MODEL: 'iPhone10,6'
   },
   WEB: {
+    NAME_ID: '1',
     NAME: 'WEB',
     VERSION: '2.20240111.09.00',
     API_KEY: 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
@@ -47,28 +49,34 @@ export const CLIENTS = Object.freeze({
     STATIC_VISITOR_ID: '6zpwvWUNAco'
   },
   WEB_KIDS: {
+    NAME_ID: '76',
     NAME: 'WEB_KIDS',
     VERSION: '2.20230111.00.00'
   },
   YTMUSIC: {
+    NAME_ID: '67',
     NAME: 'WEB_REMIX',
     VERSION: '1.20211213.00.00'
   },
   ANDROID: {
+    NAME_ID: '3',
     NAME: 'ANDROID',
     VERSION: '18.48.37',
     SDK_VERSION: 33,
     USER_AGENT: 'com.google.android.youtube/18.48.37(Linux; U; Android 13; en_US; sdk_gphone64_x86_64 Build/UPB4.230623.005) gzip'
   },
   YTSTUDIO_ANDROID: {
+    NAME_ID: '14',
     NAME: 'ANDROID_CREATOR',
     VERSION: '22.43.101'
   },
   YTMUSIC_ANDROID: {
+    NAME_ID: '21',
     NAME: 'ANDROID_MUSIC',
     VERSION: '5.34.51'
   },
   TV_EMBEDDED: {
+    NAME_ID: '85',
     NAME: 'TVHTML5_SIMPLY_EMBEDDED_PLAYER',
     VERSION: '2.0'
   }

--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -57,8 +57,15 @@ export default class HTTPClient {
     request_headers.set('Accept', '*/*');
     request_headers.set('Accept-Language', '*');
     request_headers.set('X-Goog-Visitor-Id', this.#session.context.client.visitorData || '');
-    request_headers.set('X-Origin', request_url.origin);
     request_headers.set('X-Youtube-Client-Version', this.#session.context.client.clientVersion || '');
+
+    const client_constant = Object.values(Constants.CLIENTS).find((client) => {
+      return client.NAME === this.#session.context.client.clientName;
+    });
+
+    if (client_constant) {
+      request_headers.set('X-Youtube-Client-Name', client_constant.NAME_ID);
+    }
 
     if (Platform.shim.server) {
       request_headers.set('User-Agent', getRandomUserAgent('desktop'));
@@ -90,6 +97,14 @@ export default class HTTPClient {
       this.#adjustContext(n_body.context, n_body.client);
       request_headers.set('x-youtube-client-version', n_body.context.client.clientVersion);
 
+      const client_constant = Object.values(Constants.CLIENTS).find((client) => {
+        return client.NAME === n_body.context.client.clientName;
+      });
+
+      if (client_constant) {
+        request_headers.set('X-Youtube-Client-Name', client_constant.NAME_ID);
+      }
+
       delete n_body.client;
 
       if (Platform.shim.server) {
@@ -109,7 +124,6 @@ export default class HTTPClient {
         request_headers.set('User-Agent', Constants.CLIENTS.ANDROID.USER_AGENT);
         request_headers.set('X-GOOG-API-FORMAT-VERSION', '2');
         request_headers.delete('X-Youtube-Client-Version');
-        request_headers.delete('X-Origin');
       }
     }
 


### PR DESCRIPTION
YouTube's website no longer sends the `X-Origin` header, they do however send a `X-Youtube-Client-Name` header that contains a number (presumably it's an enum in their backend).

They also send a `X-Youtube-Bootstrap-Logged-In: false` header, but as I'm not sure what the equivalent is for logged in users, I decided not to add that.

I sucessfully tested this with the web and tv embed clients.