### PR TITLE
perf(constants): Move the client name IDs into their own `CLIENT_NAME_IDS` object

### DIFF
--- a/src/core/clients/Studio.ts
+++ b/src/core/clients/Studio.ts
@@ -52,7 +52,7 @@ export default class Studio {
       context: {
         client: {
           osName: 'Android',
-          clientName: parseInt(Constants.CLIENTS.ANDROID.NAME_ID),
+          clientName: parseInt(Constants.CLIENT_NAME_IDS.ANDROID),
           clientVersion: Constants.CLIENTS.ANDROID.VERSION,
           androidSdkVersion: Constants.CLIENTS.ANDROID.SDK_VERSION,
           visitorData: this.#session.context.client.visitorData,

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -24,14 +24,12 @@ export const OAUTH = Object.freeze({
 });
 export const CLIENTS = Object.freeze({
   IOS: {
-    NAME_ID: '5',
     NAME: 'iOS',
     VERSION: '18.06.35',
     USER_AGENT: 'com.google.ios.youtube/18.06.35 (iPhone; CPU iPhone OS 14_4 like Mac OS X; en_US)',
     DEVICE_MODEL: 'iPhone10,6'
   },
   WEB: {
-    NAME_ID: '1',
     NAME: 'WEB',
     VERSION: '2.20241121.01.00',
     API_KEY: 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
@@ -40,51 +38,42 @@ export const CLIENTS = Object.freeze({
     SUGG_EXP_ID: 'ytzpb5_e2,ytpo.bo.lqp.elu=1,ytpo.bo.lqp.ecsc=1,ytpo.bo.lqp.mcsc=3,ytpo.bo.lqp.mec=1,ytpo.bo.lqp.rw=0.8,ytpo.bo.lqp.fw=0.2,ytpo.bo.lqp.szp=1,ytpo.bo.lqp.mz=3,ytpo.bo.lqp.al=en_us,ytpo.bo.lqp.zrm=1,ytpo.bo.lqp.er=1,ytpo.bo.ro.erl=1,ytpo.bo.ro.mlus=3,ytpo.bo.ro.erls=3,ytpo.bo.qfo.mlus=3,ytzprp.ppp.e=1,ytzprp.ppp.st=772,ytzprp.ppp.p=5'
   },
   MWEB: {
-    NAME_ID: '2',
     NAME: 'MWEB',
     VERSION: '2.20241205.01.00',
     API_VERSION: 'v1'
   },
   WEB_KIDS: {
-    NAME_ID: '76',
     NAME: 'WEB_KIDS',
     VERSION: '2.20230111.00.00'
   },
   YTMUSIC: {
-    NAME_ID: '67',
     NAME: 'WEB_REMIX',
     VERSION: '1.20211213.00.00'
   },
   ANDROID: {
-    NAME_ID: '3',
     NAME: 'ANDROID',
     VERSION: '19.35.36',
     SDK_VERSION: 33,
     USER_AGENT: 'com.google.android.youtube/19.35.36(Linux; U; Android 13; en_US; SM-S908E Build/TP1A.220624.014) gzip'
   },
   YTSTUDIO_ANDROID: {
-    NAME_ID: '14',
     NAME: 'ANDROID_CREATOR',
     VERSION: '22.43.101'
   },
   YTMUSIC_ANDROID: {
-    NAME_ID: '21',
     NAME: 'ANDROID_MUSIC',
     VERSION: '5.34.51'
   },
   TV: {
-    NAME_ID: '7',
     NAME: 'TVHTML5',
     VERSION: '7.20241016.15.00',
     USER_AGENT: 'Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version'
   },
   TV_EMBEDDED: {
-    NAME_ID: '85',
     NAME: 'TVHTML5_SIMPLY_EMBEDDED_PLAYER',
     VERSION: '2.0'
   },
   WEB_EMBEDDED: {
-    NAME_ID: '56',
     NAME: 'WEB_EMBEDDED_PLAYER',
     VERSION: '2.20240111.09.00',
     API_KEY: 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
@@ -92,13 +81,29 @@ export const CLIENTS = Object.freeze({
     STATIC_VISITOR_ID: '6zpwvWUNAco'
   },
   WEB_CREATOR: {
-    NAME_ID: '62',
     NAME: 'WEB_CREATOR',
     VERSION: '1.20240918.03.00',
     API_KEY: 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
     API_VERSION: 'v1',
     STATIC_VISITOR_ID: '6zpwvWUNAco'
   }
+});
+/**
+ * The keys correspond to the `NAME` fields in {@linkcode CLIENTS} constant
+ */
+export const CLIENT_NAME_IDS = Object.freeze({
+  iOS: '5',
+  WEB: '1',
+  MWEB: '2',
+  WEB_KIDS: '76',
+  WEB_REMIX: '67',
+  ANDROID: '3',
+  ANDROID_CREATOR: '14',
+  ANDROID_MUSIC: '21',
+  TVHTML5: '7',
+  TVHTML5_SIMPLY_EMBEDDED_PLAYER: '85',
+  WEB_EMBEDDED_PLAYER: '56',
+  WEB_CREATOR: '62'
 });
 export const STREAM_HEADERS = Object.freeze({
   'accept': '*/*',

--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -59,12 +59,10 @@ export default class HTTPClient {
     request_headers.set('X-Goog-Visitor-Id', this.#session.context.client.visitorData || '');
     request_headers.set('X-Youtube-Client-Version', this.#session.context.client.clientVersion || '');
 
-    const client_constant = Object.values(Constants.CLIENTS).find((client) => {
-      return client.NAME === this.#session.context.client.clientName;
-    });
+    const client_name_id = Constants.CLIENT_NAME_IDS[this.#session.context.client.clientName as keyof typeof Constants.CLIENT_NAME_IDS];
 
-    if (client_constant) {
-      request_headers.set('X-Youtube-Client-Name', client_constant.NAME_ID);
+    if (client_name_id) {
+      request_headers.set('X-Youtube-Client-Name', client_name_id);
     }
 
     if (Platform.shim.server) {
@@ -97,12 +95,10 @@ export default class HTTPClient {
       this.#adjustContext(n_body.context, n_body.client);
       request_headers.set('X-Youtube-Client-Version', n_body.context.client.clientVersion);
 
-      const client_constant = Object.values(Constants.CLIENTS).find((client) => {
-        return client.NAME === n_body.context.client.clientName;
-      });
+      const client_name_id = Constants.CLIENT_NAME_IDS[n_body.context.client.clientName as keyof typeof Constants.CLIENT_NAME_IDS];
 
-      if (client_constant) {
-        request_headers.set('X-Youtube-Client-Name', client_constant.NAME_ID);
+      if (client_name_id) {
+        request_headers.set('X-Youtube-Client-Name', client_name_id);
       }
 
       delete n_body.client;


### PR DESCRIPTION
Moving the client name IDs into their own object, allows us to simplify the lookups in HTTPClient to just being a property lookup, instead of using `Object.values()` and `Array#find()` to locate the correct client information. It is worth noting that unlike the `CLIENTS` object that uses user-friendly names as the keys, the new `CLIENT_NAME_IDS` object uses the real client names (the ones in the `NAME` fields in the `CLIENTS` object) to enable the quick lookup.