### PR TITLE
fix(FormatUtils#download): Add missing await for format.decipher() call in download function

### DIFF
--- a/src/utils/FormatUtils.ts
+++ b/src/utils/FormatUtils.ts
@@ -31,7 +31,7 @@ export async function download(
   };
 
   const format = chooseFormat(opts, streaming_data);
-  const format_url = format.decipher(player);
+  const format_url = await format.decipher(player);
 
   // If we're not downloading the video in chunks, we just use fetch once.
   if (opts.type === 'video+audio' && !options.range) {


### PR DESCRIPTION
## Description

This PR fixes a bug where `format.decipher(player)` was called without the `await` keyword in the `download` function within `FormatUtils.ts`.

## Problem

The `format.decipher()` method is asynchronous and returns a `Promise<string>`. Without `await`, the code assigns a Promise object to `format_url` instead of the actual URL string. This leads to runtime errors when the URL is used in fetch operations.

### Example Error

```shell
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

TypeError: Failed to parse URL from [object Promise]&cpn=ExSWl01dxPuvy_xN&range=0-10485760
    at node:internal/deps/undici/undici:12345:11
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async file:///Users/hi/yt-test/node_modules/youtubei.js/dist/src/utils/FormatUtils.js:54:38 {
  [cause]: TypeError: Invalid URL
      at new URL (node:internal/url:775:36)
      at new Request (node:internal/deps/undici/undici:5853:25)
      at fetch (node:internal/deps/undici/undici:10123:25)
      at Object.fetch (node:internal/deps/undici/undici:12344:10)
      at HTTPClient.fetch (node:internal/process/pre_execution:336:27)
      at file:///Users/hi/yt-test/node_modules/youtubei.js/dist/src/utils/FormatUtils.js:54:65
      at new Promise (<anonymous>)
      at Object.pull (file:///Users/hi/yt-test/node_modules/youtubei.js/dist/src/utils/FormatUtils.js:51:20)
      at ensureIsPromise (node:internal/webstreams/util:185:19)
      at readableStreamDefaultControllerCallPullIfNeeded (node:internal/webstreams/readablestream:2354:5) {
    code: 'ERR_INVALID_URL',
    input: '[object Promise]&cpn=ExSWl01dxPuvy_xN&range=0-10485760'
  }
}
```

## Solution

Added the `await` keyword to properly handle the Promise returned by `format.decipher(player)`.
