### PR TITLE
fix(Parser): parse all contents in home tab

### DIFF
--- a/src/parser/classes/Tab.ts
+++ b/src/parser/classes/Tab.ts
@@ -12,6 +12,7 @@ export default class Tab extends YTNode {
   selected: boolean;
   endpoint: NavigationEndpoint;
   content: SectionList | MusicQueue | RichGrid | null;
+  contents: (SectionList | MusicQueue | RichGrid)[] | null;
 
   constructor(data: RawNode) {
     super();
@@ -19,5 +20,6 @@ export default class Tab extends YTNode {
     this.selected = !!data.selected;
     this.endpoint = new NavigationEndpoint(data.endpoint);
     this.content = Parser.parseItem(data.content, [ SectionList, MusicQueue, RichGrid ]);
+    this.contents = Parser.parseItems(data.content, [ SectionList, MusicQueue, RichGrid ]);
   }
 }

--- a/src/parser/classes/Tab.ts
+++ b/src/parser/classes/Tab.ts
@@ -12,14 +12,28 @@ export default class Tab extends YTNode {
   selected: boolean;
   endpoint: NavigationEndpoint;
   content: SectionList | MusicQueue | RichGrid | null;
-  contents: (SectionList | MusicQueue | RichGrid)[] | null;
 
   constructor(data: RawNode) {
     super();
     this.title = data.title || 'N/A';
     this.selected = !!data.selected;
     this.endpoint = new NavigationEndpoint(data.endpoint);
-    this.content = Parser.parseItem(data.content, [ SectionList, MusicQueue, RichGrid ]);
-    this.contents = Parser.parseItems(data.content, [ SectionList, MusicQueue, RichGrid ]);
+    const contents = Parser.parseItems(data.content, [ SectionList, MusicQueue, RichGrid ]);
+    this.content = null;
+    if (contents !== null && contents.length > 0) {
+      for (const item of contents) {
+        if (item.is(SectionList) && item.contents.length > 0) {
+          this.content = item;
+        } else if (item.is(RichGrid) && item.contents.length > 0) {
+          this.content = item;
+        } else if (item.is(MusicQueue)) {
+          this.content = item;
+        }
+      }
+
+      if (this.content === null) {
+        this.content = contents[0];
+      }
+    }
   }
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -522,6 +522,29 @@ export function parseResponse<T extends IParsedResponse = IParsedResponse>(data:
 }
 
 /**
+ * Parses multiple items
+ * @param data - The data to parse.
+ * @param validTypes - YTNode types that are allowed to be parsed.
+ */
+export function parseItems<T extends YTNode, K extends YTNodeConstructor<T>[]>(data: RawNode | undefined, validTypes: K): InstanceType<K[number]>[] | null;
+export function parseItems<T extends YTNode>(data: RawNode | undefined, validTypes: YTNodeConstructor<T>): T[] | null;
+export function parseItems(data?: RawNode): YTNode[];
+export function parseItems(data?: RawNode, validTypes?: YTNodeConstructor | YTNodeConstructor[]) {
+  if (!data) return null;
+  const keys = Object.keys(data);
+  const results: YTNode[] = [];
+  for (const key of keys) {
+    const temp_data = { [key]: data[key] };
+
+    const result = parseItem(temp_data, validTypes as YTNodeConstructor);
+    if (result) {
+      results.push(result);
+    }
+  }
+  return results;
+}
+
+/**
  * Parses an item.
  * @param data - The data to parse.
  * @param validTypes - YTNode types that are allowed to be parsed.

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -522,29 +522,6 @@ export function parseResponse<T extends IParsedResponse = IParsedResponse>(data:
 }
 
 /**
- * Parses multiple items
- * @param data - The data to parse.
- * @param validTypes - YTNode types that are allowed to be parsed.
- */
-export function parseItems<T extends YTNode, K extends YTNodeConstructor<T>[]>(data: RawNode | undefined, validTypes: K): InstanceType<K[number]>[] | null;
-export function parseItems<T extends YTNode>(data: RawNode | undefined, validTypes: YTNodeConstructor<T>): T[] | null;
-export function parseItems(data?: RawNode): YTNode[];
-export function parseItems(data?: RawNode, validTypes?: YTNodeConstructor | YTNodeConstructor[]) {
-  if (!data) return null;
-  const keys = Object.keys(data);
-  const results: YTNode[] = [];
-  for (const key of keys) {
-    const temp_data = { [key]: data[key] };
-
-    const result = parseItem(temp_data, validTypes as YTNodeConstructor);
-    if (result) {
-      results.push(result);
-    }
-  }
-  return results;
-}
-
-/**
  * Parses an item.
  * @param data - The data to parse.
  * @param validTypes - YTNode types that are allowed to be parsed.
@@ -608,6 +585,29 @@ export function parseItem(data?: RawNode, validTypes?: YTNodeConstructor | YTNod
   }
 
   return null;
+}
+
+/**
+ * Parses multiple items in an object as an array of items.
+ * @param data - The data to parse.
+ * @param validTypes - YTNode types that are allowed to be parsed.
+ */
+export function parseItems<T extends YTNode, K extends YTNodeConstructor<T>[]>(data: RawNode | undefined, validTypes: K): InstanceType<K[number]>[] | null;
+export function parseItems<T extends YTNode>(data: RawNode | undefined, validTypes: YTNodeConstructor<T>): T[] | null;
+export function parseItems(data?: RawNode): YTNode[];
+export function parseItems(data?: RawNode, validTypes?: YTNodeConstructor | YTNodeConstructor[]) {
+  if (!data) return null;
+  const keys = Object.keys(data);
+  const results: YTNode[] = [];
+  for (const key of keys) {
+    const temp_data = { [key]: data[key] };
+
+    const result = parseItem(temp_data, validTypes as YTNodeConstructor);
+    if (result) {
+      results.push(result);
+    }
+  }
+  return results;
 }
 
 /**


### PR DESCRIPTION
This is a bit strange but it seems that the home pages on some channels(ex: https://www.youtube.com/channel/UC-9-kyTW8ZkZNDHQJ6FgpwQ ) have multiple different List/Grid renderers in the same object (not an array) so this PR allows for parsing them.

**To be decided/further questions**:
Is this the proper way to parse multiple items like this?
Should `content` get removed for `contents` since it could contain an empty sectionList (like the [music channel](https://www.youtube.com/channel/UC-9-kyTW8ZkZNDHQJ6FgpwQ) for example)? Or should we keep both properties (this wouldn't be a breaking change but might cause confusion because of potential duplication)