### PR TITLE
feat(parser): Add `ClientSideToggleMenuItem`

### DIFF
--- a/src/parser/classes/ClientSideToggleMenuItem.ts
+++ b/src/parser/classes/ClientSideToggleMenuItem.ts
@@ -1,5 +1,6 @@
 import { YTNode } from '../helpers.js';
 import type { RawNode } from '../index.js';
+import NavigationEndpoint from './NavigationEndpoint.js';
 import Text from './misc/Text.js';
 
 export default class ClientSideToggleMenuItem extends YTNode {
@@ -10,6 +11,7 @@ export default class ClientSideToggleMenuItem extends YTNode {
   toggled_text: Text;
   toggled_icon_type: string;
   menu_item_identifier: string;
+  endpoint: NavigationEndpoint;
 
   constructor(data: RawNode) {
     super();
@@ -18,5 +20,6 @@ export default class ClientSideToggleMenuItem extends YTNode {
     this.toggled_text = new Text(data.toggledText);
     this.toggled_icon_type = data.toggledIcon.iconType;
     this.menu_item_identifier = data.menuItemIdentifier;
+    this.endpoint = new NavigationEndpoint(data.command);
   }
 }

--- a/src/parser/classes/ClientSideToggleMenuItem.ts
+++ b/src/parser/classes/ClientSideToggleMenuItem.ts
@@ -10,8 +10,15 @@ export default class ClientSideToggleMenuItem extends YTNode {
   icon_type: string;
   toggled_text: Text;
   toggled_icon_type: string;
+  is_toggled?: boolean;
   menu_item_identifier: string;
   endpoint: NavigationEndpoint;
+  logging_directives?: {
+    visibility: {
+      types: string;
+    },
+    enable_displaylogger_experiment: boolean;
+  };
 
   constructor(data: RawNode) {
     super();
@@ -19,7 +26,21 @@ export default class ClientSideToggleMenuItem extends YTNode {
     this.icon_type = data.defaultIcon.iconType;
     this.toggled_text = new Text(data.toggledText);
     this.toggled_icon_type = data.toggledIcon.iconType;
+    
+    if (Reflect.has(data, 'isToggled')) {
+      this.is_toggled = data.isToggled;
+    }
+
     this.menu_item_identifier = data.menuItemIdentifier;
     this.endpoint = new NavigationEndpoint(data.command);
+
+    if (Reflect.has(data, 'loggingDirectives')) {
+      this.logging_directives = {
+        visibility: {
+          types: data.loggingDirectives.visibility.types
+        },
+        enable_displaylogger_experiment: data.loggingDirectives.enableDisplayloggerExperiment
+      };
+    }
   }
 }

--- a/src/parser/classes/ClientSideToggleMenuItem.ts
+++ b/src/parser/classes/ClientSideToggleMenuItem.ts
@@ -1,0 +1,22 @@
+import { YTNode } from '../helpers.js';
+import type { RawNode } from '../index.js';
+import Text from './misc/Text.js';
+
+export default class ClientSideToggleMenuItem extends YTNode {
+  static type = 'ClientSideToggleMenuItem';
+
+  text: Text;
+  icon_type: string;
+  toggled_text: Text;
+  toggled_icon_type: string;
+  menu_item_identifier: string;
+
+  constructor(data: RawNode) {
+    super();
+    this.text = new Text(data.defaultText);
+    this.icon_type = data.defaultIcon.iconType;
+    this.toggled_text = new Text(data.toggledText);
+    this.toggled_icon_type = data.toggledIcon.iconType;
+    this.menu_item_identifier = data.menuItemIdentifier;
+  }
+}

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -64,6 +64,7 @@ export { default as ChipBarView } from './classes/ChipBarView.js';
 export { default as ChipCloud } from './classes/ChipCloud.js';
 export { default as ChipCloudChip } from './classes/ChipCloudChip.js';
 export { default as ChipView } from './classes/ChipView.js';
+export { default as ClientSideToggleMenuItem } from './classes/ClientSideToggleMenuItem.js';
 export { default as ClipAdState } from './classes/ClipAdState.js';
 export { default as ClipCreation } from './classes/ClipCreation.js';
 export { default as ClipCreationScrubber } from './classes/ClipCreationScrubber.js';


### PR DESCRIPTION
Fixes #595 
Fixes #727 

Example RawNode data 1:

```json
{
  "clientSideToggleMenuItemRenderer": {
    "defaultText": {
      "runs": [
        {
          "text": "Timestamps"
        }
      ]
    },
    "defaultIcon": {
      "iconType": "ACCESS_TIME"
    },
    "toggledText": {
      "runs": [
        {
          "text": "Timestamps"
        }
      ]
    },
    "toggledIcon": {
      "iconType": "ACCESS_TIME"
    },
    "menuItemIdentifier": "timestamp_toggle",
    "command": {
      "clickTrackingParams": "CAYQl98BIhMI7bKs8KG9iQMVWaPYBR2lDhra",
      "toggleLiveChatTimestampsEndpoint": {
        "hack": true
      }
    }
  }
}
```

Example RawNode data 2:

```json
{
  "clientSideToggleMenuItemRenderer": {
    "defaultText": {
      "runs": [
        {
          "text": "Reactions"
        }
      ]
    },
    "defaultIcon": {
      "iconType": "HEART_CIRCLE"
    },
    "toggledText": {
      "runs": [
        {
          "text": "Reactions"
        }
      ]
    },
    "toggledIcon": {
      "iconType": "HEART_CIRCLE"
    },
    "isToggled": true,
    "menuItemIdentifier": "reactions_toggle",
    "command": {
      "clickTrackingParams": "CBIQjcsMGDsiEwin892z6KCKAxXtAXsHHdGyB14=",
      "toggleLiveReactionsMuteCommand": {
        "hack": true
      }
    },
    "loggingDirectives": {
      "trackingParams": "CBIQjcsMGDsiEwin892z6KCKAxXtAXsHHdGyB14=",
      "visibility": {
        "types": "12"
      },
      "enableDisplayloggerExperiment": true
    }
  }
}
```

---

I notice that the `command` field is not a conventional `NavigationEndpoint`

```json
"command": {
  "clickTrackingParams": "CAYQl98BIhMI7bKs8KG9iQMVWaPYBR2lDhra",
  "toggleLiveChatTimestampsEndpoint": {
    "hack": true
  }
}
```

I'm not sure how to properly parse this.

Or maybe, should we just ignore the `command` field?
Since it does not interact with any backend endpoint.