### PR TITLE
fix(Player): Fix extracting the n-token decipher algorithm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "jintr": "^1.1.0",
+        "jintr": "^2.0.0",
         "tslib": "^2.5.0",
         "undici": "^5.19.1"
       },
@@ -5829,9 +5829,9 @@
       }
     },
     "node_modules/jintr": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jintr/-/jintr-1.1.0.tgz",
-      "integrity": "sha512-Tu9wk3BpN2v+kb8yT6YBtue+/nbjeLFv4vvVC4PJ7oCidHKbifWhvORrAbQfxVIQZG+67am/mDagpiGSVtvrZg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jintr/-/jintr-2.0.0.tgz",
+      "integrity": "sha512-RiVlevxttZ4eHEYB2dXKXDXluzHfRuw0DJQGsYuKCc5IvZj5/GbOakeqVX+Bar/G9kTty9xDJREcxukurkmYLA==",
       "funding": [
         "https://github.com/sponsors/LuanRT"
       ],

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "jintr": "^1.1.0",
+    "jintr": "^2.0.0",
     "tslib": "^2.5.0",
     "undici": "^5.19.1"
   },

--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -220,12 +220,20 @@ export default class Player {
   }
 
   static extractNSigSourceCode(data: string): string {
-    const sc = `function descramble_nsig(a) { let b=a.split("")${getStringBetweenStrings(data, 'b=a.split("")', '}return b.join("")}')}} return b.join(""); } descramble_nsig(nsig)`;
+    let sc = getStringBetweenStrings(data, 'b=a.split("")', '}return b.join("")}');
 
-    if (!sc)
-      Log.warn(TAG, 'Failed to extract n-token decipher algorithm');
+    if (sc)
+      return `function descramble_nsig(a) { let b=a.split("")${sc}} return b.join(""); } descramble_nsig(nsig)`;
 
-    return sc;
+    sc = getStringBetweenStrings(data, 'b=String.prototype.split.call(a,"")', '}return Array.prototype.join.call(b,"")}');
+
+    if (sc)
+      return `function descramble_nsig(a) { let b=String.prototype.split.call(a, "")${sc}} return Array.prototype.join.call(b, ""); } descramble_nsig(nsig)`;
+
+    // We really should throw an error here to avoid errors later, returning a pass-through function for backwards-compatibility
+    Log.warn(TAG, 'Failed to extract n-token decipher algorithm');
+
+    return 'function descramble_nsig(a) { return a; } descramble_nsig(nsig)';
   }
 
   get url(): string {

--- a/src/platform/jsruntime/jinter.ts
+++ b/src/platform/jsruntime/jinter.ts
@@ -7,13 +7,13 @@ const TAG = 'JsRuntime';
 export default function evaluate(code: string, env: Record<string, VMPrimative>) {
   Log.debug(TAG, 'Evaluating JavaScript:\n', code);
 
-  const runtime = new Jinter(code);
+  const runtime = new Jinter();
 
   for (const [ key, value ] of Object.entries(env)) {
     runtime.scope.set(key, value);
   }
 
-  const result = runtime.interpret();
+  const result = runtime.evaluate(code);
 
   Log.debug(TAG, 'Done. Result:', result);
 


### PR DESCRIPTION
This pull request adds support for the player `b22ef6e7`, which uses `String.prototype.split` and `Array.prototype.join`.

A Jinter update will be required to add support for `Array`.