### PR TITLE
Add GetVideoInfoOptions to support content bound PoTokens

### DIFF
--- a/src/types/FormatUtils.ts
+++ b/src/types/FormatUtils.ts
@@ -1,10 +1,10 @@
-import type { InnerTubeClient } from '../types/index.js';
+import type { GetVideoInfoOptions } from '../types/index.js';
 import type { Format } from '../parser/misc.js';
 
 export type URLTransformer = (url: URL) => URL;
 export type FormatFilter = (format: Format) => boolean;
 
-export interface FormatOptions {
+export interface FormatOptions extends GetVideoInfoOptions {
   /**
    * Video or audio itag
    */
@@ -29,10 +29,6 @@ export interface FormatOptions {
    * Video or audio codec, e.g. 'avc', 'vp9', 'av01' for video, 'opus', 'mp4a' for audio
    */
   codec?: string;
-  /**
-   * InnerTube client.
-   */
-  client?: InnerTubeClient;
 }
 
 export interface DownloadOptions extends FormatOptions {

--- a/src/types/GetVideoInfoOptions.ts
+++ b/src/types/GetVideoInfoOptions.ts
@@ -1,0 +1,13 @@
+import { type InnerTubeClient } from './Misc.js';
+
+export interface GetVideoInfoOptions {
+  /**
+   * InnerTube client.
+   */
+  client?: InnerTubeClient;
+  /**
+   * Proof of Origin token, bound to the video ID being requested.
+   * If not provided, session bound token will be used.
+   */
+  po_token?: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './Cache.js';
 export * from './PlatformShim.js';
 export * from './Misc.js';
 export * from './FormatUtils.js';
+export * from './GetVideoInfoOptions.js';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Just a proposal to get comments
`getInfo` and `getBasicInfo` should be using content bound poTokens. So that means these calls will need to take a poToken as an argument.
I added `GetVideoInfoOptions` - while it is a breaking change, but avoids the need for breaking again if/when new options are needed for these operations.
Not providing content bound poToken will fallback to session poToken, I believe that should have better results than no token at all.