### PR TITLE
fix(parser): LockupMetadataView.image can also be an AvatarStackView

### DIFF
--- a/src/parser/classes/LockupMetadataView.ts
+++ b/src/parser/classes/LockupMetadataView.ts
@@ -1,6 +1,7 @@
 import { YTNode } from '../helpers.js';
 import { Parser, type RawNode } from '../index.js';
 import ContentMetadataView from './ContentMetadataView.js';
+import AvatarStackView from './AvatarStackView.js';
 import DecoratedAvatarView from './DecoratedAvatarView.js';
 import Text from './misc/Text.js';
 import ButtonView from './ButtonView.js';
@@ -10,14 +11,14 @@ export default class LockupMetadataView extends YTNode {
 
   public title: Text;
   public metadata: ContentMetadataView | null;
-  public image: DecoratedAvatarView | null;
+  public image: DecoratedAvatarView | AvatarStackView | null;
   public menu_button: ButtonView | null;
 
   constructor(data: RawNode) {
     super();
     this.title = Text.fromAttributed(data.title);
     this.metadata = Parser.parseItem(data.metadata, ContentMetadataView);
-    this.image = Parser.parseItem(data.image, DecoratedAvatarView);
+    this.image = Parser.parseItem(data.image, [ DecoratedAvatarView, AvatarStackView ]);
     this.menu_button = Parser.parseItem(data.menuButton, ButtonView);
   }
 }


### PR DESCRIPTION
Videos with multiple collaborators in the recommended videos section have an AvatarStackView instead of a DecoratedAvatarView.