### PR TITLE
feat(Log)!: Convert Log class to module

### DIFF
--- a/src/parser/helpers.ts
+++ b/src/parser/helpers.ts
@@ -1,4 +1,4 @@
-import Log from '../utils/Log.js';
+import * as Log from '../utils/Log.js';
 import { deepCompare, ParsingError } from '../utils/Utils.js';
 
 const isObserved = Symbol('ObservedArray.isObserved');
@@ -62,8 +62,9 @@ export class YTNode {
   }
 }
 
+const MAYBE_TAG = 'Maybe';
+
 export class Maybe {
-  #TAG = 'Maybe';
   readonly #value;
 
   constructor (value: any) {
@@ -278,7 +279,7 @@ export class Maybe {
    * This call is not meant to be used outside of debugging. Please use the specific type getter instead.
    */
   any(): any {
-    Log.warn(this.#TAG, 'This call is not meant to be used outside of debugging. Please use the specific type getter instead.');
+    Log.warn(MAYBE_TAG, 'This call is not meant to be used outside of debugging. Please use the specific type getter instead.');
     return this.#value;
   }
 

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -4,10 +4,11 @@ import { Platform } from '../utils/Utils.js';
 import sha1Hash from './polyfills/web-crypto.js';
 import package_json from '../../package.json' assert { type: 'json' };
 import evaluate from './jsruntime/jinter.js';
-import Log from '../utils/Log.js';
+import * as Log from '../utils/Log.js';
+
+const CACHE_TAG = 'Cache';
 
 class Cache implements ICache {
-  #TAG = 'Cache';
   #persistent_directory: string;
   #persistent: boolean;
 
@@ -23,7 +24,7 @@ class Cache implements ICache {
   #getBrowserDB() {
     const indexedDB: IDBFactory = Reflect.get(globalThis, 'indexedDB') || Reflect.get(globalThis, 'webkitIndexedDB') || Reflect.get(globalThis, 'mozIndexedDB') || Reflect.get(globalThis, 'msIndexedDB');
 
-    if (!indexedDB) return Log.warn(this.#TAG, 'IndexedDB is not supported. No cache will be used.');
+    if (!indexedDB) return Log.warn(CACHE_TAG, 'IndexedDB is not supported. No cache will be used.');
 
     return new Promise<IDBDatabase>((resolve, reject) => {
       const request = indexedDB.open('youtubei.js', 1);

--- a/src/utils/Log.ts
+++ b/src/utils/Log.ts
@@ -1,49 +1,48 @@
-export default class Log {
-  static #YTJS_TAG = 'YOUTUBEJS';
+const YTJS_TAG = 'YOUTUBEJS';
 
-  public static Level = {
-    NONE: 0,
-    ERROR: 1,
-    WARNING: 2,
-    INFO: 3,
-    DEBUG: 4
-  };
+export const Level = {
+  NONE: 0,
+  ERROR: 1,
+  WARNING: 2,
+  INFO: 3,
+  DEBUG: 4
+};
 
-  static #log_map_ = {
-    [Log.Level.ERROR]: (...args: any[]) => console.error(...args),
-    [Log.Level.WARNING]: (...args: any[]) => console.warn(...args),
-    [Log.Level.INFO]: (...args: any[]) => console.info(...args),
-    [Log.Level.DEBUG]: (...args: any[]) => console.debug(...args)
-  };
+const log_map = {
+  [Level.ERROR]: (...args: any[]) => console.error(...args),
+  [Level.WARNING]: (...args: any[]) => console.warn(...args),
+  [Level.INFO]: (...args: any[]) => console.info(...args),
+  [Level.DEBUG]: (...args: any[]) => console.debug(...args)
+};
 
-  static #log_level_ = [ Log.Level.WARNING ];
-  static #one_time_warnings_issued_ = new Set<string>();
+let log_level = [ Level.WARNING ];
+const one_time_warnings_issued = new Set<string>();
 
-  static warnOnce = (id: string, ...args: any[]) => {
-    if (this.#one_time_warnings_issued_.has(id))
-      return;
-    this.#doLog(Log.Level.WARNING, id, args);
-    this.#one_time_warnings_issued_.add(id);
-  };
+function doLog(level: number, tag?: string, args?: any[]) {
+  if (!log_map[level] || !log_level.includes(level))
+    return;
 
-  static warn = (tag?: string, ...args: any[]) => this.#doLog(Log.Level.WARNING, tag, args);
-  static error = (tag?: string, ...args: any[]) => this.#doLog(Log.Level.ERROR, tag, args);
-  static info = (tag?: string, ...args: any[]) => this.#doLog(Log.Level.INFO, tag, args);
-  static debug = (tag?: string, ...args: any[]) => this.#doLog(Log.Level.DEBUG, tag, args);
+  const tags = [ `[${YTJS_TAG}]` ];
 
-  static #doLog(level: number, tag?: string, args?: any[]) {
-    if (!this.#log_map_ [level] || !this.#log_level_.includes(level))
-      return;
+  if (tag)
+    tags.push(`[${tag}]`);
 
-    const tags = [ `[${this.#YTJS_TAG}]` ];
+  log_map[level](`${tags.join('')}:`, ...(args || []));
+}
 
-    if (tag)
-      tags.push(`[${tag}]`);
+export const warnOnce = (id: string, ...args: any[]) => {
+  if (one_time_warnings_issued.has(id))
+    return;
+  
+  doLog(Level.WARNING, id, args);
+  one_time_warnings_issued.add(id);
+};
 
-    this.#log_map_ [level](`${tags.join('')}:`, ...(args || []));
-  }
+export const warn = (tag?: string, ...args: any[]) => doLog(Level.WARNING, tag, args);
+export const error = (tag?: string, ...args: any[]) => doLog(Level.ERROR, tag, args);
+export const info = (tag?: string, ...args: any[]) => doLog(Level.INFO, tag, args);
+export const debug = (tag?: string, ...args: any[]) => doLog(Level.DEBUG, tag, args);
 
-  static setLevel(...args: number[]) {
-    this.#log_level_ = args;
-  }
+export function setLevel(...args: number[]) {
+  log_level = args;
 }

--- a/src/utils/StreamingInfo.ts
+++ b/src/utils/StreamingInfo.ts
@@ -2,7 +2,7 @@ import type { StoryboardData } from '../parser/classes/PlayerStoryboardSpec.js';
 import PlayerStoryboardSpec from '../parser/classes/PlayerStoryboardSpec.js';
 import { getStringBetweenStrings, InnertubeError, Platform } from './Utils.js';
 import * as Constants from './Constants.js';
-import Log from './Log.js';
+import * as Log from './Log.js';
 
 import type Actions from '../core/Actions.js';
 import type Player from '../core/Player.js';

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,6 +1,6 @@
 import { Memo } from '../parser/helpers.js';
 import { Text } from '../parser/misc.js';
-import Log from './Log.js';
+import * as Log from './Log.js';
 import userAgents from './user-agents.js';
 import { Jinter } from 'jintr';
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,7 +12,7 @@ export * from './HTTPClient.js';
 export { Platform } from './Utils.js';
 export * as Utils from './Utils.js';
 
-export { default as Log } from './Log.js';
+export * as Log from './Log.js';
 export * as LZW from './LZW.js';
 
 export * as ProtoUtils from './ProtoUtils.js';


### PR DESCRIPTION
This pull request converts the logger from a class to a module, as all methods and properties in the logger class were static, there was no real reason to keep it as a class. In FreeTube this shaved 889 bytes off the bundle, I know it's not much but it is something. It also meant that terser was able to inline the number values from the `Level` object to where they are used, which avoid having to look them up in the object at runtime.

I've marked this as a breaking change just in case someone was using the `Log` class as a type, but any code to use the logger outside of YouTube.js e.g. to set the log level can stay the same. If you feel like this doesn't warrant being a breaking change, I am happy to adjust the commit message and pull request title to remove the `!`.

If you are used to writing Java code where everything needs to be a class you might try to do the same in JavaScript but for web apps using classes when they are not needed is considered an anti-pattern as most mimifiers can't optimise classes, so they end up in the output almost identical as in the source code. The only mimifier that can handle classes is the Google Closure Compiler but that requires writing code specifically for it, including special comments on all classes, properties and methods.