### PR TITLE
fix(Innertube): Properly encoded params in `getPost()`

### DIFF
--- a/protos/generated/misc/params.ts
+++ b/protos/generated/misc/params.ts
@@ -2230,10 +2230,10 @@ function createBaseCommunityPostParams_Field2(): CommunityPostParams_Field2 {
 export const CommunityPostParams_Field2: MessageFns<CommunityPostParams_Field2> = {
   encode(message: CommunityPostParams_Field2, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.p1 !== 0) {
-      writer.uint32(16).int64(message.p1);
+      writer.uint32(16).uint32(message.p1);
     }
     if (message.p2 !== 0) {
-      writer.uint32(24).int64(message.p2);
+      writer.uint32(24).uint32(message.p2);
     }
     return writer;
   },
@@ -2250,14 +2250,14 @@ export const CommunityPostParams_Field2: MessageFns<CommunityPostParams_Field2> 
             break;
           }
 
-          message.p1 = longToNumber(reader.int64());
+          message.p1 = reader.uint32();
           continue;
         case 3:
           if (tag !== 24) {
             break;
           }
 
-          message.p2 = longToNumber(reader.int64());
+          message.p2 = reader.uint32();
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -2635,17 +2635,6 @@ export const CommunityPostCommentsParam_CommentDataContainer_CommentData: Messag
     return message;
   },
 };
-
-function longToNumber(int64: { toString(): string }): number {
-  const num = globalThis.Number(int64.toString());
-  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
-  }
-  return num;
-}
 
 export interface MessageFns<T> {
   encode(message: T, writer?: BinaryWriter): BinaryWriter;

--- a/protos/misc/params.proto
+++ b/protos/misc/params.proto
@@ -238,8 +238,8 @@ message CommunityPostParams {
   }
 
   message Field2 {
-    int64 p1 = 2;
-    int64 p2 = 3;
+    uint32 p1 = 2;
+    uint32 p2 = 3;
   }
 
   Field1 f1 = 25;

--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -478,7 +478,7 @@ export default class Innertube {
       }
     });
 
-    const params = encodeURIComponent(u8ToBase64(writer.finish()));
+    const params = encodeURIComponent(u8ToBase64(writer.finish()).replace(/\+/g, '-').replace(/\//g, '_'));
 
     const browse_endpoint = new NavigationEndpoint({ browseEndpoint: { browseId: channel_id, params: params } });
 


### PR DESCRIPTION
For some post ID and channel ID combinations the encoded protobuf string can contain `/`, which we need to replace with `_` for proper URL safe base64 (this was causing YouTube to return the channel home page instead of the post page). I also corrected the type of some of the number fields to uint32