### PR TITLE
chore: enable sourceMaps again to show error traces related to typescript files and allow local debugging for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "build:deno": "cpy ./src ./deno && cpy ./protos ./deno && esbuild ./src/utils/DashManifest.tsx --keep-names --format=esm --platform=neutral --target=es2020 --outfile=./deno/src/utils/DashManifest.js && cpy ./package.json ./deno && replace \".js';\" \".ts';\" ./deno -r && replace '.js\";' '.ts\";' ./deno -r && replace \"'./DashManifest.ts';\" \"'./DashManifest.js';\" ./deno -r && replace \"'jintr';\" \"'jsr:@luanrt/jintr';\" ./deno -r && replace \"@bufbuild/protobuf/wire\" \"https://esm.sh/@bufbuild/protobuf@2.0.0/wire\" ./deno -r",
     "build:proto": "rimraf ./protos/generated && node ./dev-scripts/generate-proto.mjs",
     "build:parser-map": "node ./dev-scripts/gen-parser-map.mjs",
-    "bundle:node": "esbuild ./dist/src/platform/node.js --bundle --target=node16 --keep-names --format=cjs --platform=node --outfile=./bundle/node.cjs --external:undici --external:linkedom --external:tslib --banner:js=\"/* eslint-disable */\"",
+    "bundle:node": "esbuild ./dist/src/platform/node.js --bundle --sourcemap --target=node16 --keep-names --format=cjs --platform=node --outfile=./bundle/node.cjs --external:undici --external:linkedom --external:tslib --banner:js=\"/* eslint-disable */\"",
     "bundle:browser": "esbuild ./dist/src/platform/web.js --banner:js=\"/* eslint-disable */\" --bundle --target=chrome70 --keep-names --format=esm --define:global=globalThis --conditions=module --outfile=./bundle/browser.js --platform=browser",
     "bundle:react-native": "esbuild ./dist/src/platform/react-native.js --bundle --target=es2020 --keep-names --format=esm --platform=neutral --define:global=globalThis --conditions=module --outfile=./bundle/react-native.js",
     "bundle:browser:prod": "npm run bundle:browser -- --outfile=./bundle/browser.min.js --minify",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,7 @@
     "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */


### PR DESCRIPTION
As a seperate PR of https://github.com/LuanRT/YouTube.js/pull/872, I enabled the sourcemaps again as disabled some updates before. Change included here: (refactor: Migrate to `ts-proto` (#752))
I am not sure if this was done on purpose.

But this is currently causing the issue that local debugging in the IDE is not working on the ts files, and only works when setting breakpoints on the bundles js variant.

This makes development for me a bit harder. :)

I tried the bundles variant with sourcemap on my side for a while and it worked just fine.