### PR TITLE
docs: document youtubei.js/cf-worker entrypoint for Cloudflare Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
       <img src="https://luanrt.github.io/assets/img/ytjs.svg" alt="YouTube.js Logo" width="200" />
     </a>
   </p>
-  <p>A JavaScript client for YouTube's internal API.<br/>Works on Node.js, Deno, modern browsers, and more.</p>
+  <p>A JavaScript client for YouTube's internal API.<br/>Works on Node.js, Deno, modern browsers, Cloudflare Workers, and more.</p>
 
 [![Discord](https://img.shields.io/badge/discord-online-brightgreen.svg)][discord]
 [![CI](https://github.com/LuanRT/YouTube.js/actions/workflows/test.yml/badge.svg)][actions]
@@ -51,6 +51,17 @@ import { Innertube } from 'https://deno.land/x/youtubei/deno.ts';
 import { Innertube } from 'youtubei.js';
 const innertube = await Innertube.create(/* options */);
 ```
+
+### Cloudflare Workers
+
+YouTube.js provides a dedicated `cf-worker` entrypoint optimized for Cloudflare Workers and edge environments:
+
+```ts
+import { Innertube } from 'youtubei.js/cf-worker';
+const innertube = await Innertube.create(/* options */);
+```
+
+This entrypoint uses a worker-compatible HTTP client and avoids APIs unavailable in the Workers runtime. An example is available in [`examples/cloudflare-worker/`](examples/cloudflare-worker/).
 
 For detailed usage, read the [YouTube.js Guide and API Documentation](https://ytjs.dev).
 


### PR DESCRIPTION
## Summary
Fixes #1072 — the `youtubei.js/cf-worker` entrypoint worked but had no documentation, making users unsure if it was a stable public API.

## Changes
- Added "Cloudflare Workers" to the supported environments list in the header
- Added a "Cloudflare Workers" subsection under Basic Usage with import example and link to the example directory

## Why
Users discovered the `youtubei.js/cf-worker` entrypoint by examining the package exports but couldn't find any official documentation about it. This clarifies that it's a supported public API and shows how to use it.

## Type of Change
- [x] Documentation