### PR TITLE
feat(toDash): Add support for stable volume/DRC

### DIFF
--- a/src/core/mixins/MediaInfo.ts
+++ b/src/core/mixins/MediaInfo.ts
@@ -59,7 +59,17 @@ export default class MediaInfo {
       storyboards = player_response.storyboards;
     }
 
-    return FormatUtils.toDash(this.streaming_data, this.page[0].video_details?.is_post_live_dvr, url_transformer, format_filter, this.#cpn, this.#actions.session.player, this.#actions, storyboards);
+    return FormatUtils.toDash(
+      this.streaming_data,
+      this.page[0].video_details?.is_post_live_dvr,
+      url_transformer,
+      format_filter,
+      this.#cpn,
+      this.#actions.session.player,
+      this.#actions,
+      storyboards,
+      options
+    );
   }
 
   /**

--- a/src/types/DashOptions.ts
+++ b/src/types/DashOptions.ts
@@ -1,4 +1,6 @@
-export interface DashOptions {
+import type { StreamingInfoOptions } from './StreamingInfoOptions.js';
+
+export interface DashOptions extends StreamingInfoOptions {
   /**
    * Include the storyboards in the DASH manifest when YouTube provides them.
    * Not all players support parsing and displaying storyboards.

--- a/src/types/StreamingInfoOptions.ts
+++ b/src/types/StreamingInfoOptions.ts
@@ -1,0 +1,21 @@
+export interface StreamingInfoOptions {
+  /**
+   * The label to use for the non-DRC streams when a video has DRC and streams.
+   *
+   * Defaults to `"Original"`
+   */
+  label_original?: string;
+  /**
+   * The label to use for the DRC streams when a video has DRC streams.
+   *
+   * Defaults to `"Stable Volume"`
+   */
+  label_drc?: string;
+  /**
+   * A function that generates the label to use for the DRC streams when a video has multiple audio tracks and DRC streams.
+   * The non-DRC streams use the unmodified audio track label provided by YouTube.
+   *
+   * Defaults to `(audio_track_display_name) => audio_track_display_name + " (Stable Volume)"`
+   */
+  label_drc_mutiple?: (audio_track_display_name: string) => string;
+}

--- a/src/utils/DashManifest.tsx
+++ b/src/utils/DashManifest.tsx
@@ -12,12 +12,14 @@ import type { PlayerStoryboardSpec } from '../parser/nodes.js';
 import type { SegmentInfo as FSegmentInfo } from './StreamingInfo.js';
 import type { FormatFilter, URLTransformer } from '../types/FormatUtils.js';
 import type PlayerLiveStoryboardSpec from '../parser/classes/PlayerLiveStoryboardSpec.js';
+import type { StreamingInfoOptions } from '../types/StreamingInfoOptions.js';
 
 interface DashManifestProps {
   streamingData: IStreamingData;
   isPostLiveDvr: boolean;
   transformURL?: URLTransformer;
   rejectFormat?: FormatFilter;
+  options?: StreamingInfoOptions,
   cpn?: string;
   player?: Player;
   actions?: Actions;
@@ -70,14 +72,15 @@ async function DashManifest({
   cpn,
   player,
   actions,
-  storyboards
+  storyboards,
+  options
 }: DashManifestProps) {
   const {
     getDuration,
     audio_sets,
     video_sets,
     image_sets
-  } = getStreamingInfo(streamingData, isPostLiveDvr, transformURL, rejectFormat, cpn, player, actions, storyboards);
+  } = getStreamingInfo(streamingData, isPostLiveDvr, transformURL, rejectFormat, cpn, player, actions, storyboards, options);
 
   // XXX: DASH spec: https://standards.iso.org/ittf/PubliclyAvailableStandards/c083314_ISO_IEC%2023009-1_2022(en).zip
 
@@ -104,11 +107,12 @@ async function DashManifest({
             contentType="audio"
           >
             {
-              set.track_role &&
-              <role
-                schemeIdUri="urn:mpeg:dash:role:2011"
-                value={set.track_role}
-              />
+              set.track_roles && set.track_roles.map((role) => (
+                <role
+                  schemeIdUri="urn:mpeg:dash:role:2011"
+                  value={role}
+                />
+              ))
             }
             {
               set.track_name &&
@@ -237,7 +241,8 @@ export function toDash(
   cpn?: string,
   player?: Player,
   actions?: Actions,
-  storyboards?: PlayerStoryboardSpec | PlayerLiveStoryboardSpec
+  storyboards?: PlayerStoryboardSpec | PlayerLiveStoryboardSpec,
+  options?: StreamingInfoOptions
 ) {
   if (!streaming_data)
     throw new InnertubeError('Streaming data not available');
@@ -247,6 +252,7 @@ export function toDash(
       streamingData={streaming_data}
       isPostLiveDvr={is_post_live_dvr}
       transformURL={url_transformer}
+      options={options}
       rejectFormat={format_filter}
       cpn={cpn}
       player={player}


### PR DESCRIPTION
See https://github.com/LuanRT/YouTube.js/pull/656 for more information about Stable Volume/DRC.

This pull request makes `toDash` treat DRC and non-DRC streams as a separate audio tracks, that will make most players, show their audio track selector so that you can switch between them, instead of counting them all as the same audio track. As the generated labels are user facing, I decided to allow the caller of the `toDash` method, to override the default ones if they want to, that allows the labels to be translated (we don't need this for the normal multiple audio track labels, as you can change the request language to YouTube to get translated labels).

YouTube doesn't return DRC streams for videos with multiple audio tracks at the moment, however I still decided to add support for that, to prevent it breaking if YouTube ever does start returning DRC streams for videos with multiple audio tracks.