### PR TITLE
fix(Search): Fix it occasionally returning only a small number of results

### DIFF
--- a/src/parser/youtube/Search.ts
+++ b/src/parser/youtube/Search.ts
@@ -8,13 +8,15 @@ import SearchSubMenu from '../classes/SearchSubMenu.js';
 import SectionList from '../classes/SectionList.js';
 import UniversalWatchCard from '../classes/UniversalWatchCard.js';
 
+import { observe } from '../helpers.js';
+
 import type { ApiResponse, Actions } from '../../core/index.js';
 import type { ObservedArray, YTNode } from '../helpers.js';
 import type { ISearchResponse } from '../types/index.js';
 
 export default class Search extends Feed<ISearchResponse> {
   header?: SearchHeader;
-  results?: ObservedArray<YTNode> | null;
+  results: ObservedArray<YTNode>;
   refinements: string[];
   estimated_results: number;
   sub_menu?: SearchSubMenu;
@@ -34,9 +36,7 @@ export default class Search extends Feed<ISearchResponse> {
     if (this.page.header)
       this.header = this.page.header.item().as(SearchHeader);
 
-    this.results = contents.find(
-      (content) => content.is(ItemSection) && (content.contents && content.contents.length > 0)
-    )?.as(ItemSection)?.contents;
+    this.results = observe(contents.filterType(ItemSection).flatMap((section) => section.contents));
 
     this.refinements = this.page.refinements || [];
     this.estimated_results = this.page.estimated_results || 0;


### PR DESCRIPTION
YouTube seems to have two types of search responses, one of them consists of a single `ItemSection` and then the continuation, the second type is made up of lots of `ItemSection`s each with only a few number of items in them and then the continuation. To be able to handle both cases, I've changed the code to merge together the items from all of the sections. This shouldn't cause any problems, as the `People also watched` and `People also search for` sub-sections are shelves (`Shelf` class) inside of the `ItemSection`s.

https://github.com/FreeTubeApp/FreeTube/issues/5510