### PR TITLE
fix(toDash): Fix default audio stream for dubbed movie trailers

### DIFF
--- a/src/utils/StreamingInfo.ts
+++ b/src/utils/StreamingInfo.ts
@@ -425,7 +425,8 @@ function getTrackRoles(format: Format, has_drc_streams: boolean) {
   }
 
   const roles: ('main' | 'dub' | 'description' | 'enhanced-audio-intelligibility' | 'alternate')[] = [
-    format.is_original ? 'main' : 'alternate'
+    // movie trailers can have a dubbed track as the only audio track so is_original is false but format.audio_track.audio_is_default is true
+    format.is_original || format.audio_track?.audio_is_default ? 'main' : 'alternate'
   ];
 
   if (format.is_dubbed || format.is_auto_dubbed)


### PR DESCRIPTION
Movie trailers usually only have the h264 and m4a streams. Dubbed movie trailers still only have that single itag 140 audio stream but have the `audio_track` property (with `audio_is_default` set to `true`) and `xtags` (with `acont` = `dubbed`) so when YouTube.js generates the DASH manifest for those trailers, it currently gives the audio stream the `dub` and `alternate` roles. This pull request fixes that so it gets the `dub` and `main` roles (so correctly labelling it as the default audio stream).