### PR TITLE
feat(parser): Add `EomSettingsDisclaimer` node

### DIFF
--- a/src/parser/classes/EomSettingsDisclaimer.ts
+++ b/src/parser/classes/EomSettingsDisclaimer.ts
@@ -1,0 +1,22 @@
+import Text from './misc/Text.js';
+import { YTNode } from '../helpers.js';
+import { type RawNode } from '../index.js';
+
+export default class EomSettingsDisclaimer extends YTNode {
+  static type = 'EomSettingsDisclaimer';
+
+  disclaimer: Text;
+  info_icon: {
+    icon_type: string
+  };
+  usage_scenario: string;
+
+  constructor(data: RawNode) {
+    super();
+    this.disclaimer = new Text(data.disclaimer);
+    this.info_icon = {
+      icon_type: data.infoIcon.iconType
+    };
+    this.usage_scenario = data.usageScenario;
+  }
+}

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -120,6 +120,7 @@ export { default as EndScreenPlaylist } from './classes/EndScreenPlaylist.js';
 export { default as EndScreenVideo } from './classes/EndScreenVideo.js';
 export { default as EngagementPanelSectionList } from './classes/EngagementPanelSectionList.js';
 export { default as EngagementPanelTitleHeader } from './classes/EngagementPanelTitleHeader.js';
+export { default as EomSettingsDisclaimer } from './classes/EomSettingsDisclaimer.js';
 export { default as ExpandableMetadata } from './classes/ExpandableMetadata.js';
 export { default as ExpandableTab } from './classes/ExpandableTab.js';
 export { default as ExpandableVideoDescriptionBody } from './classes/ExpandableVideoDescriptionBody.js';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This is needed when the `cookie` option is used in Node.js:

```typescript
const youtube = await Innertube.create({
	cookie: 'xxx',
});

const history = await youtube.getHistory()
console.log(history.feed_actions.contents.at(-1))
```

```javascript
EomSettingsDisclaimer {
  type: 'EomSettingsDisclaimer',
  disclaimer: Text {
    runs: [ [TextRun], [TextRun], [TextRun] ],
    text: 'These settings are not available because of your current cookies selections. If you prefer to turn on your watch & search history, you can do so by managing your cookies at any time.'
  },
  info_icon: { icon_type: 'INFO' },
  usage_scenario: 'EOM_EXIT'
}
```

Interestingly, valid browser cookies give a different response but no history:
```javascript
EomSettingsDisclaimer {
  type: 'EomSettingsDisclaimer',
  disclaimer: Text {
    runs: [ [TextRun], [TextRun], [TextRun] ],
    text: 'You can manage your cookies, including rejecting them, at any time'
  },
  info_icon: { icon_type: 'INFO' },
  usage_scenario: 'EOM_REENTRY'
}
```