### PR TITLE
feat(Parser): Add ThumbnailOverlayTitleView and PageIndicatorView classes

### DIFF
--- a/src/parser/classes/PageIndicatorView.ts
+++ b/src/parser/classes/PageIndicatorView.ts
@@ -1,0 +1,15 @@
+import { YTNode } from '../helpers.js';
+import type { RawNode } from '../index.js';
+
+export default class PageIndicatorView extends YTNode {
+  static type = 'PageIndicatorView';
+
+  public indicator_count: number;
+  public selected_index: number;
+
+  constructor(data: RawNode) {
+    super();
+    this.indicator_count = data.indicatorCount ?? 0;
+    this.selected_index = data.selectedIndex ?? 0;
+  }
+}

--- a/src/parser/classes/ThumbnailOverlayTitleView.ts
+++ b/src/parser/classes/ThumbnailOverlayTitleView.ts
@@ -1,0 +1,15 @@
+import { YTNode } from '../helpers.js';
+import type { RawNode } from '../index.js';
+
+export default class ThumbnailOverlayTitleView extends YTNode {
+  static type = 'ThumbnailOverlayTitleView';
+
+  public title: string;
+  public subtitle: string;
+
+  constructor(data: RawNode) {
+    super();
+    this.title = data.title?.content ?? '';
+    this.subtitle = data.subtitle?.content ?? '';
+  }
+}

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -360,6 +360,7 @@ export { default as NotificationAction } from './classes/NotificationAction.js';
 export { default as OpenOnePickAddVideoModalCommand } from './classes/OpenOnePickAddVideoModalCommand.js';
 export { default as PageHeader } from './classes/PageHeader.js';
 export { default as PageHeaderView } from './classes/PageHeaderView.js';
+export { default as PageIndicatorView } from './classes/PageIndicatorView.js';
 export { default as PageIntroduction } from './classes/PageIntroduction.js';
 export { default as PanelFooterView } from './classes/PanelFooterView.js';
 export { default as PivotButton } from './classes/PivotButton.js';
@@ -488,6 +489,7 @@ export { default as ThumbnailOverlayProgressBarView } from './classes/ThumbnailO
 export { default as ThumbnailOverlayResumePlayback } from './classes/ThumbnailOverlayResumePlayback.js';
 export { default as ThumbnailOverlaySidePanel } from './classes/ThumbnailOverlaySidePanel.js';
 export { default as ThumbnailOverlayTimeStatus } from './classes/ThumbnailOverlayTimeStatus.js';
+export { default as ThumbnailOverlayTitleView } from './classes/ThumbnailOverlayTitleView.js';
 export { default as ThumbnailOverlayToggleButton } from './classes/ThumbnailOverlayToggleButton.js';
 export { default as ThumbnailView } from './classes/ThumbnailView.js';
 export { default as TimedMarkerDecoration } from './classes/TimedMarkerDecoration.js';


### PR DESCRIPTION
## Summary

Add two missing parser classes that were being JIT-generated at runtime:

- **ThumbnailOverlayTitleView**: Displays title/subtitle overlays on thumbnails (e.g., "LIVE", "MIX" labels)
- **PageIndicatorView**: Tracks pagination state in carousels (indicator count and selected index)

These are encountered when parsing Mix/Playlist responses and were causing console warnings:

```
[YOUTUBEJS][Parser]: Error: ThumbnailOverlayTitleView not found!
[YOUTUBEJS][Parser]: Error: PageIndicatorView not found!
```

## Test plan

- [x] Build completes successfully with `npm run build`
- [x] Parser map auto-generates exports in `nodes.ts`