### PR TITLE
docs: document Cloudflare Workers entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ const innertube = await Innertube.create(/* options */);
 
 For detailed usage, check out the [YouTube.js Guide and API Documentation](https://ytjs.dev).
 
+## Cloudflare Workers / Edge
+
+Use the Cloudflare Workers-specific entrypoint:
+
+```ts
+import { Innertube } from 'youtubei.js/cf-worker';
+```
+
+See docs/cloudflare-workers.md for details and `examples/cloudflare-worker/` for a runnable example.
+
 ## Contributing
 We welcome all contributions, issues and feature requests, whether small or large. If you want to contribute, feel free to check out our [issues page](https://github.com/LuanRT/YouTube.js/issues) and our [guidelines](https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md).
 

--- a/docs/cloudflare-workers.md
+++ b/docs/cloudflare-workers.md
@@ -1,0 +1,31 @@
+# Cloudflare Workers and Edge Runtimes
+
+- **Entrypoint**: `youtubei.js/cf-worker`
+- **Status**: Public and supported. Exported via `package.json` and bundled in releases.
+- **Where it runs**: Cloudflare Workers and other edge runtimes with Web-standard globals (`fetch`, `Request`, `Response`, `Headers`, `FormData`, `ReadableStream`, `caches`, `crypto.randomUUID`).
+
+## Usage
+
+```ts
+import { Innertube } from 'youtubei.js/cf-worker';
+
+export async function createYouTubeClient() {
+  return await Innertube.create({
+    // Optionally provide a custom fetch (e.g., to add a proxy or headers)
+    // fetch: myCustomFetch
+  });
+}
+```
+
+- The API surface is identical to the default entrypoint; only the platform shim differs.
+- An example Worker project is available at `examples/cloudflare-worker/`.
+
+## Notes and limitations
+
+- **Cookies/credentials**: The Workers entrypoint does not set `credentials: 'include'` on requests. If you need cookies or specific headers, provide a custom `fetch`.
+- **Cache**: Uses the platform `caches` API for the library cache.
+- **Node.js APIs**: Not available in this runtime; only Web APIs are used.
+
+## When to use this
+
+- Prefer this entrypoint in Cloudflare Workers or similar edge environments. For Node.js, import from `youtubei.js` (default) or the `node` export handled via conditional exports.


### PR DESCRIPTION

Fixes #1072 

./cf-worker is exported in package.json and has a dedicated platform shim and example; this makes it discoverable.