### PR TITLE
revert: "fix(toDash): Fix default audio stream for dubbed movie trailers (#858)"

### DIFF
--- a/src/utils/StreamingInfo.ts
+++ b/src/utils/StreamingInfo.ts
@@ -425,8 +425,7 @@ function getTrackRoles(format: Format, has_drc_streams: boolean) {
   }
 
   const roles: ('main' | 'dub' | 'description' | 'enhanced-audio-intelligibility' | 'alternate')[] = [
-    // movie trailers can have a dubbed track as the only audio track so is_original is false but format.audio_track.audio_is_default is true
-    format.is_original || format.audio_track?.audio_is_default ? 'main' : 'alternate'
+    format.is_original ? 'main' : 'alternate'
   ];
 
   if (format.is_dubbed || format.is_auto_dubbed)


### PR DESCRIPTION
The issue that #858 aimed to fix only happens on a very small number of issues, as the fix seems to be causing more problems than it fixes (e.g. wrong audio track getting selected by default on videos where the original track does not match the language that was used to make the API request), this pull request proposes to revert that change.