### PR TITLE
fix(history): Add support for `LockupView` content

### DIFF
--- a/src/parser/youtube/History.ts
+++ b/src/parser/youtube/History.ts
@@ -5,8 +5,8 @@ import Button from '../classes/Button.js';
 
 import type { Actions, ApiResponse } from '../../core/index.js';
 import type { IBrowseResponse } from '../types/index.js';
-import type Video from '../classes/Video.js';
-import type LockupView from '../classes/LockupView.js';
+import Video from '../classes/Video.js';
+import LockupView from '../classes/LockupView.js';
 
 // TODO: make feed actions usable
 export default class History extends Feed<IBrowseResponse> {
@@ -40,16 +40,14 @@ export default class History extends Feed<IBrowseResponse> {
 
       for (const section of this.sections) {
         for (const content of section.contents) {
-          if (content.type === 'Video') {
-            const video = content as Video;
-            if (video.video_id === video_id && video.menu) {
-              feedbackToken = video.menu.top_level_buttons[0].as(Button).endpoint.payload.feedbackToken;
+          if (content.is(Video)) {
+            if (content.video_id === video_id && content.menu) {
+              feedbackToken = content.menu.top_level_buttons[0].as(Button).endpoint.payload.feedbackToken;
               break;
             }
-          } else if (content.type === 'LockupView') {
-            const lockupView = content as LockupView;
-            if (lockupView.content_id === video_id) {
-              const listItems = lockupView.metadata?.menu_button?.on_tap?.payload.panelLoadingStrategy.inlineContent.sheetViewModel.content.listViewModel.listItems;
+          } else if (content.is(LockupView)) {
+            if (content.content_id === video_id) {
+              const listItems = content.metadata?.menu_button?.on_tap?.payload.panelLoadingStrategy.inlineContent.sheetViewModel.content.listViewModel.listItems;
               const listItem = listItems.find((video: { listItemViewModel: { title: { content: string; }; }; }) => video.listItemViewModel?.title.content === 'Remove from watch history');
               feedbackToken = listItem.listItemViewModel.rendererContext.commandContext.onTap.innertubeCommand.feedbackEndpoint.feedbackToken;
               break;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This adds support for `LockupView` content in the watch history in addition to `Video` content. It seems that recently YouTube started using `LockupView` content in almost every instance.