### PR TITLE
refactor: Use async/await for the javascript evaluator

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -463,7 +463,7 @@ export default class Innertube {
     const info = await this.getBasicInfo(video_id, options);
 
     const format = info.chooseFormat(options);
-    format.url = format.decipher(this.#session.player);
+    format.url = await format.decipher(this.#session.player);
 
     return format;
   }

--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -98,7 +98,7 @@ export default class Player {
     return player;
   }
 
-  decipher(url?: string, signature_cipher?: string, cipher?: string, this_response_nsig_cache?: Map<string, string>): string {
+  async decipher(url?: string, signature_cipher?: string, cipher?: string, this_response_nsig_cache?: Map<string, string>): Promise<string> {
     url = url || signature_cipher || cipher;
 
     if (!url)
@@ -108,7 +108,7 @@ export default class Player {
     const url_components = new URL(args.get('url') || url);
 
     if (this.sig_sc && (signature_cipher || cipher)) {
-      const signature = Platform.shim.eval(this.sig_sc, {
+      const signature = await Platform.shim.eval(this.sig_sc, {
         sig: args.get('s')
       });
 
@@ -134,7 +134,7 @@ export default class Player {
       if (this_response_nsig_cache && this_response_nsig_cache.has(n)) {
         nsig = this_response_nsig_cache.get(n) as string;
       } else {
-        nsig = Platform.shim.eval(this.nsig_sc, {
+        nsig = await Platform.shim.eval(this.nsig_sc, {
           nsig: n
         });
 

--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -242,7 +242,7 @@ export default class Format {
    * @param player - An optional instance of the Player class used to decipher the URL.
    * @returns The deciphered URL as a string. If no player is provided, returns the original URL or an empty string.
    */
-  decipher(player?: Player): string {
+  async decipher(player?: Player): Promise<string> {
     if (!player)
       return this.url || '';
     return player.decipher(this.url, this.signature_cipher, this.cipher, this.#this_response_nsig_cache);

--- a/src/types/PlatformShim.ts
+++ b/src/types/PlatformShim.ts
@@ -12,7 +12,7 @@ interface PlatformShim {
     Cache: ICacheConstructor;
     sha1Hash(data: string): Promise<string>;
     uuidv4(): string;
-    eval(code: string, env: Record<string, VMPrimative>): unknown;
+    eval(code: string, env: Record<string, VMPrimative>): Promise<unknown>;
     fetch: FetchFunction;
     Request: typeof Request;
     Response: typeof Response;

--- a/src/utils/DashManifest.tsx
+++ b/src/utils/DashManifest.tsx
@@ -94,7 +94,7 @@ async function DashManifest({
     video_sets,
     image_sets,
     text_sets
-  } = getStreamingInfo(streamingData, isPostLiveDvr, transformURL, rejectFormat, cpn, player, actions, storyboards, captionTracks, options);
+  } = await getStreamingInfo(streamingData, isPostLiveDvr, transformURL, rejectFormat, cpn, player, actions, storyboards, captionTracks, options);
 
   // XXX: DASH spec: https://standards.iso.org/ittf/PubliclyAvailableStandards/c083314_ISO_IEC%2023009-1_2022(en).zip
 


### PR DESCRIPTION
Allows for `Platform.shim.eval` to be asynchronous for custom evaluators. EG: using an online service to evaluate the javascript code in contexts where code interpreters are prohibited.