### PR TITLE
chore: change deprecated `assert` to `with`

### DIFF
--- a/src/platform/react-native.ts
+++ b/src/platform/react-native.ts
@@ -2,7 +2,7 @@
 import type { ICache } from '../types/Cache.js';
 import { Platform } from '../utils/Utils.js';
 import sha1Hash from './polyfills/web-crypto.js';
-import package_json from '../../package.json' assert { type: 'json' };
+import package_json from '../../package.json' with { type: 'json' };
 import evaluate from './jsruntime/jinter.js';
 
 class Cache implements ICache {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

I've encountered this when updating to a recent react native version (0.78+). 