### PR TITLE
feat(Format): Add `is_drc`

### DIFF
--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -53,6 +53,7 @@ export default class Format {
   is_dubbed?: boolean;
   is_descriptive?: boolean;
   is_original?: boolean;
+  is_drc?: boolean;
 
   color_info?: {
     primaries?: string;
@@ -146,10 +147,12 @@ export default class Format {
       this.language = xtags?.find((x: string) => x.startsWith('lang='))?.split('=')[1] || null;
 
       if (this.has_audio) {
+        this.is_drc = !!data.isDrc || !!xtags?.includes('drc=1');
+
         const audio_content = xtags?.find((x) => x.startsWith('acont='))?.split('=')[1];
         this.is_dubbed = audio_content === 'dubbed';
         this.is_descriptive = audio_content === 'descriptive';
-        this.is_original = audio_content === 'original' || (!this.is_dubbed && !this.is_descriptive);
+        this.is_original = audio_content === 'original' || (!this.is_dubbed && !this.is_descriptive && !this.is_drc);
       }
 
       // Some text tracks don't have xtags while others do


### PR DESCRIPTION
YouTube is currently A/B testing Stable Volume on the website, it's been in the iOS and Android apps since summer 2023. The audio streams with stable volume, can be identified through the `is_drc` property. DRC stands for Dynamic Range Compression. The WEB client has had Dynamic Range Compression on very specific videos for a long time, since before Stable Volume was a feature on mobile. Here is yt-dlp's test case for DRC streams (age-restricted): https://www.youtube.com/watch?v=Tq92D6wQ1mg (https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/extractor/youtube.py#L2629)

I'll be doing a follow-up pull request that adds support to the `toDash` function to treat the DRC streams as a separate audio track.