### PR TITLE
fix: Make "deno" conditional export have higher precedence than "node"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   },
   "exports": {
     ".": {
+      "deno": "./dist/src/platform/deno.js",
       "node": {
         "import": "./dist/src/platform/node.js",
         "require": "./bundle/node.cjs"
       },
-      "deno": "./dist/src/platform/deno.js",
       "types": "./dist/src/platform/lib.d.ts",
       "browser": "./dist/src/platform/web.js",
       "react-native": "./dist/src/platform/react-native.js",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/LuanRT/YouTube.js/issues/991
Fixes the issue encountered in https://github.com/LuanRT/YouTube.js/issues/965

Currently, deno never uses the "deno" conditional export in `package.json` as [conditional exports are matched in the order they are specified](https://nodejs.org/api/packages.html#conditional-exports), and [deno supports both the "node" and "deno"](https://docs.deno.com/runtime/fundamentals/node/#conditional-exports) conditions.
This means that users need to apply workarounds for e.g. the fetch function, while this would work out of the box with the "deno" export.
This change should fix execution with deno and make it work out of the box, without impacting other targets such as Node.js since those don't support the "deno" export