### PR TITLE
fix(FormatUtils): Throw an error if download requests fails

### DIFF
--- a/src/utils/FormatUtils.ts
+++ b/src/utils/FormatUtils.ts
@@ -90,6 +90,10 @@ export async function download(
             signal: cancel.signal
           });
 
+          // Throw if the response is not 2xx
+          if (!response.ok)
+            throw new InnertubeError('The server responded with a non 2xx status code', { error_type: 'FETCH_FAILED', response });
+
           const body = response.body;
 
           if (!body)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This is fix for catch error when response status is not 2XX.
There are throw of 'not 2XX' in 'video+audio' type already, but not in other type.
So I meet some problem when youtube give 403 status ('audio' type), I cannot catch any error and download function is stopped.
This change is for catching error in above case.