### PR TITLE
Decipher url using video bound po_token

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -463,7 +463,7 @@ export default class Innertube {
     const info = await this.getBasicInfo(video_id, options);
 
     const format = info.chooseFormat(options);
-    format.url = format.decipher(this.#session.player);
+    format.url = format.decipher(this.#session.player, options.po_token);
 
     return format;
   }

--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -97,7 +97,7 @@ export default class Player {
     return player;
   }
 
-  decipher(url?: string, signature_cipher?: string, cipher?: string, this_response_nsig_cache?: Map<string, string>): string {
+  decipher(url?: string, signature_cipher?: string, cipher?: string, this_response_nsig_cache?: Map<string, string>, po_token?: string): string {
     url = url || signature_cipher || cipher;
 
     if (!url)
@@ -153,8 +153,12 @@ export default class Player {
     }
 
     // @NOTE: SABR requests should include the PoToken (not base64d, but as bytes!) in the payload.
-    if (url_components.searchParams.get('sabr') !== '1' && this.po_token)
-      url_components.searchParams.set('pot', this.po_token);
+    if (url_components.searchParams.get('sabr') !== '1'){
+      const pot = po_token || this.po_token;
+      if (pot) {
+        url_components.searchParams.set('pot', pot);
+      }
+    }
 
     const client = url_components.searchParams.get('c');
 

--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -240,11 +240,12 @@ export default class Format {
   /**
    * Deciphers the URL using the provided player instance.
    * @param player - An optional instance of the Player class used to decipher the URL.
+   * @param po_token - An optional po_token used in deciphered url.
    * @returns The deciphered URL as a string. If no player is provided, returns the original URL or an empty string.
    */
-  decipher(player?: Player): string {
+  decipher(player?: Player, po_token?: string): string {
     if (!player)
       return this.url || '';
-    return player.decipher(this.url, this.signature_cipher, this.cipher, this.#this_response_nsig_cache);
+    return player.decipher(this.url, this.signature_cipher, this.cipher, this.#this_response_nsig_cache, po_token);
   }
 }

--- a/src/utils/FormatUtils.ts
+++ b/src/utils/FormatUtils.ts
@@ -31,7 +31,7 @@ export async function download(
   };
 
   const format = chooseFormat(opts, streaming_data);
-  const format_url = format.decipher(player);
+  const format_url = format.decipher(player, opts.po_token);
 
   // If we're not downloading the video in chunks, we just use fetch once.
   if (opts.type === 'video+audio' && !options.range) {


### PR DESCRIPTION
This is kind of a follow up to https://github.com/LuanRT/YouTube.js/pull/994

Since `PoToken` can be videoId bound, then we should use video specific tokens for decoding (which is just setting the `pot` param`) instead of using the one in the Player, which I assume would be the session token.

I started making the changes, but then I didn't know which direction I wanted to go, because there are more changes that needed to be done, and I found myself passing po_token arg everywhere.

I thought I'd draft this and get some feedback first, or at least bring attention to it