### PR TITLE
feat(Format): Add support for Voice Boost & Super Resolution formats

### DIFF
--- a/src/parser/classes/misc/Format.ts
+++ b/src/parser/classes/misc/Format.ts
@@ -63,6 +63,8 @@ export default class Format {
   public loudness_db?: number;
   public signature_cipher?: string;
   public is_drc?: boolean;
+  public is_vb?: boolean;
+  public is_sr?: boolean;
   public drm_track_type?: string;
   public distinct_params?: string;
   public track_absolute_loudness_lkfs?: number;
@@ -212,15 +214,16 @@ export default class Format {
         id: data.captionTrack.id
       };
 
-    if (this.has_audio || this.has_text) {
-      const xtags = this.xtags
-        ? FormatXTags.decode(base64ToU8(decodeURIComponent(this.xtags).replace(/-/g, '+').replace(/_/g, '/'))).xtags
-        : [];
+    const xtags = this.xtags
+      ? FormatXTags.decode(base64ToU8(decodeURIComponent(this.xtags).replace(/-/g, '+').replace(/_/g, '/'))).xtags
+      : [];
 
+    if (this.has_audio || this.has_text) {
       this.language = xtags.find((tag) => tag.key === 'lang')?.value || null;
 
       if (this.has_audio) {
         this.is_drc = !!data.isDrc || xtags.some((tag) => tag.key === 'drc' && tag.value === '1');
+        this.is_vb = !!data.isVb || xtags.some((tag) => tag.key === 'vb' && tag.value === '1');
 
         const audio_content = xtags.find((tag) => tag.key === 'acont')?.value;
         this.is_dubbed = audio_content === 'dubbed';
@@ -234,6 +237,10 @@ export default class Format {
       if (this.has_text && !this.language && this.caption_track) {
         this.language = this.caption_track.language_code;
       }
+    }
+
+    if (this.has_video) {
+      this.is_sr = xtags.some((tag) => tag.key === 'sr' && tag.value === '1');
     }
   }
 


### PR DESCRIPTION
Probably need to add a way to label the voice boosted audio in the manifest too, but let's leave that for later.

Related: https://github.com/LuanRT/googlevideo/issues/42, https://github.com/LuanRT/googlevideo/issues/43