### PR TITLE
feat(getTrending): Add support for searching different trending pages

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -52,6 +52,13 @@ import {
   SearchFilter_SortBy
 } from '../protos/generated/misc/params.js';
 
+export enum TrendingPage {
+  Gaming = 0,
+  Movies = 1,
+  Music = 2,
+  Livestreams = 3,
+}
+
 /**
  * Provides access to various services and modules in the YouTube API.
  *
@@ -364,8 +371,27 @@ export default class Innertube {
     return new History(this.actions, response);
   }
 
-  async getTrending(): Promise<TabbedFeed<IBrowseResponse>> {
-    const browse_endpoint = new NavigationEndpoint({ browseEndpoint: { browseId: 'FEtrending' } });
+  async getTrending(trendingPage?: TrendingPage): Promise<TabbedFeed<IBrowseResponse>> {
+    let params = null;
+    let browseId = 'FEtrending';
+
+    switch (trendingPage) {
+      case TrendingPage.Gaming:
+        params = '4gIcGhpnYW1pbmdfY29ycHVzX21vc3RfcG9wdWxhcg%3D%3D';
+        break;
+      case TrendingPage.Movies:
+        params = '4gIKGgh0cmFpbGVycw%3D%3D';
+        break;
+      case TrendingPage.Music:
+        params = '4gINGgt5dG1hX2NoYXJ0cw%3D%3D';
+        break;
+      case TrendingPage.Livestreams:
+        params = 'EgdsaXZldGFikgEDCKEK';
+        browseId = 'UC4R8DWoMoI7CAwX8_LjQHig';
+        break;
+    }
+
+    const browse_endpoint = new NavigationEndpoint({ browseEndpoint: { browseId: browseId, params: params } });
     const response = await browse_endpoint.call(this.#session.actions);
     return new TabbedFeed(this.actions, response);
   }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Add the ability to search different trending pages instead of the default one.

Acording to https://github.com/iv-org/invidious/issues/5397#issuecomment-3218928458 and https://github.com/TeamNewPipe/NewPipe/discussions/12445, Youtube is removing their aggregated trending page. This adds a few more trending options instead of always fetching the default trending page.