### PR TITLE
chore(parser): Hoist API_PATH constants in endpoint nodes

### DIFF
--- a/src/parser/classes/commands/GetKidsBlocklistPickerCommand.ts
+++ b/src/parser/classes/commands/GetKidsBlocklistPickerCommand.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { GetKidsBlocklistPickerRequest, IEndpoint, RawNode } from '../../index.js';
 
+const API_PATH = 'kids/get_kids_blocklist_picker';
+
 export default class GetKidsBlocklistPickerCommand extends YTNode implements IEndpoint<GetKidsBlocklistPickerRequest> {
   static type = 'GetKidsBlocklistPickerCommand';
 
-  #API_PATH = 'kids/get_kids_blocklist_picker';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class GetKidsBlocklistPickerCommand extends YTNode implements IEn
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): GetKidsBlocklistPickerRequest {

--- a/src/parser/classes/endpoints/AddToPlaylistServiceEndpoint.ts
+++ b/src/parser/classes/endpoints/AddToPlaylistServiceEndpoint.ts
@@ -1,10 +1,10 @@
 import { YTNode } from '../../helpers.js';
 import type { AddToPlaylistServiceRequest, IEndpoint, RawNode } from '../../index.js';
 
+const API_PATH = 'playlist/get_add_to_playlist';
+
 export default class AddToPlaylistServiceEndpoint extends YTNode implements IEndpoint<AddToPlaylistServiceRequest> {
   static type = 'AddToPlaylistServiceEndpoint';
-
-  #API_PATH = 'playlist/get_add_to_playlist';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +13,7 @@ export default class AddToPlaylistServiceEndpoint extends YTNode implements IEnd
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): AddToPlaylistServiceRequest {

--- a/src/parser/classes/endpoints/BrowseEndpoint.ts
+++ b/src/parser/classes/endpoints/BrowseEndpoint.ts
@@ -1,10 +1,10 @@
 import { YTNode } from '../../helpers.js';
 import type { BrowseRequest, IEndpoint, RawNode } from '../../index.js';
 
+const API_PATH = 'browse';
+
 export default class BrowseEndpoint extends YTNode implements IEndpoint<BrowseRequest> {
   static type = 'BrowseEndpoint';
-
-  #API_PATH = 'browse';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +13,7 @@ export default class BrowseEndpoint extends YTNode implements IEndpoint<BrowseRe
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): BrowseRequest {

--- a/src/parser/classes/endpoints/CreateCommentEndpoint.ts
+++ b/src/parser/classes/endpoints/CreateCommentEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { CreateCommentRequest, IEndpoint, RawNode } from '../../index.js';
 
+const API_PATH = 'comment/create_comment';
+
 export default class CreateCommentEndpoint extends YTNode implements IEndpoint<CreateCommentRequest> {
   static type = 'CreateCommentEndpoint';
 
-  #API_PATH = 'comment/create_comment';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class CreateCommentEndpoint extends YTNode implements IEndpoint<C
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): CreateCommentRequest {

--- a/src/parser/classes/endpoints/CreatePlaylistServiceEndpoint.ts
+++ b/src/parser/classes/endpoints/CreatePlaylistServiceEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { CreatePlaylistServiceRequest, IEndpoint, RawNode } from '../../index.js';
 
+const API_PATH = 'playlist/create';
+
 export default class CreatePlaylistServiceEndpoint extends YTNode implements IEndpoint<CreatePlaylistServiceRequest> {
   static type = 'CreatePlaylistServiceEndpoint';
 
-  #API_PATH = 'playlist/create';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class CreatePlaylistServiceEndpoint extends YTNode implements IEn
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): CreatePlaylistServiceRequest {

--- a/src/parser/classes/endpoints/DeletePlaylistEndpoint.ts
+++ b/src/parser/classes/endpoints/DeletePlaylistEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { DeletePlaylistServiceRequest, IEndpoint, RawNode } from '../../index.js';
 
+const API_PATH = 'playlist/delete';
+
 export default class DeletePlaylistEndpoint extends YTNode implements IEndpoint<DeletePlaylistServiceRequest> {
   static type = 'DeletePlaylistEndpoint';
 
-  #API_PATH = 'playlist/delete';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class DeletePlaylistEndpoint extends YTNode implements IEndpoint<
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): DeletePlaylistServiceRequest {

--- a/src/parser/classes/endpoints/FeedbackEndpoint.ts
+++ b/src/parser/classes/endpoints/FeedbackEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { FeedbackRequest, IEndpoint, RawNode } from '../../index.js';
 
+const API_PATH = 'feedback';
+
 export default class FeedbackEndpoint extends YTNode implements IEndpoint<FeedbackRequest> {
   static type = 'FeedbackEndpoint';
 
-  #API_PATH = 'feedback';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class FeedbackEndpoint extends YTNode implements IEndpoint<Feedba
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): FeedbackRequest {

--- a/src/parser/classes/endpoints/GetAccountsListInnertubeEndpoint.ts
+++ b/src/parser/classes/endpoints/GetAccountsListInnertubeEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { GetAccountsListInnertubeRequest, IEndpoint, RawNode } from '../../index.js';
 
+const API_PATH = 'account/accounts_list';
+
 export default class GetAccountsListInnertubeEndpoint extends YTNode implements IEndpoint<GetAccountsListInnertubeRequest> {
   static type = 'GetAccountsListInnertubeEndpoint';
 
-  #API_PATH = 'account/accounts_list';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class GetAccountsListInnertubeEndpoint extends YTNode implements 
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): GetAccountsListInnertubeRequest {

--- a/src/parser/classes/endpoints/LikeEndpoint.ts
+++ b/src/parser/classes/endpoints/LikeEndpoint.ts
@@ -1,12 +1,13 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, LikeRequest, RawNode } from '../../index.js';
 
+const LIKE_API_PATH = 'like/like';
+const DISLIKE_API_PATH = 'like/dislike';
+const REMOVE_LIKE_API_PATH = 'like/removelike';
+
 export default class LikeEndpoint extends YTNode implements IEndpoint<LikeRequest> {
   static type = 'LikeEndpoint';
 
-  #LIKE_API_PATH = 'like/like';
-  #DISLIKE_API_PATH = 'like/dislike';
-  #REMOVE_LIKE_API_PATH = 'like/removelike';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -16,8 +17,8 @@ export default class LikeEndpoint extends YTNode implements IEndpoint<LikeReques
 
   public getApiPath(): string {
     return this.#data.status === 'DISLIKE' ?
-      this.#DISLIKE_API_PATH : this.#data.status === 'INDIFFERENT' ?
-        this.#REMOVE_LIKE_API_PATH : this.#LIKE_API_PATH;
+      DISLIKE_API_PATH : this.#data.status === 'INDIFFERENT' ?
+        REMOVE_LIKE_API_PATH : LIKE_API_PATH;
   }
 
   public buildRequest(): LikeRequest {

--- a/src/parser/classes/endpoints/LiveChatItemContextMenuEndpoint.ts
+++ b/src/parser/classes/endpoints/LiveChatItemContextMenuEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, RawNode, LiveChatItemContextMenuRequest } from '../../index.js';
 
+const API_PATH = 'live_chat/get_item_context_menu';
+
 export default class LiveChatItemContextMenuEndpoint extends YTNode implements IEndpoint<LiveChatItemContextMenuRequest> {
   static type = 'LiveChatItemContextMenuEndpoint';
 
-  #API_PATH = 'live_chat/get_item_context_menu';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class LiveChatItemContextMenuEndpoint extends YTNode implements I
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): LiveChatItemContextMenuRequest {

--- a/src/parser/classes/endpoints/ModifyChannelNotificationPreferenceEndpoint.ts
+++ b/src/parser/classes/endpoints/ModifyChannelNotificationPreferenceEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, ModifyChannelNotificationPreferenceRequest, RawNode } from '../../index.js';
 
+const API_PATH = 'notification/modify_channel_preference';
+
 export default class ModifyChannelNotificationPreferenceEndpoint extends YTNode implements IEndpoint<ModifyChannelNotificationPreferenceRequest> {
   static type = 'ModifyChannelNotificationPreferenceEndpoint';
 
-  #API_PATH = 'notification/modify_channel_preference';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class ModifyChannelNotificationPreferenceEndpoint extends YTNode 
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): ModifyChannelNotificationPreferenceRequest {

--- a/src/parser/classes/endpoints/PerformCommentActionEndpoint.ts
+++ b/src/parser/classes/endpoints/PerformCommentActionEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, PerformCommentActionRequest, RawNode } from '../../index.js';
 
+const API_PATH = 'comment/perform_comment_action';
+
 export default class PerformCommentActionEndpoint extends YTNode implements IEndpoint<PerformCommentActionRequest> {
   static type = 'PerformCommentActionEndpoint';
 
-  #API_PATH = 'comment/perform_comment_action';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class PerformCommentActionEndpoint extends YTNode implements IEnd
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): PerformCommentActionRequest {

--- a/src/parser/classes/endpoints/PlaylistEditEndpoint.ts
+++ b/src/parser/classes/endpoints/PlaylistEditEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, PlaylistEditRequest, RawNode } from '../../index.js';
 
+const API_PATH = 'browse/edit_playlist';
+
 export default class PlaylistEditEndpoint extends YTNode implements IEndpoint<PlaylistEditRequest> {
   static type = 'PlaylistEditEndpoint';
 
-  #API_PATH = 'browse/edit_playlist';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class PlaylistEditEndpoint extends YTNode implements IEndpoint<Pl
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): PlaylistEditRequest {

--- a/src/parser/classes/endpoints/ReelWatchEndpoint.ts
+++ b/src/parser/classes/endpoints/ReelWatchEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, RawNode, ReelWatchRequest } from '../../index.js';
 
+const API_PATH = 'reel/reel_item_watch';
+
 export default class ReelWatchEndpoint extends YTNode implements IEndpoint<ReelWatchRequest> {
   static type = 'ReelWatchEndpoint';
 
-  #API_PATH = 'reel/reel_item_watch';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class ReelWatchEndpoint extends YTNode implements IEndpoint<ReelW
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): ReelWatchRequest {

--- a/src/parser/classes/endpoints/SearchEndpoint.ts
+++ b/src/parser/classes/endpoints/SearchEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, RawNode, SearchRequest } from '../../index.js';
 
+const API_PATH = 'search';
+
 export default class SearchEndpoint extends YTNode implements IEndpoint<SearchRequest> {
   static type = 'SearchEndpoint';
 
-  #API_PATH = 'search';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class SearchEndpoint extends YTNode implements IEndpoint<SearchRe
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): SearchRequest {

--- a/src/parser/classes/endpoints/ShareEntityServiceEndpoint.ts
+++ b/src/parser/classes/endpoints/ShareEntityServiceEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, RawNode, ShareEntityServiceRequest } from '../../index.js';
 
+const API_PATH = 'share/get_share_panel';
+
 export default class ShareEntityServiceEndpoint extends YTNode implements IEndpoint<ShareEntityServiceRequest> {
   static type = 'ShareEntityServiceEndpoint';
 
-  #API_PATH = 'share/get_share_panel';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class ShareEntityServiceEndpoint extends YTNode implements IEndpo
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): ShareEntityServiceRequest {

--- a/src/parser/classes/endpoints/SubscribeEndpoint.ts
+++ b/src/parser/classes/endpoints/SubscribeEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, RawNode, SubscribeRequest } from '../../index.js';
 
+const API_PATH = 'subscription/subscribe';
+
 export default class SubscribeEndpoint extends YTNode implements IEndpoint<SubscribeRequest> {
   static type = 'SubscribeEndpoint';
 
-  #API_PATH = 'subscription/subscribe';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class SubscribeEndpoint extends YTNode implements IEndpoint<Subsc
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): SubscribeRequest {

--- a/src/parser/classes/endpoints/UnsubscribeEndpoint.ts
+++ b/src/parser/classes/endpoints/UnsubscribeEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, RawNode, UnsubscribeRequest } from '../../index.js';
 
+const API_PATH = 'subscription/unsubscribe';
+
 export default class UnsubscribeEndpoint extends YTNode implements IEndpoint<UnsubscribeRequest> {
   static type = 'UnsubscribeEndpoint';
 
-  #API_PATH = 'subscription/unsubscribe';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class UnsubscribeEndpoint extends YTNode implements IEndpoint<Uns
   }
 
   public getApiPath(): string{
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): UnsubscribeRequest {

--- a/src/parser/classes/endpoints/WatchEndpoint.ts
+++ b/src/parser/classes/endpoints/WatchEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, RawNode, WatchRequest } from '../../index.js';
 
+const API_PATH = 'player';
+
 export default class WatchEndpoint extends YTNode implements IEndpoint<WatchRequest> {
   static type = 'WatchEndpoint';
 
-  #API_PATH = 'player';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class WatchEndpoint extends YTNode implements IEndpoint<WatchRequ
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): WatchRequest {

--- a/src/parser/classes/endpoints/WatchNextEndpoint.ts
+++ b/src/parser/classes/endpoints/WatchNextEndpoint.ts
@@ -1,10 +1,11 @@
 import { YTNode } from '../../helpers.js';
 import type { IEndpoint, RawNode, WatchNextRequest } from '../../index.js';
 
+const API_PATH = 'next';
+
 export default class WatchNextEndpoint extends YTNode implements IEndpoint<WatchNextRequest> {
   static type = 'WatchNextEndpoint';
 
-  #API_PATH = 'next';
   #data: RawNode;
 
   constructor(data: RawNode) {
@@ -13,7 +14,7 @@ export default class WatchNextEndpoint extends YTNode implements IEndpoint<Watch
   }
 
   public getApiPath(): string {
-    return this.#API_PATH;
+    return API_PATH;
   }
 
   public buildRequest(): WatchNextRequest {


### PR DESCRIPTION
Hoisting these constants into normal variables results in a shaved 1053 bytes off FreeTube's bundle size, as it didn't require the private property polyfill and was able to inline the constants, as they are only used once. I didn't inline them in the source code to allow server side apps that likely handle a lot more requests and don't use bundling benefit from only needing to initialise those strings once.