### PR TITLE
chore(Utils): Replace private static shim property with a variable

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -11,16 +11,17 @@ import type { Node } from 'estree';
 
 const TAG_ = 'Utils';
 
+let shim: PlatformShim | undefined;
+
 export class Platform {
-  static #shim: PlatformShim | undefined;
   static load(platform: PlatformShim): void {
-    Platform.#shim = platform;
+    shim = platform;
   }
   static get shim(): PlatformShim {
-    if (!Platform.#shim) {
+    if (!shim) {
       throw new Error('Platform is not loaded');
     }
-    return Platform.#shim;
+    return shim;
   }
 }
 export class InnertubeError extends Error {


### PR DESCRIPTION
Less code both in the source and builds and will be slightly faster at runtime as it doesn't need the private property polyfill.