### PR TITLE
fix(Player): Fix extracting the n-token decipher algorithm again

### DIFF
--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -220,20 +220,13 @@ export default class Player {
   }
 
   static extractNSigSourceCode(data: string): string {
-    let sc = getStringBetweenStrings(data, 'b=a.split("")', '}return b.join("")}');
+    const match = data.match(/b=(?:a\.split\(|String\.prototype\.split\.call\(a,)""\).*?\}return (?:b\.join\(|Array\.prototype\.join\.call\(b,)""\)\}/s);
 
-    if (sc)
-      return `function descramble_nsig(a) { let b=a.split("")${sc}} return b.join(""); } descramble_nsig(nsig)`;
+    if (!match) {
+      throw new PlayerError('Failed to extract n-token decipher algorithm');
+    }
 
-    sc = getStringBetweenStrings(data, 'b=String.prototype.split.call(a,"")', '}return Array.prototype.join.call(b,"")}');
-
-    if (sc)
-      return `function descramble_nsig(a) { let b=String.prototype.split.call(a, "")${sc}} return Array.prototype.join.call(b, ""); } descramble_nsig(nsig)`;
-
-    // We really should throw an error here to avoid errors later, returning a pass-through function for backwards-compatibility
-    Log.warn(TAG, 'Failed to extract n-token decipher algorithm');
-
-    return 'function descramble_nsig(a) { return a; } descramble_nsig(nsig)';
+    return `function descramble_nsig(a) { let ${match[0]} descramble_nsig(nsig)`;
   }
 
   get url(): string {


### PR DESCRIPTION
Alternative to https://github.com/LuanRT/YouTube.js/pull/698 which maintains backwards compatibility in case YouTube switches back to their previous two versions of the function.