### PR TITLE
refactor: Remove internal uses of the `.first()` and `.matchCondition()` helpers

### DIFF
--- a/src/core/Actions.ts
+++ b/src/core/Actions.ts
@@ -177,7 +177,7 @@ export default class Actions {
       let parsed_response = Parser.parseResponse<ParsedResponse<T>>(await response.json());
 
       // Handle redirects
-      if (this.#isBrowse(parsed_response) && parsed_response.on_response_received_actions?.first()?.type === 'navigateAction') {
+      if (this.#isBrowse(parsed_response) && parsed_response.on_response_received_actions?.[0]?.type === 'navigateAction') {
         const navigate_action = parsed_response.on_response_received_actions.firstOfType(NavigateAction);
         if (navigate_action) {
           parsed_response = await navigate_action.endpoint.call(this, { parse: true });

--- a/src/core/clients/Music.ts
+++ b/src/core/clients/Music.ts
@@ -201,7 +201,7 @@ export default class Music {
     const response = await watch_next_endpoint.call(this.#actions, { client: 'YTMUSIC', parse: true });
 
     const tabs = response.contents_memo?.getType(Tab);
-    const tab = tabs?.first();
+    const tab = tabs?.[0];
 
     if (!tab)
       throw new InnertubeError('Could not find target tab.');
@@ -228,7 +228,7 @@ export default class Music {
       if (!page || !page.contents_memo)
         throw new InnertubeError('Could not fetch automix');
 
-      return page.contents_memo.getType(PlaylistPanel).first();
+      return page.contents_memo.getType(PlaylistPanel)[0];
     }
 
     return playlist_panel;
@@ -242,7 +242,7 @@ export default class Music {
 
     const tabs = response.contents_memo?.getType(Tab);
 
-    const tab = tabs?.matchCondition((tab) => tab.endpoint.payload.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType === 'MUSIC_PAGE_TYPE_TRACK_RELATED');
+    const tab = tabs?.find((tab) => tab.endpoint.payload.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType === 'MUSIC_PAGE_TYPE_TRACK_RELATED');
 
     if (!tab)
       throw new InnertubeError('Could not find target tab.');
@@ -263,7 +263,7 @@ export default class Music {
 
     const tabs = response.contents_memo?.getType(Tab);
 
-    const tab = tabs?.matchCondition((tab) => tab.endpoint.payload.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType === 'MUSIC_PAGE_TYPE_TRACK_LYRICS');
+    const tab = tabs?.find((tab) => tab.endpoint.payload.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType === 'MUSIC_PAGE_TYPE_TRACK_LYRICS');
 
     if (!tab)
       throw new InnertubeError('Could not find target tab.');

--- a/src/core/mixins/Feed.ts
+++ b/src/core/mixins/Feed.ts
@@ -139,9 +139,9 @@ export default class Feed<T extends IParsedResponse = IParsedResponse> {
    * Returns contents from the page.
    */
   get page_contents(): SectionList | MusicQueue | RichGrid | ReloadContinuationItemsCommand {
-    const tab_content = this.#memo.getType(Tab)?.first().content;
-    const reload_continuation_items = this.#memo.getType(ReloadContinuationItemsCommand).first();
-    const append_continuation_items = this.#memo.getType(AppendContinuationItemsAction).first();
+    const tab_content = this.#memo.getType(Tab)?.[0].content;
+    const reload_continuation_items = this.#memo.getType(ReloadContinuationItemsCommand)[0];
+    const append_continuation_items = this.#memo.getType(AppendContinuationItemsAction)[0];
 
     return tab_content || reload_continuation_items || append_continuation_items;
   }

--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -155,7 +155,7 @@ export default class MusicResponsiveListItem extends YTNode {
   }
 
   #parseOther() {
-    this.title = this.flex_columns.first().title.toString();
+    this.title = this.flex_columns[0].title.toString();
 
     if (this.endpoint) {
       this.item_type = 'endpoint';
@@ -183,10 +183,10 @@ export default class MusicResponsiveListItem extends YTNode {
 
   #parseSong() {
     this.id = this.#playlist_item_data.video_id || this.endpoint?.payload?.videoId;
-    this.title = this.flex_columns.first().title.toString();
+    this.title = this.flex_columns[0].title.toString();
 
     const duration_text = this.flex_columns.at(1)?.title.runs?.find(
-      (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns.first()?.title?.toString();
+      (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns[0]?.title?.toString();
 
     if (duration_text) {
       this.duration = {
@@ -230,7 +230,7 @@ export default class MusicResponsiveListItem extends YTNode {
 
   #parseVideo() {
     this.id = this.#playlist_item_data.video_id;
-    this.title = this.flex_columns.first().title.toString();
+    this.title = this.flex_columns[0].title.toString();
     this.views = this.flex_columns.at(1)?.title.runs?.find((run) => run.text.match(/(.*?) views/))?.toString();
 
     const author_runs = this.flex_columns.at(1)?.title.runs?.filter(
@@ -250,7 +250,7 @@ export default class MusicResponsiveListItem extends YTNode {
     }
 
     const duration_text = this.flex_columns[1].title.runs?.find(
-      (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns.first()?.title.runs?.find((run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text;
+      (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns[0]?.title.runs?.find((run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text;
 
     if (duration_text) {
       this.duration = {
@@ -262,30 +262,30 @@ export default class MusicResponsiveListItem extends YTNode {
 
   #parseArtist() {
     this.id = this.endpoint?.payload?.browseId;
-    this.name = this.flex_columns.first().title.toString();
+    this.name = this.flex_columns[0].title.toString();
     this.subtitle = this.flex_columns.at(1)?.title;
     this.subscribers = this.subtitle?.runs?.find((run) => (/^(\d*\.)?\d+[M|K]? subscribers?$/i).test(run.text))?.text || '';
   }
 
   #parseLibraryArtist() {
-    this.name = this.flex_columns.first().title.toString();
+    this.name = this.flex_columns[0].title.toString();
     this.subtitle = this.flex_columns.at(1)?.title;
     this.song_count = this.subtitle?.runs?.find((run) => (/^\d+(,\d+)? songs?$/i).test(run.text))?.text || '';
   }
 
   #parseNonMusicTrack() {
     this.id = this.#playlist_item_data.video_id || this.endpoint?.payload?.videoId;
-    this.title = this.flex_columns.first().title.toString();
+    this.title = this.flex_columns[0].title.toString();
   }
 
   #parsePodcastShow() {
     this.id = this.endpoint?.payload?.browseId;
-    this.title = this.flex_columns.first().title.toString();
+    this.title = this.flex_columns[0].title.toString();
   }
 
   #parseAlbum() {
     this.id = this.endpoint?.payload?.browseId;
-    this.title = this.flex_columns.first().title.toString();
+    this.title = this.flex_columns[0].title.toString();
 
     const author_run = this.flex_columns.at(1)?.title.runs?.find(
       (run) =>
@@ -308,7 +308,7 @@ export default class MusicResponsiveListItem extends YTNode {
 
   #parsePlaylist() {
     this.id = this.endpoint?.payload?.browseId;
-    this.title = this.flex_columns.first().title.toString();
+    this.title = this.flex_columns[0].title.toString();
 
     const item_count_run = this.flex_columns.at(1)?.title
       .runs?.find((run) => run.text.match(/\d+ (song|songs)/));

--- a/src/parser/classes/comments/CommentThread.ts
+++ b/src/parser/classes/comments/CommentThread.ts
@@ -58,7 +58,7 @@ export default class CommentThread extends YTNode {
       throw new InnertubeError('Unexpected response.', response);
 
     this.replies = this.#getPatchedReplies(response.on_response_received_endpoints_memo);
-    this.#continuation = response.on_response_received_endpoints_memo.getType(ContinuationItem).first();
+    this.#continuation = response.on_response_received_endpoints_memo.getType(ContinuationItem)[0];
 
     return this;
   }
@@ -87,7 +87,7 @@ export default class CommentThread extends YTNode {
       throw new InnertubeError('Unexpected response.', response);
 
     this.replies = this.#getPatchedReplies(response.on_response_received_endpoints_memo);
-    this.#continuation = response.on_response_received_endpoints_memo.getType(ContinuationItem).first();
+    this.#continuation = response.on_response_received_endpoints_memo.getType(ContinuationItem)[0];
 
     return this;
   }

--- a/src/parser/youtube/AccountInfo.ts
+++ b/src/parser/youtube/AccountInfo.ts
@@ -17,12 +17,12 @@ export default class AccountInfo {
     if (!this.#page.contents)
       throw new InnertubeError('Page contents not found');
 
-    const account_section_list = this.#page.contents.array().as(AccountSectionList).first();
+    const account_section_list = this.#page.contents.array().as(AccountSectionList)[0];
 
     if (!account_section_list)
       throw new InnertubeError('Account section list not found');
 
-    this.contents = account_section_list.contents.first();
+    this.contents = account_section_list.contents[0];
   }
 
   get page(): IParsedResponse {

--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -48,7 +48,7 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
     const microformat = this.page.microformat?.as(MicroformatData);
 
     if (this.page.alerts) {
-      const alert = this.page.alerts.first();
+      const alert = this.page.alerts[0];
       if (alert?.alert_type === 'ERROR') {
         throw new ChannelError(alert.text.toString());
       }
@@ -59,7 +59,7 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
 
     this.metadata = { ...metadata, ...(microformat || {}) };
 
-    this.subscribe_button = this.page.header_memo?.getType(SubscribeButton).first();
+    this.subscribe_button = this.page.header_memo?.getType(SubscribeButton)[0];
 
     if (this.page.contents)
       this.current_tab = this.page.contents.item().as(TwoColumnBrowseResults).tabs.array().filterType(Tab, ExpandableTab).get({ selected: true });
@@ -72,7 +72,7 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
   async applyFilter(filter: string | ChipCloudChip): Promise<FilteredChannelList> {
     let target_filter: ChipCloudChip | undefined;
 
-    const filter_chipbar = this.memo.getType(FeedFilterChipBar).first();
+    const filter_chipbar = this.memo.getType(FeedFilterChipBar)[0];
 
     if (typeof filter === 'string') {
       target_filter = filter_chipbar?.contents.get({ text: filter });
@@ -98,7 +98,7 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
    * @param sort - The sort filter to apply
    */
   async applySort(sort: string): Promise<Channel> {
-    const sort_filter_sub_menu = this.memo.getType(SortFilterSubMenu).first();
+    const sort_filter_sub_menu = this.memo.getType(SortFilterSubMenu)[0];
 
     if (!sort_filter_sub_menu || !sort_filter_sub_menu.sub_menu_items)
       throw new InnertubeError('No sort filter sub menu found');
@@ -144,7 +144,7 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
   }
 
   get sort_filters(): string[] {
-    const sort_filter_sub_menu = this.memo.getType(SortFilterSubMenu).first();
+    const sort_filter_sub_menu = this.memo.getType(SortFilterSubMenu)[0];
     return sort_filter_sub_menu?.sub_menu_items?.map((item) => item.title) || [];
   }
 
@@ -302,8 +302,8 @@ export class ChannelListContinuation extends Feed<IBrowseResponse> {
   constructor(actions: Actions, data: ApiResponse | IBrowseResponse, already_parsed = false) {
     super(actions, data, already_parsed);
     this.contents =
-      this.page.on_response_received_actions?.first() ||
-      this.page.on_response_received_endpoints?.first();
+      this.page.on_response_received_actions?.[0] ||
+      this.page.on_response_received_endpoints?.[0];
   }
 
   async getContinuation(): Promise<ChannelListContinuation> {
@@ -331,7 +331,7 @@ export class FilteredChannelList extends FilterableFeed<IBrowseResponse> {
       this.page.on_response_received_actions.shift();
     }
 
-    this.contents = this.page.on_response_received_actions?.first();
+    this.contents = this.page.on_response_received_actions?.[0];
   }
 
   /**

--- a/src/parser/youtube/HashtagFeed.ts
+++ b/src/parser/youtube/HashtagFeed.ts
@@ -19,7 +19,7 @@ export default class HashtagFeed extends FilterableFeed<IBrowseResponse> {
     if (!this.page.contents_memo)
       throw new InnertubeError('Unexpected response', this.page);
 
-    const tab = this.page.contents_memo.getType(Tab).first();
+    const tab = this.page.contents_memo.getType(Tab)[0];
 
     if (!tab.content)
       throw new InnertubeError('Content tab has no content', tab);

--- a/src/parser/youtube/History.ts
+++ b/src/parser/youtube/History.ts
@@ -15,7 +15,7 @@ export default class History extends Feed<IBrowseResponse> {
   constructor(actions: Actions, data: ApiResponse | IBrowseResponse, already_parsed = false) {
     super(actions, data, already_parsed);
     this.sections = this.memo.getType(ItemSection);
-    this.feed_actions = this.memo.getType(BrowseFeedActions).first();
+    this.feed_actions = this.memo.getType(BrowseFeedActions)[0];
   }
 
   /**

--- a/src/parser/youtube/HomeFeed.ts
+++ b/src/parser/youtube/HomeFeed.ts
@@ -13,8 +13,8 @@ export default class HomeFeed extends FilterableFeed<IBrowseResponse> {
 
   constructor(actions: Actions, data: ApiResponse | IBrowseResponse, already_parsed = false) {
     super(actions, data, already_parsed);
-    this.header = this.memo.getType(FeedTabbedHeader).first();
-    this.contents = this.memo.getType(RichGrid).first() || this.page.on_response_received_actions?.first();
+    this.header = this.memo.getType(FeedTabbedHeader)[0];
+    this.contents = this.memo.getType(RichGrid)[0] || this.page.on_response_received_actions?.[0];
   }
 
   /**

--- a/src/parser/youtube/Library.ts
+++ b/src/parser/youtube/Library.ts
@@ -20,7 +20,7 @@ export default class Library extends Feed<IBrowseResponse> {
     if (!this.page.contents_memo)
       throw new InnertubeError('Page contents not found');
 
-    this.header = this.memo.getType(PageHeader).first();
+    this.header = this.memo.getType(PageHeader)[0];
 
     const shelves = this.page.contents_memo.getType(Shelf);
 

--- a/src/parser/youtube/NotificationsMenu.ts
+++ b/src/parser/youtube/NotificationsMenu.ts
@@ -22,12 +22,12 @@ export default class NotificationsMenu {
     if (!this.#page.actions_memo)
       throw new InnertubeError('Page actions not found');
 
-    this.header = this.#page.actions_memo.getType(SimpleMenuHeader).first();
+    this.header = this.#page.actions_memo.getType(SimpleMenuHeader)[0];
     this.contents = this.#page.actions_memo.getType(Notification);
   }
 
   async getContinuation(): Promise<NotificationsMenu> {
-    const continuation = this.#page.actions_memo?.getType(ContinuationItem).first();
+    const continuation = this.#page.actions_memo?.getType(ContinuationItem)[0];
 
     if (!continuation)
       throw new InnertubeError('Continuation not found');

--- a/src/parser/youtube/Playlist.ts
+++ b/src/parser/youtube/Playlist.ts
@@ -31,9 +31,9 @@ export default class Playlist extends Feed<IBrowseResponse> {
   constructor(actions: Actions, data: ApiResponse | IBrowseResponse, already_parsed = false) {
     super(actions, data, already_parsed);
 
-    const header = this.memo.getType(PlaylistHeader).first();
-    const primary_info = this.memo.getType(PlaylistSidebarPrimaryInfo).first();
-    const secondary_info = this.memo.getType(PlaylistSidebarSecondaryInfo).first();
+    const header = this.memo.getType(PlaylistHeader)[0];
+    const primary_info = this.memo.getType(PlaylistSidebarPrimaryInfo)[0];
+    const secondary_info = this.memo.getType(PlaylistSidebarSecondaryInfo)[0];
     const alert = this.page.alerts?.firstOfType(Alert);
 
     if (alert && alert.alert_type === 'ERROR')
@@ -68,7 +68,7 @@ export default class Playlist extends Feed<IBrowseResponse> {
   }
 
   get has_continuation() {
-    const section_list = this.memo.getType(SectionList).first();
+    const section_list = this.memo.getType(SectionList)[0];
 
     if (!section_list)
       return super.has_continuation;
@@ -77,7 +77,7 @@ export default class Playlist extends Feed<IBrowseResponse> {
   }
 
   async getContinuationData(): Promise<IBrowseResponse | undefined> {
-    const section_list = this.memo.getType(SectionList).first();
+    const section_list = this.memo.getType(SectionList)[0];
 
     /**
      * No section list means there can't be additional continuation nodes here,

--- a/src/parser/youtube/Search.ts
+++ b/src/parser/youtube/Search.ts
@@ -29,8 +29,8 @@ export default class Search extends Feed<ISearchResponse> {
     super(actions, data, already_parsed);
 
     const contents =
-      this.page.contents_memo?.getType(SectionList).first().contents ||
-      this.page.on_response_received_commands?.first().as(AppendContinuationItemsAction, ReloadContinuationItemsCommand).contents;
+      this.page.contents_memo?.getType(SectionList)[0].contents ||
+      this.page.on_response_received_commands?.[0].as(AppendContinuationItemsAction, ReloadContinuationItemsCommand).contents;
 
     if (!contents)
       throw new InnertubeError('No contents found in search response');
@@ -44,8 +44,8 @@ export default class Search extends Feed<ISearchResponse> {
     this.estimated_results = this.page.estimated_results || 0;
 
     if (this.page.contents_memo) {
-      this.sub_menu = this.page.contents_memo.getType(SearchSubMenu).first();
-      this.watch_card = this.page.contents_memo.getType(UniversalWatchCard).first();
+      this.sub_menu = this.page.contents_memo.getType(SearchSubMenu)[0];
+      this.watch_card = this.page.contents_memo.getType(UniversalWatchCard)[0];
     }
 
     this.refinement_cards = this.results?.firstOfType(HorizontalCardList);

--- a/src/parser/youtube/TranscriptInfo.ts
+++ b/src/parser/youtube/TranscriptInfo.ts
@@ -16,7 +16,7 @@ export default class TranscriptInfo {
     if (!this.#page.actions_memo)
       throw new Error('Page actions not found');
 
-    this.transcript = this.#page.actions_memo.getType(Transcript).first();
+    this.transcript = this.#page.actions_memo.getType(Transcript)[0];
   }
 
   /**

--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -131,7 +131,7 @@ export default class VideoInfo extends MediaInfo {
       const comments_entry_point = results.get({ target_id: 'comments-entry-point' })?.as(ItemSection);
 
       this.comments_entry_point_header = comments_entry_point?.contents?.firstOfType(CommentsEntryPointHeader);
-      this.livechat = next?.contents_memo?.getType(LiveChat).first();
+      this.livechat = next?.contents_memo?.getType(LiveChat)[0];
     }
   }
 

--- a/src/parser/ytkids/Channel.ts
+++ b/src/parser/ytkids/Channel.ts
@@ -14,7 +14,7 @@ export default class Channel extends Feed<IBrowseResponse> {
   constructor(actions: Actions, data: ApiResponse | IBrowseResponse, already_parsed = false) {
     super(actions, data, already_parsed);
     this.header = this.page.header?.item().as(C4TabbedHeader);
-    this.contents = this.memo.getType(ItemSection).first() || this.page.continuation_contents?.as(ItemSectionContinuation);
+    this.contents = this.memo.getType(ItemSection)[0] || this.page.continuation_contents?.as(ItemSectionContinuation);
   }
 
   /**

--- a/src/parser/ytkids/Search.ts
+++ b/src/parser/ytkids/Search.ts
@@ -14,7 +14,7 @@ export default class Search extends Feed<ISearchResponse> {
     super(actions, data);
     this.estimated_results = this.page.estimated_results;
 
-    const item_section = this.memo.getType(ItemSection).first();
+    const item_section = this.memo.getType(ItemSection)[0];
 
     if (!item_section)
       throw new InnertubeError('No item section found in search response.');

--- a/src/parser/ytmusic/Album.ts
+++ b/src/parser/ytmusic/Album.ts
@@ -27,8 +27,8 @@ export default class Album {
     if (!this.#page.contents_memo)
       throw new Error('No contents found in the response');
 
-    this.header = this.#page.contents_memo.getType(MusicDetailHeader, MusicResponsiveHeader)?.first();
-    this.contents = this.#page.contents_memo.getType(MusicShelf)?.first().contents || observe([]);
+    this.header = this.#page.contents_memo.getType(MusicDetailHeader, MusicResponsiveHeader)?.[0];
+    this.contents = this.#page.contents_memo.getType(MusicShelf)?.[0].contents || observe([]);
     this.sections = this.#page.contents_memo.getType(MusicCarouselShelf) || observe([]);
     this.background = this.#page.background;
     this.url = this.#page.microformat?.as(MicroformatData).url_canonical;

--- a/src/parser/ytmusic/Artist.ts
+++ b/src/parser/ytmusic/Artist.ts
@@ -47,7 +47,7 @@ export default class Artist {
       throw new InnertubeError('Target shelf (Songs) did not have an endpoint.');
 
     const page = await shelf.endpoint.call(this.#actions, { client: 'YTMUSIC', parse: true });
-    return page.contents_memo?.getType(MusicPlaylistShelf)?.first();
+    return page.contents_memo?.getType(MusicPlaylistShelf)?.[0];
   }
 
   get page(): IBrowseResponse {

--- a/src/parser/ytmusic/Library.ts
+++ b/src/parser/ytmusic/Library.ts
@@ -30,7 +30,7 @@ export default class Library {
     this.#page = Parser.parseResponse<IBrowseResponse>(response.data);
     this.#actions = actions;
 
-    const section_list = this.#page.contents_memo?.getType(SectionList).first();
+    const section_list = this.#page.contents_memo?.getType(SectionList)[0];
 
     this.header = section_list?.header?.as(MusicSideAlignedItem);
     this.contents = section_list?.contents?.as(Grid, MusicShelf);
@@ -45,7 +45,7 @@ export default class Library {
     let target_item: MusicMultiSelectMenuItem | undefined;
 
     if (typeof sort_by === 'string') {
-      const button = this.#page.contents_memo?.getType(MusicSortFilterButton).first();
+      const button = this.#page.contents_memo?.getType(MusicSortFilterButton)[0];
 
       const options = button?.menu?.options
         .filter(
@@ -94,7 +94,7 @@ export default class Library {
   async applyFilter(filter: string | ChipCloudChip): Promise<Library> {
     let target_chip: ChipCloudChip | undefined;
 
-    const chip_cloud = this.#page.contents_memo?.getType(ChipCloud).first();
+    const chip_cloud = this.#page.contents_memo?.getType(ChipCloud)[0];
 
     if (typeof filter === 'string') {
       target_chip = chip_cloud?.chips.get({ text: filter });
@@ -134,13 +134,13 @@ export default class Library {
   }
 
   get sort_options(): string[] {
-    const button = this.#page.contents_memo?.getType(MusicSortFilterButton).first();
+    const button = this.#page.contents_memo?.getType(MusicSortFilterButton)[0];
     const options = button?.menu?.options.filter((item: MusicMultiSelectMenuItem | MusicMenuItemDivider) => item instanceof MusicMultiSelectMenuItem) as MusicMultiSelectMenuItem[];
     return options.map((item) => item.title);
   }
 
   get filters(): string[] {
-    return this.#page.contents_memo?.getType(ChipCloud)?.first().chips.map((chip: ChipCloudChip) => chip.text) || [];
+    return this.#page.contents_memo?.getType(ChipCloud)?.[0].chips.map((chip: ChipCloudChip) => chip.text) || [];
   }
 
   get page(): IBrowseResponse {

--- a/src/parser/ytmusic/Playlist.ts
+++ b/src/parser/ytmusic/Playlist.ts
@@ -45,10 +45,10 @@ export default class Playlist {
     } else {
       if (!this.#page.contents_memo)
         throw new InnertubeError('No contents found in the response');
-      this.header = this.#page.contents_memo.getType(MusicResponsiveHeader, MusicEditablePlaylistDetailHeader, MusicDetailHeader)?.first();
-      this.contents = this.#page.contents_memo.getType(MusicPlaylistShelf)?.first()?.contents || observe([]);
+      this.header = this.#page.contents_memo.getType(MusicResponsiveHeader, MusicEditablePlaylistDetailHeader, MusicDetailHeader)?.[0];
+      this.contents = this.#page.contents_memo.getType(MusicPlaylistShelf)?.[0]?.contents || observe([]);
       this.background = this.#page.background;
-      this.#continuation = this.#page.contents_memo.getType(MusicPlaylistShelf)?.first()?.continuation || null;
+      this.#continuation = this.#page.contents_memo.getType(MusicPlaylistShelf)?.[0]?.continuation || null;
     }
   }
 

--- a/src/parser/ytmusic/Search.ts
+++ b/src/parser/ytmusic/Search.ts
@@ -115,15 +115,15 @@ export default class Search {
   }
 
   get did_you_mean(): DidYouMean | undefined {
-    return this.#page.contents_memo?.getType(DidYouMean).first();
+    return this.#page.contents_memo?.getType(DidYouMean)[0];
   }
 
   get showing_results_for(): ShowingResultsFor | undefined {
-    return this.#page.contents_memo?.getType(ShowingResultsFor).first();
+    return this.#page.contents_memo?.getType(ShowingResultsFor)[0];
   }
 
   get message(): Message | undefined {
-    return this.#page.contents_memo?.getType(Message).first();
+    return this.#page.contents_memo?.getType(Message)[0];
   }
 
   get songs(): MusicShelf | undefined {

--- a/src/parser/ytmusic/TrackInfo.ts
+++ b/src/parser/ytmusic/TrackInfo.ts
@@ -49,7 +49,7 @@ class TrackInfo extends MediaInfo {
 
     const target_tab =
       this.tabs.get({ title: title_or_page_type }) ||
-      this.tabs.matchCondition((tab) => tab.endpoint.payload.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType === title_or_page_type) ||
+      this.tabs.find((tab) => tab.endpoint.payload.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType === title_or_page_type) ||
       this.tabs?.[0];
 
     if (!target_tab)


### PR DESCRIPTION
As those `ObservedArray` helpers are just thin wrappers around `[0]` and `.find()` respectively. Using the original versions should be slightly faster and uses slightly less code, without losing any functionality.

It might be worth deprecating the `.first()`, `.matchCondition()` and `.remove()` helpers, because they all are just thin wrappers that don't provide any additional functionality than just interacting with the array yourself directly. Removing them straight away might break users code, hence the suggestion to deprecate them first.