### PR TITLE
fix(HTTPClient): Add User-Agent header override for ANDROID_VR client

### DIFF
--- a/src/utils/HTTPClient.ts
+++ b/src/utils/HTTPClient.ts
@@ -98,6 +98,8 @@ export default class HTTPClient {
         request_headers.set('X-GOOG-API-FORMAT-VERSION', '2');
       } else if (adjustedClientName === Constants.CLIENTS.IOS.NAME) {
         request_headers.set('User-Agent', Constants.CLIENTS.IOS.USER_AGENT);
+      } else if (adjustedClientName === Constants.CLIENTS.ANDROID_VR.NAME) {
+        request_headers.set('User-Agent', Constants.CLIENTS.ANDROID_VR.USER_AGENT);
       }
     } else if (content_type === 'application/x-protobuf') {
       // Assume it is always an Android request.


### PR DESCRIPTION
## Description

The ANDROID_VR client was missing its User-Agent HTTP header override in `HTTPClient.fetch()`. While `#adjustContext()` correctly sets the Oculus User-Agent in the request body context, the HTTP header remained as the default Chrome desktop User-Agent, causing an inconsistency between body and headers.

This adds the missing header override to match the existing pattern used by ANDROID and IOS clients.

## Changes

- Added `ANDROID_VR` case to the User-Agent header override block in `src/utils/HTTPClient.ts`

## Testing

- `npm run test`: 30 passed (8 pre-existing YouTube Music failures unrelated to this change)
- `npm run lint:fix`: passed
- `npm run build`: passed