### PR TITLE
fix(FlexibleActionsView): Update `ActionRow` actions type

### DIFF
--- a/src/parser/classes/FlexibleActionsView.ts
+++ b/src/parser/classes/FlexibleActionsView.ts
@@ -2,9 +2,10 @@ import { type ObservedArray, YTNode } from '../helpers.js';
 import { Parser, type RawNode } from '../index.js';
 import ButtonView from './ButtonView.js';
 import ToggleButtonView from './ToggleButtonView.js';
+import SubscribeButtonView from './SubscribeButtonView.js';
 
 export type ActionRow = {
-  actions: ObservedArray<ButtonView | ToggleButtonView>;
+  actions: ObservedArray<ButtonView | ToggleButtonView | SubscribeButtonView>;
 };
 
 export default class FlexibleActionsView extends YTNode {
@@ -16,7 +17,7 @@ export default class FlexibleActionsView extends YTNode {
   constructor(data: RawNode) {
     super();
     this.actions_rows = data.actionsRows.map((row: RawNode) => ({
-      actions: Parser.parseArray(row.actions, [ ButtonView, ToggleButtonView ])
+      actions: Parser.parseArray(row.actions, [ ButtonView, ToggleButtonView, SubscribeButtonView ])
     }));
     this.style = data.style;
   }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This fixes the following error when calling `getChannel()` as an authenticated user:
```
[YOUTUBEJS][Parser]: ParsingError: Type mismatch, got SubscribeButtonView expected ButtonView | ToggleButtonView
```