### PR TITLE
fix(innertube): Allowing getStreamingData to use client.

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -431,7 +431,7 @@ export default class Innertube {
    * @param options - Format options.
    */
   async getStreamingData(video_id: string, options: FormatOptions = {}): Promise<Format> {
-    const info = await this.getBasicInfo(video_id);
+    const info = await this.getBasicInfo(video_id, options?.client);
 
     const format = info.chooseFormat(options);
     format.url = format.decipher(this.#session.player);


### PR DESCRIPTION
Fixes #828 

The function did not use the client parameter while still allowing the user to provide it in Format Options.