### PR TITLE
fix(Format): Parse xtags from protobuf to support SABR-only responses

### DIFF
--- a/protos/misc/common.proto
+++ b/protos/misc/common.proto
@@ -26,3 +26,7 @@ message KeyValuePair {
   optional string key = 1;
   optional string value = 2;
 }
+
+message FormatXTags {
+  repeated KeyValuePair xtags = 1;
+}

--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -1,5 +1,7 @@
 import type Player from '../../../core/Player.js';
 import type { RawNode } from '../../index.js';
+import { FormatXTags } from '../../../../protos/generated/misc/common.js';
+import { base64ToU8 } from '../../../utils/Utils.js';
 
 export type ProjectionType = 'RECTANGULAR' | 'EQUIRECTANGULAR' | 'EQUIRECTANGULAR_THREED_TOP_BOTTOM' | 'MESH';
 export type SpatialAudioType = 'AMBISONICS_5_1' | 'AMBISONICS_QUAD' | 'FOA_WITH_NON_DIEGETIC';
@@ -211,17 +213,16 @@ export default class Format {
       };
 
     if (this.has_audio || this.has_text) {
-      const args = new URLSearchParams(this.cipher || this.signature_cipher);
-      const url_components = new URLSearchParams(args.get('url') || this.url);
+      const xtags = this.xtags
+        ? FormatXTags.decode(base64ToU8(decodeURIComponent(this.xtags).replace(/-/g, '+').replace(/_/g, '/'))).xtags
+        : [];
 
-      const xtags = url_components.get('xtags')?.split(':');
-
-      this.language = xtags?.find((x: string) => x.startsWith('lang='))?.split('=')[1] || null;
+      this.language = xtags.find((tag) => tag.key === 'lang')?.value || null;
 
       if (this.has_audio) {
-        this.is_drc = !!data.isDrc || !!xtags?.includes('drc=1');
+        this.is_drc = !!data.isDrc || xtags.some((tag) => tag.key === 'drc' && tag.value === '1');
 
-        const audio_content = xtags?.find((x) => x.startsWith('acont='))?.split('=')[1];
+        const audio_content = xtags.find((tag) => tag.key === 'acont')?.value;
         this.is_dubbed = audio_content === 'dubbed';
         this.is_descriptive = audio_content === 'descriptive';
         this.is_secondary = audio_content === 'secondary';


### PR DESCRIPTION
As SABR-only responses don't contain the individual URLs for the adaptive formats, parsing the xtags from the URLs is not possible with those reponses. To fix that I have switched to parsing the xtags protobuf instead, which is available on both "normal" responses and SABR-only ones. I have tested this PR on a SABR-only response and various normal reponses for video with multiple audio tracks and the parsed information seemed to be correct.