### PR TITLE
chore(Utils): Bump WEB version constant to latest version

### DIFF
--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -33,7 +33,7 @@ export const CLIENTS = Object.freeze({
   WEB: {
     NAME_ID: '1',
     NAME: 'WEB',
-    VERSION: '2.20240111.09.00',
+    VERSION: '2.20241121.01.00',
     API_KEY: 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
     API_VERSION: 'v1',
     STATIC_VISITOR_ID: '6zpwvWUNAco'


### PR DESCRIPTION
The hardcoded version is over 11 months old and as some fields are not returned for older versions, I decided to update it.