### PR TITLE
feat(Parser): Add support for parsing subtitle for `RichShelf`

### DIFF
--- a/src/parser/classes/RichShelf.ts
+++ b/src/parser/classes/RichShelf.ts
@@ -9,6 +9,7 @@ export default class RichShelf extends YTNode {
   title: Text;
   contents: ObservedArray<YTNode>;
   endpoint?: NavigationEndpoint;
+  subtitle?: Text;
 
   constructor(data: RawNode) {
     super();
@@ -17,6 +18,10 @@ export default class RichShelf extends YTNode {
 
     if (Reflect.has(data, 'endpoint')) {
       this.endpoint = new NavigationEndpoint(data.endpoint);
+    }
+
+    if (Reflect.has(data, 'subtitle')) {
+      this.subtitle = new Text(data.subtitle);
     }
   }
 }


### PR DESCRIPTION
This PR adds support for an optional subtitle property for the RichShelf object.

Example channel that could have it:
https://www.youtube.com/channel/UCtFRv9O2AHqOZjjynzrv-xg