### PR TITLE
Fix json import syntax deprecation for Deno

### DIFF
--- a/src/platform/deno.ts
+++ b/src/platform/deno.ts
@@ -3,7 +3,7 @@ import type { ICache } from '../types/Cache.js';
 import { Platform } from '../utils/Utils.js';
 import evaluate from './jsruntime/jinter.js';
 import sha1Hash from './polyfills/web-crypto.js';
-import package_json from '../../package.json' assert { type: 'json' };
+import package_json from '../../package.json' with { type: 'json' };
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes a warning in the console when running YouTube.js under Deno:
![image](https://github.com/user-attachments/assets/e029554f-c596-4078-b851-8581a4c48bf6)

This requires Deno v1.46 or newer, so it would be a breaking change, but `assert` is being [removed completely in Deno v2.0](https://deno.com/blog/v2.0-release-candidate#import-assertions-are-dead-long-live-import-attributes), which is releasing probably in the next month or so. I figured I'd post this PR now so that you have it available to merge whenever you do the next major release.