### PR TITLE
refactor(Constants): Use `as const` instead of `Object.freeze()`

### DIFF
--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -370,8 +370,8 @@ export default class Session extends EventEmitter {
     if (!session_data) {
       Log.info(TAG, 'Generating session data.');
 
-      let api_key = Constants.CLIENTS.WEB.API_KEY;
-      let api_version = Constants.CLIENTS.WEB.API_VERSION;
+      let api_key: string = Constants.CLIENTS.WEB.API_KEY;
+      let api_version: string = Constants.CLIENTS.WEB.API_VERSION;
 
       let context_data: ContextData = {
         hl: lang || 'en',

--- a/src/core/mixins/MediaInfo.ts
+++ b/src/core/mixins/MediaInfo.ts
@@ -205,7 +205,7 @@ export default class MediaInfo {
   /**
    * Adds video to the watch history.
    */
-  async addToWatchHistory(client_name = Constants.CLIENTS.WEB.NAME, client_version = Constants.CLIENTS.WEB.VERSION, replacement = 'https://www.'): Promise<Response> {
+  async addToWatchHistory(client_name: string = Constants.CLIENTS.WEB.NAME, client_version: string = Constants.CLIENTS.WEB.VERSION, replacement = 'https://www.'): Promise<Response> {
     if (!this.#playback_tracking)
       throw new InnertubeError('Playback tracking not available');
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -1,10 +1,10 @@
 
-export const URLS = Object.freeze({
+export const URLS = {
   YT_BASE: 'https://www.youtube.com',
   YT_MUSIC_BASE: 'https://music.youtube.com',
   YT_SUGGESTIONS: 'https://suggestqueries-clients6.youtube.com',
   YT_UPLOAD: 'https://upload.youtube.com/',
-  API: Object.freeze({
+  API: {
     BASE: 'https://youtubei.googleapis.com',
     PRODUCTION_1: 'https://www.youtube.com/youtubei/',
     PRODUCTION_2: 'https://youtubei.googleapis.com/youtubei/',
@@ -13,16 +13,16 @@ export const URLS = Object.freeze({
     TEST: 'https://test-youtubei.sandbox.googleapis.com/youtubei/',
     CAMI: 'http://cami-youtubei.sandbox.googleapis.com/youtubei/',
     UYTFE: 'https://uytfe.sandbox.google.com/youtubei/'
-  }),
+  },
   GOOGLE_SEARCH_BASE: 'https://www.google.com/'
-});
-export const OAUTH = Object.freeze({
-  REGEX: Object.freeze({
+} as const;
+export const OAUTH = {
+  REGEX: {
     TV_SCRIPT: new RegExp('<script\\s+id="base-js"\\s+src="([^"]+)"[^>]*><\\/script>'),
     CLIENT_IDENTITY: new RegExp('clientId:"(?<client_id>[^"]+)",[^"]*?:"(?<client_secret>[^"]+)"')
-  })
-});
-export const CLIENTS = Object.freeze({
+  }
+} as const;
+export const CLIENTS = {
   IOS: {
     NAME: 'iOS',
     VERSION: '18.06.35',
@@ -87,11 +87,11 @@ export const CLIENTS = Object.freeze({
     API_VERSION: 'v1',
     STATIC_VISITOR_ID: '6zpwvWUNAco'
   }
-});
+} as const;
 /**
  * The keys correspond to the `NAME` fields in {@linkcode CLIENTS} constant
  */
-export const CLIENT_NAME_IDS = Object.freeze({
+export const CLIENT_NAME_IDS = {
   iOS: '5',
   WEB: '1',
   MWEB: '2',
@@ -104,17 +104,17 @@ export const CLIENT_NAME_IDS = Object.freeze({
   TVHTML5_SIMPLY_EMBEDDED_PLAYER: '85',
   WEB_EMBEDDED_PLAYER: '56',
   WEB_CREATOR: '62'
-});
-export const STREAM_HEADERS = Object.freeze({
+} as const;
+export const STREAM_HEADERS = {
   'accept': '*/*',
   'origin': 'https://www.youtube.com',
   'referer': 'https://www.youtube.com',
   'DNT': '?1'
-});
-export const INNERTUBE_HEADERS_BASE = Object.freeze({
+} as const;
+export const INNERTUBE_HEADERS_BASE = {
   'accept': '*/*',
   'accept-encoding': 'gzip, deflate',
   'content-type': 'application/json'
-});
+} as const;
 
 export const SUPPORTED_CLIENTS = [ 'IOS', 'WEB', 'MWEB', 'YTKIDS', 'YTMUSIC', 'ANDROID', 'YTSTUDIO_ANDROID', 'YTMUSIC_ANDROID', 'TV', 'TV_EMBEDDED', 'WEB_EMBEDDED', 'WEB_CREATOR' ];


### PR DESCRIPTION
For people using bundlers and mimifiers this allows unused constants to be treeshaken and in the case of terser, it even goes a step further and hoists the strings out of the objects into their own variables. While yes this doesn't provide protection at runtime like the prior solution did, I think it is probably fair to say that if someone intentionally modifies the constants and things break, it is their own fault and developers using TypeScript still won't be able to modify them easily thanks to the `as const` assertion.