### PR TITLE
feat(parser): Add optional image property to LockupMetadataView

### DIFF
--- a/src/parser/classes/LockupMetadataView.ts
+++ b/src/parser/classes/LockupMetadataView.ts
@@ -1,6 +1,7 @@
 import { YTNode } from '../helpers.js';
 import { Parser, type RawNode } from '../index.js';
 import ContentMetadataView from './ContentMetadataView.js';
+import DecoratedAvatarView from './DecoratedAvatarView.js';
 import Text from './misc/Text.js';
 
 export default class LockupMetadataView extends YTNode {
@@ -8,11 +9,13 @@ export default class LockupMetadataView extends YTNode {
 
   title: Text;
   metadata: ContentMetadataView | null;
+  image: DecoratedAvatarView | null;
 
   constructor(data: RawNode) {
     super();
 
     this.title = Text.fromAttributed(data.title);
     this.metadata = Parser.parseItem(data.metadata, ContentMetadataView);
+    this.image = Parser.parseItem(data.image, DecoratedAvatarView);
   }
 }


### PR DESCRIPTION
LockupView with the `content_type` `VIDEO` can sometimes have a channel avatar in their metadata.