### PR TITLE
fix(getBasicInfo): Add racyCheckOk and contentCheckOk to payload

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -118,7 +118,13 @@ export default class Innertube {
   async getBasicInfo(video_id: string, client?: InnerTubeClient): Promise<VideoInfo> {
     throwIfMissing({ video_id });
 
-    const watch_endpoint = new NavigationEndpoint({ watchEndpoint: { videoId: video_id } });
+    const watch_endpoint = new NavigationEndpoint({
+      watchEndpoint: {
+        videoId: video_id,
+        racyCheckOk: true,
+        contentCheckOk: true
+      }
+    });
 
     const session = this.#session;
 


### PR DESCRIPTION
For `getInfo` YouTube.js sets the `racyCheckOk` and `contentCheckOk` properties to `true` but they are currently not set for `getBasicInfo`. This pull request corrects by adding them to the `getBasicInfo` request too.