### PR TITLE
chore(parser)!: Remove getters that have been deprecated for a long time

### DIFF
--- a/src/parser/classes/Channel.ts
+++ b/src/parser/classes/Channel.ts
@@ -1,4 +1,3 @@
-import { Log } from '../../utils/index.js';
 import { YTNode } from '../helpers.js';
 import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
@@ -37,25 +36,5 @@ export default class Channel extends YTNode {
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
     this.subscribe_button = Parser.parseItem(data.subscribeButton, [ SubscribeButton, Button ]);
     this.description_snippet = new Text(data.descriptionSnippet);
-  }
-
-  /**
-   * @deprecated
-   * This will be removed in a future release.
-   * Please use {@link Channel.subscriber_count} instead.
-   */
-  get subscribers(): Text {
-    Log.warnOnce(Channel.type, 'Channel#subscribers is deprecated. Please use Channel#subscriber_count instead.');
-    return this.subscriber_count;
-  }
-
-  /**
-   * @deprecated
-   * This will be removed in a future release.
-   * Please use {@link Channel.video_count} instead.
-   */
-  get videos(): Text {
-    Log.warnOnce(Channel.type, 'Channel#videos is deprecated. Please use Channel#video_count instead.');
-    return this.video_count;
   }
 }

--- a/src/parser/classes/ChannelAboutFullMetadata.ts
+++ b/src/parser/classes/ChannelAboutFullMetadata.ts
@@ -1,4 +1,3 @@
-import { Log } from '../../utils/index.js';
 import { YTNode, type ObservedArray } from '../helpers.js';
 import { Parser, type RawNode } from '../index.js';
 import Button from './Button.js';
@@ -48,25 +47,5 @@ export default class ChannelAboutFullMetadata extends YTNode {
     this.can_reveal_email = !data.signInForBusinessEmail;
     this.country = new Text(data.country);
     this.buttons = Parser.parseArray(data.actionButtons, Button);
-  }
-
-  /**
-   * @deprecated
-   * This will be removed in a future release.
-   * Please use {@link ChannelAboutFullMetadata.view_count} instead.
-   */
-  get views() {
-    Log.warnOnce(ChannelAboutFullMetadata.type, 'ChannelAboutFullMetadata#views is deprecated. Please use ChannelAboutFullMetadata#view_count instead.');
-    return this.view_count;
-  }
-
-  /**
-   * @deprecated
-   * This will be removed in a future release.
-   * Please use {@link ChannelAboutFullMetadata.joined_date} instead.
-   */
-  get joined(): Text {
-    Log.warnOnce(ChannelAboutFullMetadata.type, 'ChannelAboutFullMetadata#joined is deprecated. Please use ChannelAboutFullMetadata#joined_date instead.');
-    return this.joined_date;
   }
 }

--- a/src/parser/classes/ChannelVideoPlayer.ts
+++ b/src/parser/classes/ChannelVideoPlayer.ts
@@ -1,7 +1,6 @@
 import Text from './misc/Text.js';
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
-import { Log } from '../../utils/index.js';
 
 export default class ChannelVideoPlayer extends YTNode {
   static type = 'ChannelVideoPlayer';
@@ -19,25 +18,5 @@ export default class ChannelVideoPlayer extends YTNode {
     this.description = new Text(data.description);
     this.view_count = new Text(data.viewCountText);
     this.published_time = new Text(data.publishedTimeText);
-  }
-
-  /**
-   * @deprecated
-   * This will be removed in a future release.
-   * Please use {@link ChannelVideoPlayer.view_count} instead.
-   */
-  get views(): Text {
-    Log.warnOnce(ChannelVideoPlayer.type, 'ChannelVideoPlayer#views is deprecated. Please use ChannelVideoPlayer#view_count instead.');
-    return this.view_count;
-  }
-
-  /**
-   * @deprecated
-   * This will be removed in a future release.
-   * Please use {@link ChannelVideoPlayer.published_time} instead.
-   */
-  get published(): Text {
-    Log.warnOnce(ChannelVideoPlayer.type, 'ChannelVideoPlayer#published is deprecated. Please use ChannelVideoPlayer#published_time instead.');
-    return this.published_time;
   }
 }

--- a/src/parser/ytmusic/Search.ts
+++ b/src/parser/ytmusic/Search.ts
@@ -16,7 +16,6 @@ import TabbedSearchResults from '../classes/TabbedSearchResults.js';
 import type { ObservedArray } from '../helpers.js';
 import type { ISearchResponse } from '../types/ParsedResponse.js';
 import type { ApiResponse, Actions } from '../../core/index.js';
-import type MusicResponsiveListItem from '../classes/MusicResponsiveListItem.js';
 
 export default class Search {
   #page: ISearchResponse;
@@ -145,20 +144,6 @@ export default class Search {
 
   get playlists(): MusicShelf | undefined {
     return this.contents?.filterType(MusicShelf).find((section) => section.title.toString() === 'Community playlists');
-  }
-
-  /**
-   * @deprecated Use {@link Search.contents} instead.
-   */
-  get results(): ObservedArray<MusicResponsiveListItem> | undefined {
-    return this.contents?.firstOfType(MusicShelf)?.contents;
-  }
-
-  /**
-   * @deprecated Use {@link Search.contents} instead.
-   */
-  get sections(): ObservedArray<MusicShelf> | undefined {
-    return this.contents?.filterType(MusicShelf);
   }
 
   get page(): ISearchResponse {


### PR DESCRIPTION
These getters have been marked as deprecated for a long tme and many of them logged warnings when they were used, so I think it is okay to remove them now.