### PR TITLE
perf(Utils): Optimise `options.name` handling in `findVariable`

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -385,12 +385,14 @@ export function findVariable(code: string, options: ASTLookupArgs): ASTLookupRes
       const [ start, end ] = node.range!;
       const node_source = code.slice(start, end);
 
-      for (const declarator of node.declarations) {
-        if (declarator.id.type === 'Identifier') {
-          const var_name = declarator.id.name;
-          if (options.name && var_name === options.name) {
-            found = { start, end, name: var_name, node, result: node_source };
-            return;
+      if (options.name) {
+        for (const declarator of node.declarations) {
+          if (declarator.id.type === 'Identifier') {
+            const var_name = declarator.id.name;
+            if (var_name === options.name) {
+              found = { start, end, name: var_name, node, result: node_source };
+              return;
+            }
           }
         }
       }


### PR DESCRIPTION
This pull request hoists the `options.name` check outside of the for-loop, that way if the option is specified we only have to check it once and when it is not specified we can skip the for-loop entirely.