### PR TITLE
perf: Optimise DASH manifest generation

### DIFF
--- a/src/utils/DashManifest.tsx
+++ b/src/utils/DashManifest.tsx
@@ -32,13 +32,13 @@ async function OTFPostLiveDvrSegmentInfo({ info }: { info: FSegmentInfo }) {
 
   const template = await info.getSegmentTemplate();
 
-  return <segment-template
+  return <segmentTemplate
     startNumber={template.init_url ? '1' : '0'}
     timescale="1000"
     initialization={template.init_url}
     media={template.media_url}
   >
-    <segment-timeline>
+    <segmentTimeline>
       {
         template.timeline.map((segment_duration) => (
           <s
@@ -47,8 +47,8 @@ async function OTFPostLiveDvrSegmentInfo({ info }: { info: FSegmentInfo }) {
           />
         ))
       }
-    </segment-timeline>
-  </segment-template>;
+    </segmentTimeline>
+  </segmentTemplate>;
 }
 
 function SegmentInfo({ info }: { info: FSegmentInfo }) {
@@ -56,12 +56,12 @@ function SegmentInfo({ info }: { info: FSegmentInfo }) {
     return <OTFPostLiveDvrSegmentInfo info={info} />;
   }
   return <>
-    <base-url>
+    <baseURL>
       {info.base_url}
-    </base-url>
-    <segment-base indexRange={`${info.index_range.start}-${info.index_range.end}`}>
+    </baseURL>
+    <segmentBase indexRange={`${info.index_range.start}-${info.index_range.end}`}>
       <initialization range={`${info.init_range.start}-${info.init_range.end}`} />
-    </segment-base>
+    </segmentBase>
   </>;
 }
 
@@ -87,7 +87,7 @@ async function DashManifest({
 
   // XXX: DASH spec: https://standards.iso.org/ittf/PubliclyAvailableStandards/c083314_ISO_IEC%2023009-1_2022(en).zip
 
-  return <mpd
+  return <mPD
     xmlns="urn:mpeg:dash:schema:mpd:2011"
     minBufferTime="PT1.500S"
     profiles="urn:mpeg:dash:profile:isoff-main:2011"
@@ -99,7 +99,7 @@ async function DashManifest({
     <period>
       {
         audio_sets.map((set, index) => (
-          <adaptation-set
+          <adaptationSet
             id={index}
             mimeType={set.mime_type}
             startWithSAP="1"
@@ -125,7 +125,7 @@ async function DashManifest({
             }
             {
               set.channels &&
-              <audio-channel-configuration
+              <audioChannelConfiguration
                 schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
                 value={set.channels}
               />
@@ -140,7 +140,7 @@ async function DashManifest({
                 >
                   {
                     rep.channels &&
-                    <audio-channel-configuration
+                    <audioChannelConfiguration
                       schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
                       value={rep.channels}
                     />
@@ -149,12 +149,12 @@ async function DashManifest({
                 </representation>
               ))
             }
-          </adaptation-set>
+          </adaptationSet>
         ))
       }
       {
         video_sets.map((set, index) => (
-          <adaptation-set
+          <adaptationSet
             id={index + audio_sets.length}
             mimeType={set.mime_type}
             startWithSAP="1"
@@ -166,21 +166,21 @@ async function DashManifest({
           >
             {
               set.color_info.primaries &&
-              <supplemental-property
+              <supplementalProperty
                 schemeIdUri="urn:mpeg:mpegB:cicp:ColourPrimaries"
                 value={set.color_info.primaries}
               />
             }
             {
               set.color_info.transfer_characteristics &&
-              <supplemental-property
+              <supplementalProperty
                 schemeIdUri="urn:mpeg:mpegB:cicp:TransferCharacteristics"
                 value={set.color_info.transfer_characteristics}
               />
             }
             {
               set.color_info.matrix_coefficients &&
-              <supplemental-property
+              <supplementalProperty
                 schemeIdUri="urn:mpeg:mpegB:cicp:MatrixCoefficients"
                 value={set.color_info.matrix_coefficients}
               />
@@ -199,12 +199,12 @@ async function DashManifest({
                 </representation>
               ))
             }
-          </adaptation-set>
+          </adaptationSet>
         ))
       }
       {
         image_sets.map(async (set, index) => {
-          return <adaptation-set
+          return <adaptationSet
             id={index + audio_sets.length + video_sets.length}
             mimeType={await set.getMimeType()}
             contentType="image"
@@ -217,11 +217,11 @@ async function DashManifest({
                   width={rep.sheet_width}
                   height={rep.sheet_height}
                 >
-                  <essential-property
+                  <essentialProperty
                     schemeIdUri="http://dashif.org/thumbnail_tile"
                     value={`${rep.columns}x${rep.rows}`}
                   />
-                  <segment-template
+                  <segmentTemplate
                     media={rep.template_url}
                     duration={rep.template_duration}
                     startNumber="0"
@@ -229,12 +229,12 @@ async function DashManifest({
                 </representation>
               ))
             }
-          </adaptation-set>;
+          </adaptationSet>;
         })
       }
       {
         text_sets.map((set, index) => {
-          return <adaptation-set
+          return <adaptationSet
             id={index + audio_sets.length + video_sets.length + image_sets.length}
             mimeType={set.mime_type}
             lang={set.language}
@@ -255,15 +255,15 @@ async function DashManifest({
               id={set.representation.uid}
               bandwidth="0"
             >
-              <base-url>
+              <baseURL>
                 {set.representation.base_url}
-              </base-url>
+              </baseURL>
             </representation>
-          </adaptation-set>;
+          </adaptationSet>;
         })
       }
     </period>
-  </mpd>;
+  </mPD>;
 }
 
 export function toDash(


### PR DESCRIPTION
This pull request introduces various optimisations to DASH manifest generation. I have checked that the generated XML is still the same as before.
1. It turns out that the JSX transform only checks the first letter in the tag name to decided if it is an element (lower case) or a component/function (upper case). So I decided to change the tag names to be the same as their actual names but with the first letter changed to lower case, that way we can simplify the code in `normalizeTag` name to just change the first character to upper case.
2. For text nodes we currently create a `TEXT_ELEMENT` wrapper object and then give that `TEXT_ELEMENT` object special treatment in `renderElementToString` to treat it as a string. As our target is just a string and not some DOM like environment, I simplified it to just pass through the string and then to give it special treatment if it is a string. That means the code is simpler and we are creating less temporary objects.
3. I simplified the property handling from using `.filter()`, `.map()`, checking the `.length`, then calling `.join()` and appending it to the element string to a `for-of` loop with an `if` that appends directly to the element string.

The DASH manifest generation still isn't ideal (parser structure -> streaming info structure -> jsx elements tree -> string) but these changes will at least improve it a bit, without major refactoring.