### PR TITLE
refactor(node): Replace undici dependency with built-in fetch

### DIFF
--- a/dev-scripts/get-agents.mjs
+++ b/dev-scripts/get-agents.mjs
@@ -1,4 +1,3 @@
-import { fetch } from 'undici';
 import { gunzip } from 'zlib';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
-        "jintr": "^3.3.1",
-        "undici": "^6.21.3"
+        "jintr": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -5032,15 +5031,6 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
-    },
-    "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
     },
     "node_modules/undici-types": {
       "version": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -103,8 +103,7 @@
   "license": "MIT",
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0",
-    "jintr": "^3.3.1",
-    "undici": "^6.21.3"
+    "jintr": "^3.3.1"
   },
   "overrides": {
     "typescript": "^5.0.0"

--- a/src/platform/node.ts
+++ b/src/platform/node.ts
@@ -1,17 +1,8 @@
 // Node.js Platform Support
 import { ReadableStream } from 'stream/web';
-import {
-  fetch as defaultFetch,
-  Request,
-  Response,
-  Headers,
-  FormData,
-  File
-} from 'undici';
 import type { ICache } from '../types/Cache.js';
 import { Platform } from '../utils/Utils.js';
 import crypto from 'crypto';
-import type { FetchFunction } from '../types/PlatformShim.js';
 import path from 'path';
 import os from 'os';
 import fs from 'fs/promises';
@@ -105,12 +96,12 @@ Platform.load({
     return crypto.randomUUID();
   },
   eval: evaluate,
-  fetch: defaultFetch as unknown as FetchFunction,
-  Request: Request as unknown as typeof globalThis.Request,
-  Response: Response as unknown as typeof globalThis.Response,
-  Headers: Headers as unknown as typeof globalThis.Headers,
-  FormData: FormData as unknown as typeof globalThis.FormData,
-  File: File as unknown as typeof globalThis.File,
+  fetch: globalThis.fetch,
+  Request: globalThis.Request,
+  Response: globalThis.Response,
+  Headers: globalThis.Headers,
+  FormData: globalThis.FormData,
+  File: globalThis.File,
   ReadableStream: ReadableStream as unknown as typeof globalThis.ReadableStream,
   CustomEvent: CustomEvent as unknown as typeof globalThis.CustomEvent
 });


### PR DESCRIPTION
Now that YouTube.js only support more recent versions of Node.js, we no longer need the external undici dependency and can instead use the fetch implementation built-into Node.js, which is also happens to be undici.