### PR TITLE
 fix(Innertube): getChannel() if subscribed

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -387,7 +387,7 @@ export default class Innertube {
     const browse_endpoint = new NavigationEndpoint({ browseEndpoint: { browseId: id } });
     let response = await browse_endpoint.call<IBrowseResponse>(this.#session.actions, { parse: true });
 
-    if (response.on_response_received_actions?.[0].is(NavigateAction)) {
+    if (response.on_response_received_actions?.[0]?.is(NavigateAction)) {
       response = await response.on_response_received_actions[0].endpoint.call<IBrowseResponse>(this.#session.actions, { parse: true });
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This fixes an issue where fetching the authenticated user's subscribed channels could fail due to undefined array elements in on_response_received_actions. This adds optional chaining to safely handle those cases.

Fixes #1023.