### PR TITLE
refactor: Import version, bugs URL and repo URL directly from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "rimraf": "^6.0.1",
         "ts-patch": "^3.0.2",
         "ts-proto": "^2.2.0",
-        "ts-transformer-inline-file": "^0.2.0",
         "typedoc": "^0.26.7",
         "typedoc-plugin-markdown": "^4.2.7",
         "typescript": "^5.0.0",
@@ -4917,18 +4916,6 @@
       "dev": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0"
-      }
-    },
-    "node_modules/ts-transformer-inline-file": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ts-transformer-inline-file/-/ts-transformer-inline-file-0.2.0.tgz",
-      "integrity": "sha512-16IBBt0d8MxVdEyxDEFx2+EetgELWs/kUu4FEaL4b1dffu5gB/aw+CwVPW3EzsuO67g8OAF34LcDHsyxQp16Aw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "typescript": "^4.0.0"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
       "react-native": "./dist/src/platform/react-native.js",
       "default": "./dist/src/platform/web.js"
     },
+    "./package.json": "./package.json",
     "./agnostic": {
       "types": "./dist/src/platform/lib.d.ts",
       "default": "./dist/src/platform/lib.js"
@@ -122,7 +123,6 @@
     "rimraf": "^6.0.1",
     "ts-patch": "^3.0.2",
     "ts-proto": "^2.2.0",
-    "ts-transformer-inline-file": "^0.2.0",
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.7",
     "typescript": "^5.0.0",

--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -10,6 +10,7 @@ import {
   Platform,
   PlayerError
 } from '../utils/Utils.js';
+import packageInfo from '../../package.json' with { type: 'json' };
 
 const TAG = 'Player';
 
@@ -199,7 +200,7 @@ export default class Player {
       return null;
 
     try {
-      const current_library_version = parseInt(Platform.shim.info.version.split('.')[0]);
+      const current_library_version = parseInt(packageInfo.version.split('.', 1)[0]);
       const player_data = BinarySerializer.deserialize<SerializablePlayer>(new Uint8Array(buffer));
 
       if (player_data.library_version !== current_library_version) {
@@ -224,7 +225,7 @@ export default class Player {
     if (!cache || !this.sig_sc || !this.nsig_sc)
       return;
 
-    const current_library_version = parseInt(Platform.shim.info.version.split('.')[0]);
+    const current_library_version = parseInt(packageInfo.version.split('.', 1)[0]);
 
     const buffer = BinarySerializer.serialize({
       player_id: this.player_id,

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -7,6 +7,7 @@ import {
   generateRandomString, getRandomUserAgent,
   InnertubeError, Platform, SessionError
 } from '../utils/Utils.js';
+import packageInfo from '../../package.json' with { type: 'json' };
 
 import type { DeviceCategory } from '../utils/Utils.js';
 import type { FetchFunction, ICache } from '../types/index.js';
@@ -332,7 +333,7 @@ export default class Session extends EventEmitter {
     try {
       const session_data = BinarySerializer.deserialize<SerializableSession>(new Uint8Array(buffer));
 
-      if (session_data.library_version !== parseInt(Platform.shim.info.version.split('.')[0])) {
+      if (session_data.library_version !== parseInt(packageInfo.version.split('.', 1)[0])) {
         Log.warn(TAG, `Cached session data is from a different library version (${session_data.library_version}). Regenerating session data.`);
         return null;
       }
@@ -517,7 +518,7 @@ export default class Session extends EventEmitter {
 
     const buffer = BinarySerializer.serialize({
       ...session_data,
-      library_version: parseInt(Platform.shim.info.version)
+      library_version: parseInt(packageInfo.version)
     });
 
     await cache.set('innertube_session_data', buffer);

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,10 +1,11 @@
 import * as YTNodes from './nodes.js';
-import { InnertubeError, ParsingError, Platform } from '../utils/Utils.js';
+import { InnertubeError, ParsingError } from '../utils/Utils.js';
 import type { ObservedArray, YTNode, YTNodeConstructor } from './helpers.js';
 import { Memo, observe, SuperParsedResult } from './helpers.js';
 import type { KeyInfo } from './generator.js';
 import { camelToSnake, generateRuntimeClass, generateTypescriptClass } from './generator.js';
 import { Log } from '../utils/index.js';
+import packageInfo from '../../package.json' with { type: 'json' };
 
 import {
   Continuation,
@@ -102,7 +103,7 @@ let ERROR_HANDLER: ParserErrorHandler = ({ classname, ...context }: ParserError)
         Log.warn(TAG,
           new InnertubeError(
             `Something went wrong at ${classname}!\n` +
-            `This is a bug, please report it at ${Platform.shim.info.bugs_url}`, {
+            `This is a bug, please report it at ${packageInfo.bugs.url}`, {
               stack: context.error.stack,
               classdata: JSON.stringify(context.classdata, null, 2)
             }
@@ -122,7 +123,7 @@ let ERROR_HANDLER: ParserErrorHandler = ({ classname, ...context }: ParserError)
       Log.warn(TAG,
         new InnertubeError(
           `Mutation data required for processing ${classname}, but none found.\n` +
-          `This is a bug, please report it at ${Platform.shim.info.bugs_url}`
+          `This is a bug, please report it at ${packageInfo.bugs.url}`
         )
       );
       break;
@@ -131,7 +132,7 @@ let ERROR_HANDLER: ParserErrorHandler = ({ classname, ...context }: ParserError)
         new InnertubeError(
           `Mutation data missing or invalid for ${context.failed} out of ${context.total} MusicMultiSelectMenuItems. ` +
           `The titles of the failed items are: ${context.titles.join(', ')}.\n` +
-          `This is a bug, please report it at ${Platform.shim.info.bugs_url}`
+          `This is a bug, please report it at ${packageInfo.bugs.url}`
         )
       );
       break;
@@ -139,7 +140,7 @@ let ERROR_HANDLER: ParserErrorHandler = ({ classname, ...context }: ParserError)
       Log.warn(TAG,
         new InnertubeError(
           `${classname} not found!\n` +
-          `This is a bug, want to help us fix it? Follow the instructions at ${Platform.shim.info.repo_url}/blob/main/docs/updating-the-parser.md or report it at ${Platform.shim.info.bugs_url}!\n` +
+          `This is a bug, want to help us fix it? Follow the instructions at ${packageInfo.homepage.split('#', 1)[0]}/blob/main/docs/updating-the-parser.md or report it at ${packageInfo.bugs.url}!\n` +
           `Introspected and JIT generated this class in the meantime:\n${generateTypescriptClass(classname, context.key_info)}`
         )
       );

--- a/src/platform/cf-worker.ts
+++ b/src/platform/cf-worker.ts
@@ -1,11 +1,7 @@
 import type { ICache } from '../types/Cache.js';
 import { Platform } from '../utils/Utils.js';
 import evaluate from './jsruntime/jinter.js';
-import { $INLINE_JSON } from 'ts-transformer-inline-file';
 import sha1Hash from './polyfills/web-crypto.js';
-
-const { homepage, version, bugs } = $INLINE_JSON('../../package.json');
-const repo_url = homepage?.split('#')[0];
 
 class Cache implements ICache {
   #persistent_directory: string;
@@ -44,11 +40,6 @@ class Cache implements ICache {
 
 Platform.load({
   runtime: 'cf-worker',
-  info: {
-    version: version,
-    bugs_url: bugs?.url || `${repo_url}/issues`,
-    repo_url
-  },
   server: true,
   Cache: Cache,
   sha1Hash,

--- a/src/platform/deno.ts
+++ b/src/platform/deno.ts
@@ -3,7 +3,6 @@ import type { ICache } from '../types/Cache.js';
 import { Platform } from '../utils/Utils.js';
 import evaluate from './jsruntime/jinter.js';
 import sha1Hash from './polyfills/web-crypto.js';
-import package_json from '../../package.json' with { type: 'json' };
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -82,11 +81,6 @@ class Cache implements ICache {
 
 Platform.load({
   runtime: 'deno',
-  info: {
-    version: package_json.version,
-    bugs_url: package_json.bugs.url,
-    repo_url: package_json.homepage.split('#')[0]
-  },
   server: true,
   Cache: Cache,
   sha1Hash,

--- a/src/platform/node.ts
+++ b/src/platform/node.ts
@@ -18,14 +18,10 @@ import fs from 'fs/promises';
 import CustomEvent from './polyfills/node-custom-event.js';
 import { fileURLToPath } from 'url';
 import evaluate from './jsruntime/jinter.js';
-import { $INLINE_JSON } from 'ts-transformer-inline-file';
 
 const meta_url = import.meta.url;
 const is_cjs = !meta_url;
 const __dirname__ = is_cjs ? __dirname : path.dirname(fileURLToPath(meta_url));
-
-const { homepage, version, bugs } = $INLINE_JSON('../../package.json');
-const repo_url = homepage?.split('#')[0];
 
 class Cache implements ICache {
   #persistent_directory: string;
@@ -100,11 +96,6 @@ class Cache implements ICache {
 
 Platform.load({
   runtime: 'node',
-  info: {
-    version: version,
-    bugs_url: bugs?.url || `${repo_url}/issues`,
-    repo_url
-  },
   server: true,
   Cache: Cache,
   sha1Hash: async (data: string) => {

--- a/src/platform/react-native.ts
+++ b/src/platform/react-native.ts
@@ -2,7 +2,6 @@
 import type { ICache } from '../types/Cache.js';
 import { Platform } from '../utils/Utils.js';
 import sha1Hash from './polyfills/web-crypto.js';
-import package_json from '../../package.json' with { type: 'json' };
 import evaluate from './jsruntime/jinter.js';
 
 class Cache implements ICache {
@@ -42,11 +41,6 @@ class Cache implements ICache {
 Platform.load({
   runtime: 'react-native',
   server: false,
-  info: {
-    version: package_json.version,
-    bugs_url: package_json.bugs.url,
-    repo_url: package_json.homepage.split('#')[0]
-  },
   Cache: Cache,
   sha1Hash,
   uuidv4() {

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -2,7 +2,6 @@
 import type { ICache } from '../types/Cache.js';
 import { Platform } from '../utils/Utils.js';
 import sha1Hash from './polyfills/web-crypto.js';
-import package_json from '../../package.json' assert { type: 'json' };
 import evaluate from './jsruntime/jinter.js';
 import * as Log from '../utils/Log.js';
 
@@ -95,11 +94,6 @@ class Cache implements ICache {
 Platform.load({
   runtime: 'browser',
   server: false,
-  info: {
-    version: package_json.version,
-    bugs_url: package_json.bugs.url,
-    repo_url: package_json.homepage.split('#')[0]
-  },
   Cache: Cache,
   sha1Hash,
   uuidv4() {

--- a/src/types/PlatformShim.ts
+++ b/src/types/PlatformShim.ts
@@ -8,11 +8,6 @@ export type VMPrimative = string | number | boolean | null | undefined;
 
 interface PlatformShim {
     runtime: Runtime;
-    info: {
-        version: string,
-        bugs_url: string,
-        repo_url: string
-    },
     server: boolean;
     Cache: ICacheConstructor;
     sha1Hash(data: string): Promise<string>;

--- a/src/utils/StreamingInfo.ts
+++ b/src/utils/StreamingInfo.ts
@@ -1,8 +1,9 @@
 import type { StoryboardData } from '../parser/classes/PlayerStoryboardSpec.js';
 import PlayerStoryboardSpec from '../parser/classes/PlayerStoryboardSpec.js';
-import { getStringBetweenStrings, InnertubeError, Platform } from './Utils.js';
+import { getStringBetweenStrings, InnertubeError } from './Utils.js';
 import * as Constants from './Constants.js';
 import * as Log from './Log.js';
+import packageInfo from '../../package.json' with { type: 'json' };
 
 import type Actions from '../core/Actions.js';
 import type Player from '../core/Player.js';
@@ -543,7 +544,7 @@ function getColorInfo(format: Format) {
         anonymisedFormat.cipher = 'REDACTED';
 
         Log.warn(TAG_, `Unknown matrix coefficients "${color_info.matrix_coefficients}". The DASH manifest is still usable without this.\n`
-          + `Please report it at ${Platform.shim.info.bugs_url} so we can add support for it.\n`
+          + `Please report it at ${packageInfo.bugs.url} so we can add support for it.\n`
           + `InnerTube client: ${url.searchParams.get('c')}\nformat:`, anonymisedFormat);
       }
     }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -9,6 +9,7 @@ import { Memo } from '../parser/helpers.js';
 import { Text } from '../parser/misc.js';
 import * as Log from './Log.js';
 import userAgents from './user-agents.js';
+import packageInfo from '../../package.json' with { type: 'json' };
 
 const TAG_ = 'Utils';
 
@@ -40,7 +41,7 @@ export class InnertubeError extends Error {
     }
 
     this.date = new Date();
-    this.version = Platform.shim.info.version;
+    this.version = packageInfo.version;
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -100,7 +100,6 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
     "plugins": [
-      { "transform": "ts-transformer-inline-file/transformer" },
       { "transform": "./dev-scripts/enum-optimising-transformer.cjs" }
     ]
   },


### PR DESCRIPTION
Now that YouTube.js is ESM only and has dropped support for older Node.js versions that required workarounds for JSON imports, we can import the package.json file directly rather than having to proxy it through the platform shim. The package version, bugs URL and repo URL are also not something that users of YouTube.js would need to customise or polyfill at runtime.

If you still need to access to the YouTube.js version, bugs URL or repo URL in your own application, you can import the YouTube.js package.json file with `youtubei.js/package.json`. E.g. 
```js
import ytjsPackageInfo from 'youtubei.js/package.json' with { type: 'json' };

console.log(`YouTube.js version: ${ytjsPackageInfo.version}`);
```