### PR TITLE
chore: Remove unused tslib dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
         "jintr": "^3.3.1",
-        "tslib": "^2.5.0",
         "undici": "^6.21.3"
       },
       "devDependencies": {
@@ -4931,11 +4930,6 @@
       "peerDependencies": {
         "typescript": "^4.0.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0",
     "jintr": "^3.3.1",
-    "tslib": "^2.5.0",
     "undici": "^6.21.3"
   },
   "overrides": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,7 +52,7 @@
     "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */


### PR DESCRIPTION
Now that the tsconfig target is set to ESNext TypeScript won't generate or import any polyfills, so we no longer need the tslib dependency. For the bundles created with esbuild, esbuild adds its own polyfills.