### PR TITLE
fix(Constants): Update the iOS client version

### DIFF
--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -25,9 +25,11 @@ export const OAUTH = {
 export const CLIENTS = {
   IOS: {
     NAME: 'iOS',
-    VERSION: '18.06.35',
-    USER_AGENT: 'com.google.ios.youtube/18.06.35 (iPhone; CPU iPhone OS 14_4 like Mac OS X; en_US)',
-    DEVICE_MODEL: 'iPhone10,6'
+    VERSION: '20.11.6',
+    USER_AGENT: 'com.google.ios.youtube/20.11.6 (iPhone10,4; U; CPU iOS 16_7_7 like Mac OS X)',
+    DEVICE_MODEL: 'iPhone10,4',
+    OS_NAME: 'iOS',
+    OS_VERSION: '16.7.7.20H330'
   },
   WEB: {
     NAME: 'WEB',

--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -197,7 +197,8 @@ export default class HTTPClient {
         ctx.client.clientVersion = Constants.CLIENTS.IOS.VERSION;
         ctx.client.clientName = Constants.CLIENTS.IOS.NAME;
         ctx.client.platform = 'MOBILE';
-        ctx.client.osName = 'iOS';
+        ctx.client.osName = Constants.CLIENTS.IOS.NAME;
+        ctx.client.osVersion = Constants.CLIENTS.IOS.OS_VERSION;
         delete ctx.client.browserName;
         delete ctx.client.browserVersion;
         break;


### PR DESCRIPTION
This pull request fixes the "precondition failed" error when requesting the player with the iOS client. YouTube seems to have deprecated the 18.x app version, increasing the rollout yesterday. Thought it'd be better to make a pull request with a fix right away rather than an issue.

This is the latest app version at the time of writing, so it should last a good while.