### PR TITLE
fix(parser): The icon_name property does not always exist in ThumbnailBadgeView

### DIFF
--- a/src/parser/classes/ThumbnailBadgeView.ts
+++ b/src/parser/classes/ThumbnailBadgeView.ts
@@ -4,7 +4,7 @@ import type { RawNode } from '../index.js';
 export default class ThumbnailBadgeView extends YTNode {
   static type = 'ThumbnailBadgeView';
 
-  icon_name: string;
+  icon_name?: string;
   text: string;
   badge_style: string;
   background_color?: {
@@ -15,14 +15,18 @@ export default class ThumbnailBadgeView extends YTNode {
   constructor(data: RawNode) {
     super();
 
-    this.icon_name = data.icon.sources[0].clientResource.imageName;
     this.text = data.text;
     this.badge_style = data.badgeStyle;
+
     if (data.backgroundColor) {
       this.background_color = {
         light_theme: data.backgroundColor.lightTheme,
         dark_theme: data.backgroundColor.darkTheme
       };
+    }
+
+    if (data.iconName) {
+      this.icon_name = data.icon.sources[0].clientResource.imageName;
     }
   }
 }


### PR DESCRIPTION
Fixes the parser error caused by `ThumbnailBadgeView` assuming that the `icon_name` is always available.