### PR TITLE
chore(build): More efficient enum emit

### DIFF
--- a/dev-scripts/enum-optimising-transformer.cjs
+++ b/dev-scripts/enum-optimising-transformer.cjs
@@ -1,0 +1,124 @@
+/**
+ * @param {import('typescript').Program} program 
+ * @param {import('ts-patch').PluginConfig} pluginConfig 
+ * @param {import('ts-patch').TransformerExtras} extras 
+ */
+module.exports = (program, pluginConfig, { ts: tsInstance }) => {
+  /** @param {import('typescript').TransformationContext} context */
+  return (context) => {
+    const { factory } = context
+
+    /** @param {import('typescript').SourceFile} sourceFile */
+    return (sourceFile) => {
+      /**
+     * @param {import('typescript').Node} node 
+     * @returns {import('typescript').Node}
+     */
+      const visitor = (node) => {
+        if (
+          tsInstance.isEnumDeclaration(node) &&
+          (!node.modifiers || node.modifiers.every(modifier => modifier.kind !== tsInstance.SyntaxKind.DeclareKeyword))
+        ) {
+          let variableStatementModifiers
+
+          if (node.modifiers?.some(modifier => modifier.kind === tsInstance.SyntaxKind.ExportKeyword)) {
+            variableStatementModifiers = [
+              factory.createModifier(tsInstance.SyntaxKind.ExportKeyword)
+            ]
+          }
+
+          const properties = []
+          let currentValue = 0
+
+          for (const member of node.members) {
+            const name = member.name.text
+            let value
+            let isNumeric = true
+            let hasMinus = false
+
+            if (!member.initializer) {
+              value = currentValue.toString()
+              currentValue++
+            } else if (tsInstance.isStringLiteral(member.initializer)) {
+              value = member.initializer.text
+              isNumeric = false
+            } else if (tsInstance.isNumericLiteral(member.initializer)) {
+              value = member.initializer.text
+              currentValue = Number(value) + 1
+            } else if (
+              tsInstance.isPrefixUnaryExpression(member.initializer) &&
+              member.initializer.operator === tsInstance.SyntaxKind.MinusToken
+            ) {
+              value = member.initializer.operand.text
+              hasMinus = true
+              currentValue = (-1 * Number(value)) + 1
+            } else {
+              console.warn(`Unsupported enum member initializer "${tsInstance.SyntaxKind[member.initializer.kind]}" in "${node.name.text}", using original enum output.`)
+              return tsInstance.visitEachChild(node, visitor, context);
+            }
+
+            if (isNumeric) {
+              if (hasMinus) {
+                properties.push(
+                  factory.createPropertyAssignment(
+                    name,
+                    factory.createPrefixUnaryExpression(
+                      tsInstance.SyntaxKind.MinusToken,
+                      factory.createNumericLiteral(value)
+                    )
+                  ),
+                  factory.createPropertyAssignment(
+                    factory.createStringLiteral(`-${value}`),
+                    factory.createStringLiteral(name)
+                  )
+                )
+              } else {
+                properties.push(
+                  factory.createPropertyAssignment(
+                    name,
+                    factory.createNumericLiteral(value)
+                  ),
+                  factory.createPropertyAssignment(
+                    value,
+                    factory.createStringLiteral(name)
+                  )
+                )
+              }
+            } else {
+              properties.push(
+                factory.createPropertyAssignment(
+                  name,
+                  factory.createStringLiteral(value)
+                )
+              )
+            }
+          }
+
+          const convertedEnum = factory.createVariableStatement(
+            variableStatementModifiers,
+            factory.createVariableDeclarationList(
+              [
+                factory.createVariableDeclaration(
+                  factory.createIdentifier(node.name.text),
+                  undefined,
+                  undefined,
+                  factory.createObjectLiteralExpression(
+                    properties,
+                    true
+                  )
+                )
+              ],
+              tsInstance.NodeFlags.Const
+            )
+          )
+
+          return convertedEnum
+        }
+
+        return tsInstance.visitEachChild(node, visitor, context);
+      };
+
+      return tsInstance.visitNode(sourceFile, visitor);
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -100,7 +100,8 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
     "plugins": [
-      { "transform": "ts-transformer-inline-file/transformer" }
+      { "transform": "ts-transformer-inline-file/transformer" },
+      { "transform": "./dev-scripts/enum-optimising-transformer.cjs" }
     ]
   },
   "include": [


### PR DESCRIPTION
It retains the two-way mappings for numeric enums and follows TypeScripts behaviour of only generating one-way mappings for string enums, it also only handles basic enums so either where no values are assigned or they are static. Currently all enums in the code base fit that criteria, however if an enum were to be added that doesn't, then a warning will be logged and it will fallback to tsc's own enum emit for that enum.

This:
```ts
enum Sample {
  Val1,
  Val2
}
```

Gets turned into this, instead of TypeScripts complicated output (which they need to support the dynamic enum values), it also allows removing the unused members during bundling if there are no dynamic lookups or removing the entire enum if it is unused.
```js
const Sample = {
  Val1 = 0,
  0: "Val1",
  Val2: 1,
  1: "Val2"
}
```

Which is a lot simpler that what tsc produces:
```js
var Sample;
(function (Sample) {
    Sample[Sample["Val1"] = 0] = "Val1";
    Sample[Sample["Val2"] = 1] = "Val2";
})(Sample || (Sample = {}));
```