### PR TITLE
fix(Innertube): Properly encoded params in getPostComments()

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -528,7 +528,7 @@ export default class Innertube {
     const writer2 = CommunityPostCommentsParamContainer.encode({
       f0: {
         location: 'FEcomment_post_detail_page_web_top_level',
-        protoData: encodeURIComponent(u8ToBase64(writer1.finish()))
+        protoData: encodeURIComponent(u8ToBase64(writer1.finish()).replace(/\+/g, '-').replace(/\//g, '_'))
       }
     });
 


### PR DESCRIPTION
Same issue that PR #882 solved but for the getPostComments() method.

Example post where getting post comments was failing (but is fixed by this PR): https://www.youtube.com/channel/UCX6OQ3DkcsbYNE6H8uQQuVA/community?lb=UgkxtWKnO2Yc3gxTEWTGylicAK2gv8CSfeAO