### PR TITLE
feat: Add `getCourses` function to get courses from explore.

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -320,6 +320,13 @@ export default class Innertube {
     return new TabbedFeed(this.actions, response);
   }
 
+  async getCourses(): Promise<TabbedFeed<IBrowseResponse>> {
+    const response = await this.actions.execute(
+      BrowseEndpoint.PATH, { ...BrowseEndpoint.build({ browse_id: 'FEcourses_destination' }), parse: true }
+    );
+    return new TabbedFeed(this.actions, response);
+  }
+
   async getSubscriptionsFeed(): Promise<Feed<IBrowseResponse>> {
     const response = await this.actions.execute(
       BrowseEndpoint.PATH, { ...BrowseEndpoint.build({ browse_id: 'FEsubscriptions' }), parse: true }

--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -320,11 +320,11 @@ export default class Innertube {
     return new TabbedFeed(this.actions, response);
   }
 
-  async getCourses(): Promise<TabbedFeed<IBrowseResponse>> {
+  async getCourses(): Promise<Feed<IBrowseResponse>> {
     const response = await this.actions.execute(
       BrowseEndpoint.PATH, { ...BrowseEndpoint.build({ browse_id: 'FEcourses_destination' }), parse: true }
     );
-    return new TabbedFeed(this.actions, response);
+    return new Feed(this.actions, response);
   }
 
   async getSubscriptionsFeed(): Promise<Feed<IBrowseResponse>> {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,6 +1,7 @@
 import { createWriteStream, existsSync } from 'node:fs';
-import { Innertube, Utils, YT, YTMusic, YTNodes } from '../bundle/node.cjs';
+import { Innertube, Log, Utils, YT, YTMusic, YTNodes } from '../bundle/node.cjs';
 
+Log.setLevel(Log.Level.NONE)
 jest.useRealTimers();
 
 describe('YouTube.js Tests', () => {
@@ -163,6 +164,14 @@ describe('YouTube.js Tests', () => {
       expect(trending.page.contents).toBeDefined();
       expect(trending.page.contents_memo).toBeDefined();
       expect(trending.videos.length).toBeGreaterThan(0);
+    });
+
+    test('Innertube#getCourses', async () => {
+      const courses = await innertube.getCourses();
+      expect(courses).toBeDefined();
+      expect(courses.page.contents).toBeDefined();
+      expect(courses.page.contents_memo).toBeDefined();
+      expect(courses.shelves.length).toBeGreaterThan(0);
     });
 
     describe('Innertube#getChannel', () => {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,7 +1,6 @@
 import { createWriteStream, existsSync } from 'node:fs';
-import { Innertube, Log, Utils, YT, YTMusic, YTNodes } from '../bundle/node.cjs';
+import { Innertube, Utils, YT, YTMusic, YTNodes } from '../bundle/node.cjs';
 
-Log.setLevel(Log.Level.NONE)
 jest.useRealTimers();
 
 describe('YouTube.js Tests', () => {


### PR DESCRIPTION
As per https://github.com/LuanRT/YouTube.js/issues/797, I wanted a way to get the "Courses" from the "Explore" so I added a function. We have not made any significant changes.
To test this code, run the `getCourses` function and make sure `shelves` has the retrieved courses.