### PR TITLE
feat(parser): Add `animated_image` to `PageHeaderView`

### DIFF
--- a/src/parser/classes/PageHeaderView.ts
+++ b/src/parser/classes/PageHeaderView.ts
@@ -14,6 +14,7 @@ export default class PageHeaderView extends YTNode {
 
   title: DynamicTextView | null;
   image: ContentPreviewImageView | DecoratedAvatarView | null;
+  animated_image: ContentPreviewImageView | null;
   metadata: ContentMetadataView | null;
   actions: FlexibleActionsView | null;
   description: DescriptionPreviewView | null;
@@ -24,6 +25,7 @@ export default class PageHeaderView extends YTNode {
     super();
     this.title = Parser.parseItem(data.title, DynamicTextView);
     this.image = Parser.parseItem(data.image, [ ContentPreviewImageView, DecoratedAvatarView ]);
+    this.animated_image = Parser.parseItem(data.animatedImage, ContentPreviewImageView);
     this.metadata = Parser.parseItem(data.metadata, ContentMetadataView);
     this.actions = Parser.parseItem(data.actions, FlexibleActionsView);
     this.description = Parser.parseItem(data.description, DescriptionPreviewView);


### PR DESCRIPTION
This field is used for the channel thumbnail on some system channels such as `https://youtube.com/gaming` and `https://youtube.com/learning` the thumbnail links point to animated WebP images.