### PR TITLE
feat(FormatUtils): choose more specific format by itag or codec

### DIFF
--- a/src/types/FormatUtils.ts
+++ b/src/types/FormatUtils.ts
@@ -6,6 +6,10 @@ export type FormatFilter = (format: Format) => boolean;
 
 export interface FormatOptions {
   /**
+   * Video or audio itag
+   */
+  itag?: number;
+  /**
    * Video quality; 360p, 720p, 1080p, etc... also accepts 'best' and 'bestefficiency'.
    */
   quality?: string;
@@ -21,6 +25,10 @@ export interface FormatOptions {
    * File format, use 'any' to download any format
    */
   format?: string;
+  /**
+   * Video or audio codec, e.g. 'avc', 'vp9', 'av01' for video, 'opus', 'mp4a' for audio
+   */
+  codec?: string;
   /**
    * InnerTube client.
    */

--- a/src/utils/FormatUtils.ts
+++ b/src/utils/FormatUtils.ts
@@ -155,9 +155,13 @@ export function chooseFormat(options: FormatOptions, streaming_data?: IStreaming
   const use_most_efficient = quality !== 'best';
 
   let candidates = formats.filter((format) => {
+    if (options.itag && format.itag !== options.itag)
+      return false;
     if (requires_audio && !format.has_audio)
       return false;
     if (requires_video && !format.has_video)
+      return false;
+    if (options.codec && !format.mime_type.includes(options.codec))
       return false;
     if (options.format !== 'any' && !format.mime_type.includes(options.format || 'mp4'))
       return false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #871 

More specific format control is better, like filtering by itag or video/audio codec.