### PR TITLE
fix(Player): Bump cache version

### DIFF
--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -234,6 +234,6 @@ export default class Player {
   }
 
   static get LIBRARY_VERSION(): number {
-    return 10;
+    return 11;
   }
 }


### PR DESCRIPTION
We should always do this after updating the sig/nsig code. It's so that the old cache gets ignored : ).