### PR TITLE
feat(Parser): Add support for parsing subtitle for `Shelf`

### DIFF
--- a/src/parser/classes/Shelf.ts
+++ b/src/parser/classes/Shelf.ts
@@ -13,6 +13,7 @@ export default class Shelf extends YTNode {
   icon_type?: string;
   menu?: YTNode | null;
   play_all_button?: Button | null;
+  subtitle?: Text;
 
   constructor(data: RawNode) {
     super();
@@ -34,6 +35,10 @@ export default class Shelf extends YTNode {
 
     if (Reflect.has(data, 'playAllButton')) {
       this.play_all_button = Parser.parseItem(data.playAllButton, Button);
+    }
+
+    if (Reflect.has(data, 'subtitle')) {
+      this.subtitle = new Text(data.subtitle);
     }
   }
 }


### PR DESCRIPTION
This PR adds support for an optional subtitle property for the Shelf object.

An example of this can be found on Linus Tech Tips home page with the "As Fast As Possible" shelf:
![image](https://github.com/user-attachments/assets/4ec13f9c-df42-402a-ac47-d300b3abcef1)
