### PR TITLE
fix(types): Parser.parseArray always returns an ObservedArray

### DIFF
--- a/src/parser/classes/ChipBarView.ts
+++ b/src/parser/classes/ChipBarView.ts
@@ -5,7 +5,7 @@ import ChipView from './ChipView.js';
 export default class ChipBarView extends YTNode {
   static type = 'ChipBarView';
 
-  chips: ObservedArray<ChipView> | null;
+  chips: ObservedArray<ChipView>;
 
   constructor(data: RawNode) {
     super();

--- a/src/parser/classes/CompactVideo.ts
+++ b/src/parser/classes/CompactVideo.ts
@@ -22,7 +22,7 @@ export default class CompactVideo extends YTNode {
   public short_byline_text?: Text;
   public long_byline_text?: Text;
   public published?: Text;
-  public badges: MetadataBadge[];
+  public badges: ObservedArray<MetadataBadge>;
   public thumbnail_overlays: ObservedArray<YTNode>;
   public endpoint?: NavigationEndpoint;
   public menu: Menu | null;

--- a/src/parser/classes/GridShow.ts
+++ b/src/parser/classes/GridShow.ts
@@ -14,7 +14,7 @@ export default class GridShow extends YTNode {
   thumbnail_renderer: ShowCustomThumbnail | null;
   endpoint: NavigationEndpoint;
   long_byline_text: Text;
-  thumbnail_overlays: ObservedArray<ThumbnailOverlayBottomPanel> | null;
+  thumbnail_overlays: ObservedArray<ThumbnailOverlayBottomPanel>;
   author: Author;
 
   constructor(data: RawNode) {

--- a/src/parser/classes/InteractiveTabbedHeader.ts
+++ b/src/parser/classes/InteractiveTabbedHeader.ts
@@ -14,7 +14,7 @@ export default class InteractiveTabbedHeader extends YTNode {
   title: Text;
   description: Text;
   metadata: Text;
-  badges: MetadataBadge[];
+  badges: ObservedArray<MetadataBadge>;
   box_art: Thumbnail[];
   banner: Thumbnail[];
   buttons: ObservedArray<SubscribeButton | Button>;

--- a/src/parser/classes/MultiMarkersPlayerBar.ts
+++ b/src/parser/classes/MultiMarkersPlayerBar.ts
@@ -10,7 +10,7 @@ export class Marker extends YTNode {
   marker_key: string;
   value: {
     heatmap?: Heatmap | null;
-    chapters?: Chapter[];
+    chapters?: ObservedArray<Chapter>;
   };
 
   constructor(data: RawNode) {

--- a/src/parser/classes/MusicResponsiveHeader.ts
+++ b/src/parser/classes/MusicResponsiveHeader.ts
@@ -22,7 +22,7 @@ export default class MusicResponsiveHeader extends YTNode {
   strapline_text_one: Text;
   strapline_thumbnail: MusicThumbnail | null;
   second_subtitle: Text;
-  subtitle_badge?: ObservedArray<MusicInlineBadge> | null;
+  subtitle_badge?: ObservedArray<MusicInlineBadge>;
   description?: MusicDescriptionShelf | null;
 
   constructor(data: RawNode) {

--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -30,7 +30,7 @@ export default class MusicResponsiveListItem extends YTNode {
   item_type: 'album' | 'playlist' | 'artist' | 'library_artist' | 'non_music_track' | 'video' | 'song' | 'endpoint' | 'unknown' | 'podcast_show' | undefined;
   index?: Text;
   thumbnail?: MusicThumbnail | null;
-  badges;
+  badges?: ObservedArray<YTNode>;
   menu?: Menu | null;
   overlay?: MusicItemThumbnailOverlay | null;
 

--- a/src/parser/classes/Playlist.ts
+++ b/src/parser/classes/Playlist.ts
@@ -22,7 +22,7 @@ export default class Playlist extends YTNode {
   menu: YTNode;
   badges: ObservedArray<YTNode>;
   endpoint: NavigationEndpoint;
-  thumbnail_overlays;
+  thumbnail_overlays: ObservedArray<YTNode>;
   view_playlist?: Text;
 
   constructor(data: RawNode) {

--- a/src/parser/classes/PostMultiImage.ts
+++ b/src/parser/classes/PostMultiImage.ts
@@ -1,11 +1,12 @@
 import { Parser, type RawNode } from '../index.js';
 import BackstageImage from './BackstageImage.js';
+import type { ObservedArray } from '../helpers.js';
 import { YTNode } from '../helpers.js';
 
 export default class PostMultiImage extends YTNode {
   static type = 'PostMultiImage';
 
-  images : BackstageImage[];
+  images: ObservedArray<BackstageImage>;
 
   constructor(data: RawNode) {
     super();

--- a/src/parser/classes/ThumbnailOverlayBadgeView.ts
+++ b/src/parser/classes/ThumbnailOverlayBadgeView.ts
@@ -1,3 +1,4 @@
+import type { ObservedArray } from '../helpers.js';
 import { YTNode } from '../helpers.js';
 import { Parser, type RawNode } from '../index.js';
 import ThumbnailBadgeView from './ThumbnailBadgeView.js';
@@ -5,7 +6,7 @@ import ThumbnailBadgeView from './ThumbnailBadgeView.js';
 export default class ThumbnailOverlayBadgeView extends YTNode {
   static type = 'ThumbnailOverlayBadgeView';
 
-  public badges: ThumbnailBadgeView[];
+  public badges: ObservedArray<ThumbnailBadgeView>;
   public position: string;
 
   constructor(data: RawNode) {

--- a/src/parser/classes/TwoColumnWatchNextResults.ts
+++ b/src/parser/classes/TwoColumnWatchNextResults.ts
@@ -20,7 +20,7 @@ export default class TwoColumnWatchNextResults extends YTNode {
     id: string,
     title: string,
     author: Text | Author,
-    contents: YTNode[],
+    contents: ObservedArray<YTNode>,
     current_index: number,
     is_infinite: boolean,
     menu: Menu | null

--- a/src/parser/classes/Video.ts
+++ b/src/parser/classes/Video.ts
@@ -24,7 +24,7 @@ export default class Video extends YTNode {
   public thumbnail_overlays: ObservedArray<YTNode>;
   public rich_thumbnail?: YTNode;
   public author: Author;
-  public badges: MetadataBadge[];
+  public badges: ObservedArray<MetadataBadge>;
   public endpoint?: NavigationEndpoint;
   public published?: Text;
   public view_count?: Text;

--- a/src/parser/classes/actions/AppendContinuationItemsAction.ts
+++ b/src/parser/classes/actions/AppendContinuationItemsAction.ts
@@ -6,7 +6,7 @@ import { YTNode } from '../../helpers.js';
 export default class AppendContinuationItemsAction extends YTNode {
   static type = 'AppendContinuationItemsAction';
 
-  contents: ObservedArray<YTNode> | null;
+  contents: ObservedArray<YTNode>;
   target: string;
 
   constructor(data: RawNode) {

--- a/src/parser/classes/livechat/items/LiveChatSponsorshipsHeader.ts
+++ b/src/parser/classes/livechat/items/LiveChatSponsorshipsHeader.ts
@@ -12,7 +12,7 @@ export default class LiveChatSponsorshipsHeader extends YTNode {
 
   author_name: Text;
   author_photo: Thumbnail[];
-  author_badges: ObservedArray<LiveChatAuthorBadge> | null;
+  author_badges: ObservedArray<LiveChatAuthorBadge>;
   primary_text: Text;
   menu_endpoint: NavigationEndpoint;
   context_menu_accessibility_label: string;

--- a/src/parser/classes/mweb/MobileTopbar.ts
+++ b/src/parser/classes/mweb/MobileTopbar.ts
@@ -1,3 +1,4 @@
+import type { ObservedArray } from '../../helpers.js';
 import { YTNode } from '../../helpers.js';
 import Text from '../misc/Text.js';
 import { Parser, type RawNode } from '../../index.js';
@@ -6,7 +7,7 @@ export default class MobileTopbar extends YTNode {
   static type = 'MobileTopbar';
 
   public placeholder_text: Text;
-  public buttons;
+  public buttons: ObservedArray<YTNode>;
   public logo_type?: string;
 
   constructor(data: RawNode) {

--- a/src/parser/classes/mweb/PivotBar.ts
+++ b/src/parser/classes/mweb/PivotBar.ts
@@ -1,10 +1,11 @@
+import type { ObservedArray } from '../../helpers.js';
 import { YTNode } from '../../helpers.js';
 import { Parser, type RawNode } from '../../index.js';
 
 export default class PivotBar extends YTNode {
   static type = 'PivotBar';
 
-  public items;
+  public items: ObservedArray<YTNode>;
 
   constructor(data: RawNode) {
     super();

--- a/src/parser/continuations.ts
+++ b/src/parser/continuations.ts
@@ -9,7 +9,7 @@ import type { ObservedArray } from './helpers.js';
 export class ItemSectionContinuation extends YTNode {
   static readonly type = 'itemSectionContinuation';
 
-  contents: ObservedArray<YTNode> | null;
+  contents: ObservedArray<YTNode>;
   continuation?: string;
 
   constructor(data: RawNode) {
@@ -94,7 +94,7 @@ export class MusicShelfContinuation extends YTNode {
   static readonly type = 'musicShelfContinuation';
 
   continuation: string;
-  contents: ObservedArray<YTNode> | null;
+  contents: ObservedArray<YTNode>;
 
   constructor(data: RawNode) {
     super();
@@ -126,7 +126,7 @@ export class PlaylistPanelContinuation extends YTNode {
   static readonly type = 'playlistPanelContinuation';
 
   continuation: string;
-  contents: ObservedArray<YTNode> | null;
+  contents: ObservedArray<YTNode>;
 
   constructor(data: RawNode) {
     super();


### PR DESCRIPTION
Fixes various places where properties holding the return value of a `Parser.parseArray` call, were typed as also allowing `null` or as plain arrays.