### PR TITLE
feat(toDash): Add option to include WebVTT or TTML captions

### DIFF
--- a/src/core/mixins/MediaInfo.ts
+++ b/src/core/mixins/MediaInfo.ts
@@ -54,9 +54,14 @@ export default class MediaInfo {
     }
 
     let storyboards;
+    let captions;
 
     if (options.include_thumbnails && player_response.storyboards) {
       storyboards = player_response.storyboards;
+    }
+
+    if (typeof options.captions_format === 'string' && player_response.captions?.caption_tracks) {
+      captions = player_response.captions.caption_tracks;
     }
 
     return FormatUtils.toDash(
@@ -68,6 +73,7 @@ export default class MediaInfo {
       this.#actions.session.player,
       this.#actions,
       storyboards,
+      captions,
       options
     );
   }

--- a/src/parser/classes/PlayerCaptionsTracklist.ts
+++ b/src/parser/classes/PlayerCaptionsTracklist.ts
@@ -2,17 +2,19 @@ import Text from './misc/Text.js';
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
 
+export interface CaptionTrackData {
+  base_url: string;
+  name: Text;
+  vss_id: string;
+  language_code: string;
+  kind?: 'asr' | 'frc';
+  is_translatable: boolean;
+}
+
 export default class PlayerCaptionsTracklist extends YTNode {
   static type = 'PlayerCaptionsTracklist';
 
-  caption_tracks?: {
-    base_url: string;
-    name: Text;
-    vss_id: string;
-    language_code: string;
-    kind?: 'asr' | 'frc';
-    is_translatable: boolean;
-  }[];
+  caption_tracks?: CaptionTrackData[];
 
   audio_tracks?: {
     audio_track_id: string;

--- a/src/types/StreamingInfoOptions.ts
+++ b/src/types/StreamingInfoOptions.ts
@@ -1,5 +1,14 @@
 export interface StreamingInfoOptions {
   /**
+   * The format to use for the captions, when the video has captions.
+   * If this option is not set, the DASH manifest will not include the captions.
+   *
+   * Possible values:
+   * * `vtt`: Tells YouTube to return the captions in the WebVTT format
+   * * `ttml`: Tells YouTube to return the captions in the TTML format
+   */
+  captions_format?: 'vtt' | 'ttml';
+  /**
    * The label to use for the non-DRC streams when a video has DRC and streams.
    *
    * Defaults to `"Original"`


### PR DESCRIPTION
By default no captions get included in the DASH manifest, however if the video has captions, the developer can ask for them to be included by setting the new `captions_format` option to either `vtt` or `ttml` depending on which format they would like.
To avoid making extra requests, this hardcodes the bandwidth/bitrate of the text adaptation sets to `0`.

I tested that this works with shaka-player, I haven't tested it with any other players.