### PR TITLE
perf: Replace uses of ObservableArray#get with Array#find

### DIFF
--- a/src/core/mixins/Feed.ts
+++ b/src/core/mixins/Feed.ts
@@ -160,7 +160,7 @@ export default class Feed<T extends IParsedResponse = IParsedResponse> {
    * Finds shelf by title.
    */
   getShelf(title: string) {
-    return this.shelves.get({ title });
+    return this.shelves.find((shelf) => shelf.title.toString() === title);
   }
 
   /**

--- a/src/core/mixins/MediaInfo.ts
+++ b/src/core/mixins/MediaInfo.ts
@@ -188,8 +188,8 @@ export default class MediaInfo {
     if (!next_response.engagement_panels)
       throw new InnertubeError('Engagement panels not found. Video likely has no transcript.');
 
-    const transcript_panel = next_response.engagement_panels.get({
-      panel_identifier: 'engagement-panel-searchable-transcript'
+    const transcript_panel = next_response.engagement_panels.find((panel) => {
+      return panel.panel_identifier === 'engagement-panel-searchable-transcript';
     });
 
     if (!transcript_panel)

--- a/src/parser/youtube/Channel.ts
+++ b/src/parser/youtube/Channel.ts
@@ -62,7 +62,7 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
     this.subscribe_button = this.page.header_memo?.getType(SubscribeButton)[0];
 
     if (this.page.contents)
-      this.current_tab = this.page.contents.item().as(TwoColumnBrowseResults).tabs.get({ selected: true });
+      this.current_tab = this.page.contents.item().as(TwoColumnBrowseResults).tabs.find((tab) => tab.selected);
   }
 
   /**
@@ -75,7 +75,7 @@ export default class Channel extends TabbedFeed<IBrowseResponse> {
     const filter_chipbar = this.memo.getType(FeedFilterChipBar)[0];
 
     if (typeof filter === 'string') {
-      target_filter = filter_chipbar?.contents.get({ text: filter });
+      target_filter = filter_chipbar?.contents.find((chip) => chip.text === filter);
       if (!target_filter)
         throw new InnertubeError(`Filter ${filter} not found`, { available_filters: this.filters });
     } else {
@@ -330,7 +330,7 @@ export class FilteredChannelList extends FilterableFeed<IBrowseResponse> {
   constructor(actions: Actions, data: ApiResponse | IBrowseResponse, already_parsed = false) {
     super(actions, data, already_parsed);
 
-    this.applied_filter = this.memo.getType(ChipCloudChip).get({ is_selected: true });
+    this.applied_filter = this.memo.getType(ChipCloudChip).find((chip) => chip.is_selected);
 
     // Removes the filter chipbar from the actions list
     if (

--- a/src/parser/youtube/Search.ts
+++ b/src/parser/youtube/Search.ts
@@ -59,7 +59,9 @@ export default class Search extends Feed<ISearchResponse> {
 
     if (typeof card === 'string') {
       if (!this.refinement_cards) throw new InnertubeError('No refinement cards found.');
-      target_card = this.refinement_cards?.cards.get({ query: card })?.as(SearchRefinementCard);
+      target_card = this.refinement_cards?.cards.find((refinement_card): refinement_card is SearchRefinementCard => {
+        return refinement_card.is(SearchRefinementCard) && refinement_card.query === card;
+      });
       if (!target_card)
         throw new InnertubeError(`Refinement card "${card}" not found`, { available_cards: this.refinement_card_queries });
     } else if (card.type === 'SearchRefinementCard') {

--- a/src/parser/youtube/Settings.ts
+++ b/src/parser/youtube/Settings.ts
@@ -33,7 +33,7 @@ export default class Settings {
     if (!this.#page.contents)
       throw new InnertubeError('Page contents not found');
 
-    const tab = this.#page.contents.item().as(TwoColumnBrowseResults).tabs.get({ selected: true });
+    const tab = this.#page.contents.item().as(TwoColumnBrowseResults).tabs.find((tab) => tab.selected);
 
     if (!tab)
       throw new InnertubeError('Target tab not found');
@@ -58,7 +58,7 @@ export default class Settings {
     let item: CompactLink | undefined;
 
     if (typeof target_item === 'string') {
-      item = this.sidebar.items.get({ title: target_item });
+      item = this.sidebar.items.find((link) => link.title === target_item);
       if (!item)
         throw new InnertubeError(`Item "${target_item}" not found`, { available_items: this.sidebar_items });
     } else if (target_item?.is(CompactLink)) {

--- a/src/parser/ytmusic/Explore.ts
+++ b/src/parser/ytmusic/Explore.ts
@@ -20,7 +20,7 @@ export default class Explore {
   constructor(response: ApiResponse) {
     this.#page = Parser.parseResponse<IBrowseResponse>(response.data);
 
-    const tab = this.#page.contents?.item().as(SingleColumnBrowseResults).tabs.get({ selected: true });
+    const tab = this.#page.contents?.item().as(SingleColumnBrowseResults).tabs.find((tab) => tab.selected);
 
     if (!tab)
       throw new InnertubeError('Could not find target tab.');

--- a/src/parser/ytmusic/HomeFeed.ts
+++ b/src/parser/ytmusic/HomeFeed.ts
@@ -23,7 +23,7 @@ export default class HomeFeed {
     this.#actions = actions;
     this.#page = Parser.parseResponse<IBrowseResponse>(response.data);
 
-    const tab = this.#page.contents?.item().as(SingleColumnBrowseResults).tabs.get({ selected: true });
+    const tab = this.#page.contents?.item().as(SingleColumnBrowseResults).tabs.find((tab) => tab.selected);
 
     if (!tab)
       throw new InnertubeError('Could not find Home tab.');
@@ -62,7 +62,7 @@ export default class HomeFeed {
     let cloud_chip: ChipCloudChip | undefined;
 
     if (typeof target_filter === 'string') {
-      cloud_chip = this.header?.chips?.as(ChipCloudChip).get({ text: target_filter });
+      cloud_chip = this.header?.chips?.as(ChipCloudChip).find((chip) => chip.text === target_filter);
       if (!cloud_chip)
         throw new InnertubeError('Could not find filter with given name.', { available_filters: this.filters });
     } else if (target_filter?.is(ChipCloudChip)) {

--- a/src/parser/ytmusic/Library.ts
+++ b/src/parser/ytmusic/Library.ts
@@ -97,7 +97,7 @@ export default class Library {
     const chip_cloud = this.#page.contents_memo?.getType(ChipCloud)[0];
 
     if (typeof filter === 'string') {
-      target_chip = chip_cloud?.chips.get({ text: filter });
+      target_chip = chip_cloud?.chips.find((chip) => chip.text === filter);
 
       if (!target_chip)
         throw new InnertubeError(`Filter "${filter}" not found`, { available_filters: this.filters });

--- a/src/parser/ytmusic/Search.ts
+++ b/src/parser/ytmusic/Search.ts
@@ -32,7 +32,7 @@ export default class Search {
     if (!this.#page.contents || !this.#page.contents_memo)
       throw new InnertubeError('Response did not contain any contents.');
 
-    const tab = this.#page.contents.item().as(TabbedSearchResults).tabs.get({ selected: true });
+    const tab = this.#page.contents.item().as(TabbedSearchResults).tabs.find((tab) => tab.selected);
 
     if (!tab)
       throw new InnertubeError('Could not find target tab.');
@@ -87,7 +87,7 @@ export default class Search {
     let cloud_chip: ChipCloudChip | undefined;
 
     if (typeof target_filter === 'string') {
-      cloud_chip = this.header?.chips?.as(ChipCloudChip).get({ text: target_filter });
+      cloud_chip = this.header?.chips?.as(ChipCloudChip).find((chip) => chip.text === target_filter);
       if (!cloud_chip)
         throw new InnertubeError('Could not find filter with given name.', { available_filters: this.filters });
     } else if (target_filter?.is(ChipCloudChip)) {

--- a/src/parser/ytmusic/TrackInfo.ts
+++ b/src/parser/ytmusic/TrackInfo.ts
@@ -48,7 +48,7 @@ class TrackInfo extends MediaInfo {
       throw new InnertubeError('Could not find any tab');
 
     const target_tab =
-      this.tabs.get({ title: title_or_page_type }) ||
+      this.tabs.find((tab) => tab.title === title_or_page_type) ||
       this.tabs.find((tab) => tab.endpoint.payload.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType === title_or_page_type) ||
       this.tabs?.[0];
 


### PR DESCRIPTION
Using Array#find directly is faster when checking a single property compared to ObservableArray#get as that does object comparisons instead of direct property accesses.