### PR TITLE
feat(toDash): Add the "dub" role to translated captions

### DIFF
--- a/src/utils/DashManifest.tsx
+++ b/src/utils/DashManifest.tsx
@@ -241,10 +241,14 @@ async function DashManifest({
             lang={set.language}
             contentType="text"
           >
-            <role
-              schemeIdUri="urn:mpeg:dash:role:2011"
-              value="caption"
-            />
+            {
+              set.track_roles.map((role) => (
+                <role
+                  schemeIdUri="urn:mpeg:dash:role:2011"
+                  value={role}
+                />
+              ))
+            }
             <label id={index + audio_sets.length}>
               {set.track_name}
             </label>

--- a/src/utils/StreamingInfo.ts
+++ b/src/utils/StreamingInfo.ts
@@ -128,6 +128,7 @@ export interface TextSet {
   mime_type: string;
   language: string;
   track_name: string;
+  track_roles: ('caption' | 'dub')[];
   representation: TextRepresentation;
 }
 
@@ -760,10 +761,17 @@ function getTextSets(
     const url = new URL(caption_track.base_url);
     url.searchParams.set('fmt', format);
 
+    const track_roles: ('caption' | 'dub')[] = [ 'caption' ];
+
+    if (url.searchParams.has('tlang')) {
+      track_roles.push('dub');
+    }
+
     return {
       mime_type,
       language: caption_track.language_code,
       track_name: caption_track.name.toString(),
+      track_roles,
       representation: {
         uid: `text-${caption_track.vss_id}`,
         base_url: transform_url(url).toString()


### PR DESCRIPTION
You can ask YouTube to translate a caption track with machine translation by adding the `tlang` query parameter with your desired locale. This pull request adds to `dub` role to those caption tracks when adding them to the DASH manifest.

Unfortunately there doesn't seem to be a suitable role value in the `urn:mpeg:dash:role:2011` scheme for auto-generated captions (`kind=asr`), so we don't currently have a way to tag those inside the DASH manifest, unless we want to create a custom scheme.