### PR TITLE
feat(parser-classes): Add `CompositeVideoPrimaryInfo` parser class

### DIFF
--- a/src/parser/classes/CompositeVideoPrimaryInfo.ts
+++ b/src/parser/classes/CompositeVideoPrimaryInfo.ts
@@ -1,0 +1,12 @@
+import { YTNode } from '../helpers.js';
+import type { RawNode } from '../types/RawResponse.js';
+
+export default class CompositeVideoPrimaryInfo extends YTNode {
+  static type = 'CompositeVideoPrimaryInfo';
+  data: RawNode;
+
+  constructor(data: RawNode) {
+    super();
+    this.data = data;
+  }
+}

--- a/src/parser/classes/CompositeVideoPrimaryInfo.ts
+++ b/src/parser/classes/CompositeVideoPrimaryInfo.ts
@@ -1,5 +1,5 @@
 import { YTNode } from '../helpers.js';
-import type { RawNode } from '../types/RawResponse.js';
+import type { RawNode } from '../types/index.js';
 
 export default class CompositeVideoPrimaryInfo extends YTNode {
   static type = 'CompositeVideoPrimaryInfo';

--- a/src/parser/classes/CompositeVideoPrimaryInfo.ts
+++ b/src/parser/classes/CompositeVideoPrimaryInfo.ts
@@ -3,10 +3,9 @@ import type { RawNode } from '../types/RawResponse.js';
 
 export default class CompositeVideoPrimaryInfo extends YTNode {
   static type = 'CompositeVideoPrimaryInfo';
-  data: RawNode;
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(data: RawNode) {
     super();
-    this.data = data;
   }
 }

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -109,6 +109,7 @@ export { default as CompactMovie } from './classes/CompactMovie.js';
 export { default as CompactPlaylist } from './classes/CompactPlaylist.js';
 export { default as CompactStation } from './classes/CompactStation.js';
 export { default as CompactVideo } from './classes/CompactVideo.js';
+export { default as CompositeVideoPrimaryInfo } from './classes/CompositeVideoPrimaryInfo.js';
 export { default as ConfirmDialog } from './classes/ConfirmDialog.js';
 export { default as ContentMetadataView } from './classes/ContentMetadataView.js';
 export { default as ContentPreviewImageView } from './classes/ContentPreviewImageView.js';


### PR DESCRIPTION
* Added a new parser class called `CompositeVideoPrimaryInfo`.

- [x] `npm run lint` (No lint errors)
- [x] `npm run build:parser-map` (Passed)
- [x] `npm run build` (Passed)

<details><summary><strong>Error Message</strong></summary>

```console
[YOUTUBEJS][Parser]: InnertubeError: CompositeVideoPrimaryInfo not found!
This is a bug, want to help us fix it? Follow the instructions at https://github.com/LuanRT/YouTube.js/blob/main/docs/updating-the-parser.md or report it at https://github.com/LuanRT/YouTube.js/issues!
Introspected and JIT generated this class in the meantime:
class CompositeVideoPrimaryInfo extends YTNode {
  static type = 'CompositeVideoPrimaryInfo';



  constructor(data: RawNode) {
    super();
  }
}
...
```

</details>