### PR TITLE
Session.logged_in to reflect YouTube logged-in state when creating an Innertube instance with a cookie.

### DIFF
--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -474,7 +474,7 @@ export default class Session extends EventEmitter {
           const coldConfigData = configJson.responseContext?.globalConfigGroup?.rawColdConfigGroup?.configData;
           const coldHashData = configJson.responseContext?.globalConfigGroup?.coldHashData;
           const hotHashData = configJson.responseContext?.globalConfigGroup?.hotHashData;
-          this.logged_in = !configJson.responseContext?.mainAppWebResponseContext?.loggedOut
+          this.logged_in = !configJson.responseContext?.mainAppWebResponseContext?.loggedOut;
 
           session_data.config_data = configJson.configData;
           session_data.context.client.configInfo = {

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -474,6 +474,7 @@ export default class Session extends EventEmitter {
           const coldConfigData = configJson.responseContext?.globalConfigGroup?.rawColdConfigGroup?.configData;
           const coldHashData = configJson.responseContext?.globalConfigGroup?.coldHashData;
           const hotHashData = configJson.responseContext?.globalConfigGroup?.hotHashData;
+          this.logged_in = !configJson.responseContext?.mainAppWebResponseContext?.loggedOut
 
           session_data.config_data = configJson.configData;
           session_data.context.client.configInfo = {


### PR DESCRIPTION
Currently if you supply a cookie when creating an Innertube instance, `innertube.session.logged_in = true`, whether the cookie is from a logged-in session or not. 

This one-liner will use the responseContext of the initial innertube config POST to set `logged_in = !LoggedOut`