### PR TITLE
feat(proto): Add `comment_id` to commentSectionParams

### DIFF
--- a/src/proto/generated/messages/youtube/(GetCommentsSectionParams)/(Params)/Options.ts
+++ b/src/proto/generated/messages/youtube/(GetCommentsSectionParams)/(Params)/Options.ts
@@ -21,6 +21,7 @@ export declare namespace $.youtube.GetCommentsSectionParams.Params {
     videoId: string;
     sortBy: number;
     type: number;
+    commentId?: string;
   }
 }
 
@@ -31,6 +32,7 @@ export function getDefaultValue(): $.youtube.GetCommentsSectionParams.Params.Opt
     videoId: "",
     sortBy: 0,
     type: 0,
+    commentId: undefined,
   };
 }
 
@@ -46,6 +48,7 @@ export function encodeJson(value: $.youtube.GetCommentsSectionParams.Params.Opti
   if (value.videoId !== undefined) result.videoId = tsValueToJsonValueFns.string(value.videoId);
   if (value.sortBy !== undefined) result.sortBy = tsValueToJsonValueFns.int32(value.sortBy);
   if (value.type !== undefined) result.type = tsValueToJsonValueFns.int32(value.type);
+  if (value.commentId !== undefined) result.commentId = tsValueToJsonValueFns.string(value.commentId);
   return result;
 }
 
@@ -54,6 +57,7 @@ export function decodeJson(value: any): $.youtube.GetCommentsSectionParams.Param
   if (value.videoId !== undefined) result.videoId = jsonValueToTsValueFns.string(value.videoId);
   if (value.sortBy !== undefined) result.sortBy = jsonValueToTsValueFns.int32(value.sortBy);
   if (value.type !== undefined) result.type = jsonValueToTsValueFns.int32(value.type);
+  if (value.commentId !== undefined) result.commentId = jsonValueToTsValueFns.string(value.commentId);
   return result;
 }
 
@@ -75,6 +79,12 @@ export function encodeBinary(value: $.youtube.GetCommentsSectionParams.Params.Op
     const tsValue = value.type;
     result.push(
       [15, tsValueToWireValueFns.int32(tsValue)],
+    );
+  }
+  if (value.commentId !== undefined) {
+    const tsValue = value.commentId;
+    result.push(
+      [16, tsValueToWireValueFns.string(tsValue)],
     );
   }
   return serialize(result);
@@ -104,6 +114,13 @@ export function decodeBinary(binary: Uint8Array): $.youtube.GetCommentsSectionPa
     const value = wireValueToTsValueFns.int32(wireValue);
     if (value === undefined) break field;
     result.type = value;
+  }
+  field: {
+    const wireValue = wireFields.get(16);
+    if (wireValue === undefined) break field;
+    const value = wireValueToTsValueFns.string(wireValue);
+    if (value === undefined) break field;
+    result.commentId = value;
   }
   return result;
 }

--- a/src/proto/index.ts
+++ b/src/proto/index.ts
@@ -155,7 +155,8 @@ export function encodeMessageParams(channel_id: string, video_id: string): strin
 
 export function encodeCommentsSectionParams(video_id: string, options: {
   type?: number,
-  sort_by?: 'TOP_COMMENTS' | 'NEWEST_FIRST'
+  sort_by?: 'TOP_COMMENTS' | 'NEWEST_FIRST',
+  comment_id?: string
 } = {}): string {
   const sort_options = {
     TOP_COMMENTS: 0,
@@ -171,7 +172,8 @@ export function encodeCommentsSectionParams(video_id: string, options: {
       opts: {
         videoId: video_id,
         sortBy: sort_options[options.sort_by || 'TOP_COMMENTS'],
-        type: options.type || 2
+        type: options.type || 2,
+        commentId: options.comment_id || ''
       },
       target: 'comments-section'
     }

--- a/src/proto/youtube.proto
+++ b/src/proto/youtube.proto
@@ -162,6 +162,7 @@ message GetCommentsSectionParams {
       required string video_id = 4;
       required int32 sort_by = 6;
       required int32 type = 15;
+      optional string comment_id = 16;
     }
     
     message RepliesOptions {


### PR DESCRIPTION
### Fixes #689

The `proto.encodeCommentSectionParams` method now has a new optional parameter called `comment_id`, which allows highlighting a specific comment when the page is opened. Here is an example code snippet:

```javascript
//continuation for /watch?v=jlAd027IBsc&lc=Ugxvmarhks-D40zwQKJ4AaABAg
const continuation = encodeCommentsSectionParams(
  "jlAd027IBsc",
  {
    comment_id: "Ugxvmarhks-D40zwQKJ4AaABAg"
  }
);
console.log(continuation);
```

The output of the above code will be:

```
Eg0SC2psQWQwMjdJQnNjGAYyQiIuIgtqbEFkMDI3SUJzYzAAeAKCARpVZ3h2bWFyaGtzLUQ0MHp3UUtKNEFhQUJBZ0IQY29tbWVudHMtc2VjdGlvbg%3D%3D

Process finished with exit code 0
```

---
