### PR TITLE
feat(core): Add getCaptionTrackContent (MediaInfo)

### DIFF
--- a/src/parser/classes/PlayerCaptionsTracklist.ts
+++ b/src/parser/classes/PlayerCaptionsTracklist.ts
@@ -11,6 +11,17 @@ export interface CaptionTrackData {
   is_translatable: boolean;
 }
 
+export interface CaptionTrackContentLine {
+  start: number;
+  duration: number;
+  end: number;
+  text: string;
+}
+
+export interface CaptionTrackContent {
+  lines: CaptionTrackContentLine[];
+}
+
 export default class PlayerCaptionsTracklist extends YTNode {
   static type = 'PlayerCaptionsTracklist';
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Somewhat fixes #1102

Adds an alternate API for getting captions by using the caption track's base URL. Motivation for this is fixing Invidious Companion, and because yt-dlp also uses the caption API for getting the transcript.

This is an alternate API because it seems like captions return different things from the searcheable transcript? I'm not too sure, though.

Tests are not in yet. WIP.

Example code:
```
import { Innertube } from "./platform/node.js";

(async () => {
  const innertube = await Innertube.create({
    generate_session_locally: true,
    lang: "en",
    location: "US",
  });
  const info = await innertube.getInfo("k7fXbdRH9v4");
  const captions = info.captions;
  if (!captions) {
    console.log("Captions is undefined");
    return;
  }
  const captionTracks = captions.caption_tracks;
  if (!captionTracks) {
    console.log("Caption tracks is undefined");
    return;
  }
  const captionTrack = captionTracks[0];
  const response = await info.getCaptionTrackContent(captionTrack);
  console.log(response);
})();
```
