### PR TITLE
fix: Handle CommandExecutorCommand in NavigationEndpoint.call

### DIFF
--- a/src/parser/classes/NavigationEndpoint.ts
+++ b/src/parser/classes/NavigationEndpoint.ts
@@ -2,6 +2,7 @@ import { YTNode } from '../helpers.js';
 import { Parser, type IEndpoint, type RawNode } from '../index.js';
 import OpenPopupAction from './actions/OpenPopupAction.js';
 import CreatePlaylistDialog from './CreatePlaylistDialog.js';
+import CommandExecutorCommand from './commands/CommandExecutorCommand.js';
 
 import type Actions from '../../core/Actions.js';
 import type ModalWithTitleAndButton from './ModalWithTitleAndButton.js';
@@ -124,7 +125,12 @@ export default class NavigationEndpoint extends YTNode {
       throw new Error('An API caller must be provided');
 
     if (this.command) {
-      const command = this.command as (YTNode & IEndpoint);
+      let command = this.command as (YTNode & IEndpoint);
+
+      if (command.is(CommandExecutorCommand)) {
+        command = command.commands.at(-1) as (YTNode & IEndpoint);
+      }
+
       return actions.execute(command.getApiPath(), { ...command.buildRequest(), ...args });
     }
 


### PR DESCRIPTION
YouTube has started occasionally returning CommandExecutorCommands inside of the playlist ContinuationItems, this pull request adds handling for them to fix playlist continuations erroring with `TypeError: command.getApiPath is not a function`.

Related https://github.com/FreeTubeApp/FreeTube/issues/7437, https://github.com/TeamNewPipe/NewPipeExtractor/pull/1301