### PR TITLE
feat(ContentMetadataView): Parse `enableTruncation`

### DIFF
--- a/src/parser/classes/ContentMetadataView.ts
+++ b/src/parser/classes/ContentMetadataView.ts
@@ -8,6 +8,7 @@ export type MetadataRow = {
   metadata_parts?: {
     text: Text | null;
     avatar_stack: AvatarStackView | null;
+    enable_truncation?: boolean;
   }[];
 };
 
@@ -22,7 +23,8 @@ export default class ContentMetadataView extends YTNode {
     this.metadata_rows = data.metadataRows.map((row: RawNode) => ({
       metadata_parts: row.metadataParts?.map((part: RawNode) => ({
         text: part.text ? Text.fromAttributed(part.text) : null,
-        avatar_stack: Parser.parseItem(part.avatarStack, AvatarStackView)
+        avatar_stack: Parser.parseItem(part.avatarStack, AvatarStackView),
+        enable_truncation: data.enableTruncation
       }))
     }));
     this.delimiter = data.delimiter;


### PR DESCRIPTION
Example RawNode data:

```json
{
  "contentMetadataViewModel": {
    "metadataRows": [
      {
        "metadataParts": [
          {
            "text": {
              "content": "@pbsspacetime",
              "styleRuns": [
                {
                  "weightLabel": "FONT_WEIGHT_MEDIUM",
                  "styleRunExtensions": {
                    "styleRunColorMapExtension": {
                      "colorMap": [
                        {
                          "key": "USER_INTERFACE_THEME_LIGHT",
                          "value": 4279440147
                        },
                        {
                          "key": "USER_INTERFACE_THEME_DARK",
                          "value": 4294967295
                        }
                      ]
                    }
                  }
                }
              ]
            },
            "enableTruncation": true
          }
        ]
      }
    ],
    "delimiter": "•"
  }
}
```