### PR TITLE
Add additional browser target

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "build:proto": "rimraf ./protos/generated && node ./dev-scripts/generate-proto.mjs",
     "build:parser-map": "node ./dev-scripts/gen-parser-map.mjs",
     "bundle:browser": "esbuild ./dist/src/platform/web.js --banner:js=\"/* eslint-disable */\" --bundle --sourcemap --target=chrome70 --keep-names --format=esm --define:global=globalThis --conditions=module --outfile=./bundle/browser.js --platform=browser",
+    "bundle:browser-iife": "esbuild ./dist/src/platform/web.js --bundle --sourcemap --target=es2017 --keep-names --format=iife --global-name=YouTubeJS --outfile=./bundle/browser-iife.js --platform=browser",
     "bundle:react-native": "esbuild ./dist/src/platform/react-native.js --bundle --sourcemap --target=es2020 --keep-names --format=esm --platform=neutral --define:global=globalThis --conditions=module --outfile=./bundle/react-native.js",
     "bundle:cf-worker": "esbuild ./dist/src/platform/cf-worker.js --banner:js=\"/* eslint-disable */\" --bundle --sourcemap --target=es2020 --keep-names --format=esm --define:global=globalThis --conditions=module --outfile=./bundle/cf-worker.js --platform=node",
     "build:docs": "typedoc",


### PR DESCRIPTION
This adds a build that is usable in the browser without any transpilation.

Presently, you would need to run this to use the project in a script tag:
```
npm install youtubei.js
npx webpack ./node_modules/youtubei.js/bundle/browser.js --output-library YouTube --output-library-type umd -o youtubei.umd.js
```

With this change, it can be used from a Userscript:
```
// @require https://cdn.jsdelivr.net/npm/youtubei.js@latest/bundle/browser-iife.js

// ==UserScript==
    const Innertube = YouTubeJS.default
    const yt = await Innertube.create({
        cookie: document.cookie,
        fetch: (...args) => fetch(...args)
    });
// ==
```