### PR TITLE
Exposed members-only attribute in video classes

### DIFF
--- a/src/parser/classes/GridVideo.ts
+++ b/src/parser/classes/GridVideo.ts
@@ -69,6 +69,6 @@ export default class GridVideo extends YTNode {
   }
 
   get is_members_only(): boolean {
-    return this.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
+    return this.badges.some((badge) => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
   }
 }

--- a/src/parser/classes/GridVideo.ts
+++ b/src/parser/classes/GridVideo.ts
@@ -5,6 +5,7 @@ import Menu from './menus/Menu.js';
 import Author from './misc/Author.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';
+import MetadataBadge from './MetadataBadge.js';
 
 export default class GridVideo extends YTNode {
   static type = 'GridVideo';
@@ -21,6 +22,7 @@ export default class GridVideo extends YTNode {
   public short_view_count: Text;
   public endpoint: NavigationEndpoint;
   public menu: Menu | null;
+  public badges: ObservedArray<MetadataBadge>;
   public buttons?: ObservedArray<YTNode>;
   public upcoming?: Date;
   public upcoming_text?: Text;
@@ -42,6 +44,7 @@ export default class GridVideo extends YTNode {
     this.short_view_count = new Text(data.shortViewCountText);
     this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
     this.menu = Parser.parseItem(data.menu, Menu);
+    this.badges = Parser.parseArray(data.badges, MetadataBadge);
 
     if (Reflect.has(data, 'buttons')) {
       this.buttons = Parser.parseArray(data.buttons);
@@ -63,5 +66,9 @@ export default class GridVideo extends YTNode {
 
   get is_upcoming(): boolean {
     return Boolean(this.upcoming && this.upcoming > new Date());
+  }
+
+  get is_members_only(): boolean {
+    return this.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
   }
 }

--- a/src/parser/classes/PlaylistVideo.ts
+++ b/src/parser/classes/PlaylistVideo.ts
@@ -72,6 +72,6 @@ export default class PlaylistVideo extends YTNode {
   }
 
   get is_members_only(): boolean {
-    return this.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
+    return this.badges.some((badge) => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
   }
 }

--- a/src/parser/classes/PlaylistVideo.ts
+++ b/src/parser/classes/PlaylistVideo.ts
@@ -6,6 +6,7 @@ import Menu from './menus/Menu.js';
 import Author from './misc/Author.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';
+import MetadataBadge from './MetadataBadge.js';
 
 export default class PlaylistVideo extends YTNode {
   static type = 'PlaylistVideo';
@@ -22,6 +23,7 @@ export default class PlaylistVideo extends YTNode {
   menu: Menu | null;
   upcoming?: Date;
   video_info: Text;
+  badges: ObservedArray<MetadataBadge>;
   accessibility_label?: string;
   style?: string;
 
@@ -44,6 +46,7 @@ export default class PlaylistVideo extends YTNode {
     this.menu = Parser.parseItem(data.menu, Menu);
     this.video_info = new Text(data.videoInfo);
     this.accessibility_label = data.title.accessibility.accessibilityData.label;
+    this.badges = Parser.parseArray(data.badges, MetadataBadge);
 
     if (Reflect.has(data, 'style')) {
       this.style = data.style;
@@ -66,5 +69,9 @@ export default class PlaylistVideo extends YTNode {
 
   get is_upcoming(): boolean {
     return this.thumbnail_overlays.firstOfType(ThumbnailOverlayTimeStatus)?.style === 'UPCOMING';
+  }
+
+  get is_members_only(): boolean {
+    return this.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
   }
 }

--- a/src/parser/classes/ShortsLockupView.ts
+++ b/src/parser/classes/ShortsLockupView.ts
@@ -52,6 +52,6 @@ export default class ShortsLockupView extends YTNode {
   }
 
   get is_members_only(): boolean {
-    return this.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
+    return this.badges.some((badge) => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
   }
 }

--- a/src/parser/classes/ShortsLockupView.ts
+++ b/src/parser/classes/ShortsLockupView.ts
@@ -1,11 +1,10 @@
-import { type ObservedArray, YTNode } from '../helpers.js';
+import { YTNode } from '../helpers.js';
 import { Parser } from '../index.js';
 import type { RawNode } from '../types/index.js';
 import BadgeView from './BadgeView.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
-import MetadataBadge from './MetadataBadge.js';
 
 export default class ShortsLockupView extends YTNode {
   static type = 'ShortsLockupView';
@@ -22,7 +21,6 @@ export default class ShortsLockupView extends YTNode {
     secondary_text?: Text;
   };
   inline_player_data?: NavigationEndpoint;
-  badges: ObservedArray<MetadataBadge>;
   badge?: BadgeView | null;
 
   constructor(data: RawNode) {
@@ -35,7 +33,6 @@ export default class ShortsLockupView extends YTNode {
     this.menu_on_tap = new NavigationEndpoint(data.menuOnTap);
     this.index_in_collection = data.indexInCollection;
     this.menu_on_tap_a11y_label = data.menuOnTapA11yLabel;
-    this.badges = Parser.parseArray(data.badges, MetadataBadge);
 
     this.overlay_metadata = {
       primary_text: data.overlayMetadata.primaryText ? Text.fromAttributed(data.overlayMetadata.primaryText) : undefined,
@@ -49,9 +46,5 @@ export default class ShortsLockupView extends YTNode {
     if (data.badge) {
       this.badge = Parser.parseItem(data.badge, BadgeView);
     }
-  }
-
-  get is_members_only(): boolean {
-    return this.badges.some((badge) => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
   }
 }

--- a/src/parser/classes/ShortsLockupView.ts
+++ b/src/parser/classes/ShortsLockupView.ts
@@ -1,10 +1,11 @@
-import { YTNode } from '../helpers.js';
+import { type ObservedArray, YTNode } from '../helpers.js';
 import { Parser } from '../index.js';
 import type { RawNode } from '../types/index.js';
 import BadgeView from './BadgeView.js';
 import Text from './misc/Text.js';
 import Thumbnail from './misc/Thumbnail.js';
 import NavigationEndpoint from './NavigationEndpoint.js';
+import MetadataBadge from './MetadataBadge.js';
 
 export default class ShortsLockupView extends YTNode {
   static type = 'ShortsLockupView';
@@ -21,6 +22,7 @@ export default class ShortsLockupView extends YTNode {
     secondary_text?: Text;
   };
   inline_player_data?: NavigationEndpoint;
+  badges: ObservedArray<MetadataBadge>;
   badge?: BadgeView | null;
 
   constructor(data: RawNode) {
@@ -33,6 +35,7 @@ export default class ShortsLockupView extends YTNode {
     this.menu_on_tap = new NavigationEndpoint(data.menuOnTap);
     this.index_in_collection = data.indexInCollection;
     this.menu_on_tap_a11y_label = data.menuOnTapA11yLabel;
+    this.badges = Parser.parseArray(data.badges, MetadataBadge);
 
     this.overlay_metadata = {
       primary_text: data.overlayMetadata.primaryText ? Text.fromAttributed(data.overlayMetadata.primaryText) : undefined,
@@ -46,5 +49,9 @@ export default class ShortsLockupView extends YTNode {
     if (data.badge) {
       this.badge = Parser.parseItem(data.badge, BadgeView);
     }
+  }
+
+  get is_members_only(): boolean {
+    return this.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
   }
 }

--- a/src/parser/classes/Video.ts
+++ b/src/parser/classes/Video.ts
@@ -142,7 +142,7 @@ export default class Video extends YTNode {
   }
 
   get is_members_only(): boolean {
-    return this.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
+    return this.badges.some((badge) => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
   }
 
   get has_captions(): boolean {

--- a/src/parser/classes/Video.ts
+++ b/src/parser/classes/Video.ts
@@ -141,6 +141,10 @@ export default class Video extends YTNode {
     return this.badges.some((badge) => badge.label === '4K');
   }
 
+  get is_members_only(): boolean {
+    return this.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY');
+  }
+
   get has_captions(): boolean {
     return this.badges.some((badge) => badge.label === 'CC');
   }


### PR DESCRIPTION
Title says it all. Very simple addition so that members-only videos can be distinguished from freely available ones. YT API does that with badges, so I added a helper function is_members_only()

Works with the classes I edited, although I'm not sure I caught them all. I didn't study the docs, so maybe someone else would know if other classes will also have those members-only badges