### PR TITLE
feat(parser): add `LiveChatModeChangeMessage` node

### DIFF
--- a/src/parser/classes/livechat/items/LiveChatModeChangeMessage.ts
+++ b/src/parser/classes/livechat/items/LiveChatModeChangeMessage.ts
@@ -1,0 +1,26 @@
+import { YTNode } from '../../../helpers.js';
+import type { RawNode } from '../../../index.js';
+import Text from '../../misc/Text.js';
+
+export default class LiveChatModeChangeMessage extends YTNode {
+  static type = 'LiveChatModeChangeMessage';
+
+  id: string;
+  icon_type: string;
+  text: Text;
+  subtext: Text;
+  timestamp: number;
+  timestamp_usec: string;
+  timestamp_text: string;
+
+  constructor(data: RawNode) {
+    super();
+    this.id = data.id;
+    this.icon_type = data.icon.iconType;
+    this.text = new Text(data.text);
+    this.subtext = new Text(data.subtext);
+    this.timestamp = Math.floor(parseInt(data.timestampUsec) / 1000);
+    this.timestamp_usec = data.timestampUsec;
+    this.timestamp_text = new Text(data.timestampText).toString();
+  }
+}

--- a/src/parser/classes/livechat/items/LiveChatModeChangeMessage.ts
+++ b/src/parser/classes/livechat/items/LiveChatModeChangeMessage.ts
@@ -21,6 +21,6 @@ export default class LiveChatModeChangeMessage extends YTNode {
     this.subtext = new Text(data.subtext);
     this.timestamp = Math.floor(parseInt(data.timestampUsec) / 1000);
     this.timestamp_usec = data.timestampUsec;
-    this.timestamp_text = new Text(data.timestampText).toString();
+    this.timestamp_text = new Text(data.timestampText);
   }
 }

--- a/src/parser/classes/livechat/items/LiveChatModeChangeMessage.ts
+++ b/src/parser/classes/livechat/items/LiveChatModeChangeMessage.ts
@@ -11,7 +11,7 @@ export default class LiveChatModeChangeMessage extends YTNode {
   subtext: Text;
   timestamp: number;
   timestamp_usec: string;
-  timestamp_text: string;
+  timestamp_text: Text;
 
   constructor(data: RawNode) {
     super();

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -186,6 +186,7 @@ export { default as LiveChatBannerHeader } from './classes/livechat/items/LiveCh
 export { default as LiveChatBannerPoll } from './classes/livechat/items/LiveChatBannerPoll.js';
 export { default as LiveChatBannerRedirect } from './classes/livechat/items/LiveChatBannerRedirect.js';
 export { default as LiveChatMembershipItem } from './classes/livechat/items/LiveChatMembershipItem.js';
+export { default as LiveChatModeChangeMessage } from './classes/livechat/items/LiveChatModeChangeMessage.js';
 export { default as LiveChatPaidMessage } from './classes/livechat/items/LiveChatPaidMessage.js';
 export { default as LiveChatPaidSticker } from './classes/livechat/items/LiveChatPaidSticker.js';
 export { default as LiveChatPlaceholderItem } from './classes/livechat/items/LiveChatPlaceholderItem.js';


### PR DESCRIPTION
Example RawNode data 1:

```json
{
  "liveChatModeChangeMessageRenderer": {
    "id": "ChwKGkNQdTQwcFd1MVBZQ0ZTVU01d29kX2NNTW1R",
    "timestampUsec": "1647768006658253",
    "icon": {
      "iconType": "TAB_SUBSCRIPTIONS"
    },
    "text": {
      "runs": [
        {
          "text": "庫洛姆•Kuromu",
          "bold": true
        },
        {
          "text": " turned on subscribers-only mode",
          "bold": true
        }
      ]
    },
    "subtext": {
      "runs": [
        {
          "text": "Only channel subscribers of ",
          "italics": true
        },
        {
          "text": "5 minutes",
          "italics": true
        },
        {
          "text": " or longer can send messages",
          "italics": true
        }
      ]
    },
    "timestampText": {
      "simpleText": "18:29"
    }
  }
}
```

Example RawNode data 2:

```json
{
  "liveChatModeChangeMessageRenderer": {
    "id": "ChwKGkNQVzYwcFd1MVBZQ0Zlc2VyUVlkV1JVQ2Nn",
    "timestampUsec": "1647768006657834",
    "icon": {
      "iconType": "QUESTION_ANSWER"
    },
    "text": {
      "runs": [
        {
          "text": "Members-only mode is off",
          "bold": true
        }
      ]
    },
    "subtext": {
      "runs": [
        {
          "text": "Everybody can chat now",
          "italics": true
        }
      ]
    },
    "timestampText": {
      "simpleText": "18:29"
    }
  }
}
```