### PR TITLE
chore(constants): update android client version

### DIFF
--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -54,9 +54,9 @@ export const CLIENTS = {
   },
   ANDROID: {
     NAME: 'ANDROID',
-    VERSION: '19.35.36',
-    SDK_VERSION: 33,
-    USER_AGENT: 'com.google.android.youtube/19.35.36(Linux; U; Android 13; en_US; SM-S908E Build/TP1A.220624.014) gzip'
+    VERSION: '21.03.36',
+    SDK_VERSION: 36,
+    USER_AGENT: 'com.google.android.youtube/21.03.36(Linux; U; Android 16; en_US; SM-S908E Build/TP1A.220624.014) gzip'
   },
   YTSTUDIO_ANDROID: {
     NAME: 'ANDROID_CREATOR',


### PR DESCRIPTION
endpoint reel/reel_item_watch endpoint (getShortsVideoInfo) now gives status 400 with FAILED_PRECONDITION in US using the seemingly deprecated android client version 19.35.36. The new client version is courtesy of [newpipe](https://github.com/TeamNewPipe/NewPipeExtractor/blob/ffb4654e1c35a06e1e17311b26458499ce1c8259/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ClientsConstants.java#L111).

Test: getShortsVideoInfo('WCkcPcMTYuQ', 'ANDROID') should now return 200 instead of 400