### PR TITLE
fix(toDash): Fix image representations not being spec compliant

### DIFF
--- a/src/utils/StreamingInfo.ts
+++ b/src/utils/StreamingInfo.ts
@@ -706,7 +706,7 @@ function getImageRepresentation(
     thumbnail_width: board.thumbnail_width,
     rows: board.rows,
     columns: board.columns,
-    template_duration: template_duration,
+    template_duration: Math.round(template_duration),
     template_url: transform_url(template_url).toString(),
     getURL(n) {
       return template_url.toString().replace('$Number$', n.toString());


### PR DESCRIPTION
SegmentTemplate durations are supposed to be unsigned integers, as the toDash function was generating image representations that had float durations, it broke the thumbnails display in recent versions of shaka-player.