### PR TITLE
fix(ThumbnailBadgeView): Parse icon

### DIFF
--- a/src/parser/classes/ThumbnailBadgeView.ts
+++ b/src/parser/classes/ThumbnailBadgeView.ts
@@ -25,7 +25,7 @@ export default class ThumbnailBadgeView extends YTNode {
       };
     }
 
-    if (data.iconName) {
+    if (data.icon) {
       this.icon_name = data.icon.sources[0].clientResource.imageName;
     }
   }


### PR DESCRIPTION
This PR fixes the setting of the `ThumbnailBadgeView.icon_name` field. The old check for `data.iconName` no longer succeeds, even on badges that have icons, presumably because the field was removed at some point, so I changed it to check for `data.icon` instead.

I encountered this on the home feed (`getHomeFeed()`) for music and livestreams, so that's one avenue for testing it.