### PR TITLE
fix(ButtonCardView): correct typo

### DIFF
--- a/src/parser/classes/ButtonCardView.ts
+++ b/src/parser/classes/ButtonCardView.ts
@@ -12,7 +12,7 @@ export default class ButtonCardView extends YTNode {
   constructor(data: RawNode) {
     super();
     this.title = data.title;
-    this.icon_name = data.icon.sources[0].clientResource.imageName;
+    this.icon_name = data.image.sources[0].clientResource.imageName;
     this.on_tap_endpoint = new NavigationEndpoint(data.rendererContext.commandContext.onTap);
   }
 }


### PR DESCRIPTION
Fix the typo introduced in #834

The data field should be `data.image` rather than `data.icon`.