### PR TITLE
chore: Inline some trivial private methods

### DIFF
--- a/src/core/Actions.ts
+++ b/src/core/Actions.ts
@@ -51,18 +51,6 @@ export default class Actions {
   }
 
   /**
-   * Mimics the Axios API using Fetch's Response object.
-   * @param response - The response object.
-   */
-  async #wrap(response: Response): Promise<ApiResponse> {
-    return {
-      success: response.ok,
-      status_code: response.status,
-      data: JSON.parse(await response.text())
-    };
-  }
-
-  /**
    * Makes calls to the playback tracking API.
    * @param url - The URL to call.
    * @param client - The client to use.
@@ -187,7 +175,12 @@ export default class Actions {
       return parsed_response;
     }
 
-    return this.#wrap(response);
+    // Mimics the Axios API using Fetch's Response object.
+    return {
+      success: response.ok,
+      status_code: response.status,
+      data: JSON.parse(await response.text())
+    };
   }
 
   #isBrowse(response: IParsedResponse): response is IBrowseResponse {

--- a/src/parser/helpers.ts
+++ b/src/parser/helpers.ts
@@ -13,20 +13,11 @@ export class YTNode {
 
   /**
    * Check if the node is of the given type.
-   * @param type - The type to check
-   * @returns whether the node is of the given type
-   */
-  #is<T extends YTNode>(type: YTNodeConstructor<T>): this is T {
-    return this.type === type.type;
-  }
-
-  /**
-   * Check if the node is of the given type.
    * @param types - The type to check
    * @returns whether the node is of the given type
    */
   is<T extends YTNode, K extends YTNodeConstructor<T>[]>(...types: K): this is InstanceType<K[number]> {
-    return types.some((type) => this.#is(type));
+    return types.some((type) => this.type === type.type);
   }
 
   /**


### PR DESCRIPTION
This pull request inlines two trivial private methods. The first one is `#is()` on the YTNode class, there doesn't seem to be any typechecking benefit to having it split out into its own method and the code is trivial enough to inline into the public `is()` method. The second one is `#wrap()` in the Actions class whose only purpose is to return an object.

While yes these changes won't have a major impact on code size or performance, `YTNode`'s `is()` method is called in quite a few places in the parser both directly and indirectly (e.g `YTNode.as()`, `ObserveredArray.firstOfType()`), so making it faster definitely won't hurt.