### PR TITLE
fix(Player): Use global var to find signature algorithm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
-        "jintr": "^3.3.0",
+        "jintr": "^3.3.1",
         "tslib": "^2.5.0",
         "undici": "^5.19.1"
       },
@@ -6155,9 +6155,9 @@
       }
     },
     "node_modules/jintr": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/jintr/-/jintr-3.3.0.tgz",
-      "integrity": "sha512-ZsaajJ4Hr5XR0tSPhOZOTjFhxA0qscKNSOs41NRjx7ZOGwpfdp8NKIBEUtvUPbA37JXyv1sJlgeOOZHjr3h76Q==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jintr/-/jintr-3.3.1.tgz",
+      "integrity": "sha512-nnOzyhf0SLpbWuZ270Omwbj5LcXUkTcZkVnK8/veJXtSZOiATM5gMZMdmzN75FmTyj+NVgrGaPdH12zIJ24oIA==",
       "funding": [
         "https://github.com/sponsors/LuanRT"
       ],

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "license": "MIT",
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0",
-    "jintr": "^3.3.0",
+    "jintr": "^3.3.1",
     "tslib": "^2.5.0",
     "undici": "^5.19.1"
   },


### PR DESCRIPTION
This change allows matching code such as:
```
// "Y" is the global var.

r = r[Y[14]](Y[19]);
q3[Y[8]](r, 30);
q3[Y[8]](r, 65);
q3[Y[8]](r, 2);
```

TODO:
Maybe consider removing the regex (it's too fragile) and instead use the AST walker, like we already do for `nsig` and the global lookup variable.

Closes #952