### PR TITLE
feat: add missing survey-related YTNode parsers (fixes #1173)

### DIFF
--- a/src/parser/classes/ExpandableSurveyResponse.ts
+++ b/src/parser/classes/ExpandableSurveyResponse.ts
@@ -1,0 +1,19 @@
+import { Parser, type RawNode } from '../index.js';
+import { YTNode } from '../helpers.js';
+import Button from './Button.js';
+import RatingSurvey from './RatingSurvey.js';
+
+export default class ExpandableSurveyResponse extends YTNode {
+  static type = 'ExpandableSurveyResponse';
+
+  public options: RatingSurvey | null;
+  public submit_button: Button | null;
+
+  constructor(data: RawNode) {
+    super();
+    this.options = Parser.parseItem(data.options, RatingSurvey);
+    this.submit_button = Parser.parseItem(data.submitButton, Button);
+  }
+}
+
+ExpandableSurveyResponse.prototype.type = 'ExpandableSurveyResponse';

--- a/src/parser/classes/InlineSurvey.ts
+++ b/src/parser/classes/InlineSurvey.ts
@@ -1,0 +1,49 @@
+import Text from './misc/Text.js';
+import NavigationEndpoint from './NavigationEndpoint.js';
+import { Parser, type RawNode } from '../index.js';
+import { YTNode } from '../helpers.js';
+import CompactVideo from './CompactVideo.js';
+import ExpandableSurveyResponse from './ExpandableSurveyResponse.js';
+
+export default class InlineSurvey extends YTNode {
+  static type = 'InlineSurvey';
+
+  public endpoint: NavigationEndpoint;
+  public title: Text;
+  public subtitle: Text;
+  public inline_content: CompactVideo | null;
+  public response: ExpandableSurveyResponse | null;
+  public dismissal_text: Text;
+  public impression_endpoints: {
+    click_tracking_params: string;
+    command_metadata: {
+      web_command_metadata: {
+        send_post: boolean;
+        api_url: string;
+      };
+    };
+    feedback_endpoint: NavigationEndpoint;
+  }[];
+
+  constructor(data: RawNode) {
+    super();
+    this.endpoint = new NavigationEndpoint(data.dismissalEndpoint);
+    this.title = new Text(data.title);
+    this.subtitle = new Text(data.subtitle);
+    this.inline_content = Parser.parseItem(data.inlineContent, CompactVideo);
+    this.response = Parser.parseItem(data.response, ExpandableSurveyResponse);
+    this.dismissal_text = new Text(data.dismissalText);
+    this.impression_endpoints = data.impressionEndpoints.map((item: any) => ({
+      click_tracking_params: item.clickTrackingParams,
+      command_metadata: {
+        web_command_metadata: {
+          send_post: item.commandMetadata.webCommandMetadata.sendPost,
+          api_url: item.commandMetadata.webCommandMetadata.apiUrl
+        }
+      },
+      feedback_endpoint: new NavigationEndpoint(item.feedbackEndpoint)
+    }));
+  }
+}
+
+InlineSurvey.prototype.type = 'InlineSurvey';

--- a/src/parser/classes/RatingSurvey.ts
+++ b/src/parser/classes/RatingSurvey.ts
@@ -1,0 +1,19 @@
+import { Parser, type RawNode } from '../index.js';
+import { type ObservedArray, YTNode } from '../helpers.js';
+import Button from './Button.js';
+import RatingSurveyOption from './RatingSurveyOption.js';
+
+export default class RatingSurvey extends YTNode {
+  static type = 'RatingSurvey';
+
+  public ratings: ObservedArray<RatingSurveyOption>;
+  public undo_button: Button | null;
+
+  constructor(data: RawNode) {
+    super();
+    this.ratings = Parser.parse(data.ratings, true, RatingSurveyOption);
+    this.undo_button = Parser.parseItem(data.undoButton, Button);
+  }
+}
+
+RatingSurvey.prototype.type = 'RatingSurvey';

--- a/src/parser/classes/RatingSurveyOption.ts
+++ b/src/parser/classes/RatingSurveyOption.ts
@@ -1,0 +1,31 @@
+import Text from './misc/Text.js';
+import NavigationEndpoint from './NavigationEndpoint.js';
+import { YTNode } from '../helpers.js';
+import type { RawNode } from '../index.js';
+
+export default class RatingSurveyOption extends YTNode {
+  static type = 'RatingSurveyOption';
+
+  public response_text: Text;
+  public default_state_icon: {
+    icon_type: string;
+  };
+  public on_state_icon: {
+    icon_type: string;
+  };
+  public endpoint: NavigationEndpoint;
+
+  constructor(data: RawNode) {
+    super();
+    this.response_text = new Text(data.responseText);
+    this.default_state_icon = {
+      icon_type: data.defaultStateIcon.iconType
+    };
+    this.on_state_icon = {
+      icon_type: data.onStateIcon.iconType
+    };
+    this.endpoint = new NavigationEndpoint(data.followUpCommand || data.responseEndpoint);
+  }
+}
+
+RatingSurveyOption.prototype.type = 'RatingSurveyOption';

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -174,6 +174,7 @@ export { default as EngagementPanelSectionList } from './classes/EngagementPanel
 export { default as EngagementPanelTitleHeader } from './classes/EngagementPanelTitleHeader.js';
 export { default as EomSettingsDisclaimer } from './classes/EomSettingsDisclaimer.js';
 export { default as ExpandableMetadata } from './classes/ExpandableMetadata.js';
+export { default as ExpandableSurveyResponse } from './classes/ExpandableSurveyResponse.js';
 export { default as ExpandableTab } from './classes/ExpandableTab.js';
 export { default as ExpandableVideoDescriptionBody } from './classes/ExpandableVideoDescriptionBody.js';
 export { default as ExpandedShelfContents } from './classes/ExpandedShelfContents.js';
@@ -222,6 +223,7 @@ export { default as IncludingResultsFor } from './classes/IncludingResultsFor.js
 export { default as InfoPanelContainer } from './classes/InfoPanelContainer.js';
 export { default as InfoPanelContent } from './classes/InfoPanelContent.js';
 export { default as InfoRow } from './classes/InfoRow.js';
+export { default as InlineSurvey } from './classes/InlineSurvey.js';
 export { default as InteractiveTabbedHeader } from './classes/InteractiveTabbedHeader.js';
 export { default as ItemSection } from './classes/ItemSection.js';
 export { default as ItemSectionHeader } from './classes/ItemSectionHeader.js';
@@ -409,6 +411,8 @@ export { default as ProfileColumnStats } from './classes/ProfileColumnStats.js';
 export { default as ProfileColumnStatsEntry } from './classes/ProfileColumnStatsEntry.js';
 export { default as ProfileColumnUserInfo } from './classes/ProfileColumnUserInfo.js';
 export { default as Quiz } from './classes/Quiz.js';
+export { default as RatingSurvey } from './classes/RatingSurvey.js';
+export { default as RatingSurveyOption } from './classes/RatingSurveyOption.js';
 export { default as RecognitionShelf } from './classes/RecognitionShelf.js';
 export { default as ReelItem } from './classes/ReelItem.js';
 export { default as ReelPlayerHeader } from './classes/ReelPlayerHeader.js';


### PR DESCRIPTION
## Description

Fixes #1173

Add parsers for 4 missing survey-related node types that were causing parser warnings:

- **InlineSurvey** - Inline survey displayed in the feed
- **ExpandableSurveyResponse** - Expandable survey response container
- **RatingSurvey** - Rating-based survey with multiple options
- **RatingSurveyOption** - Individual rating option in a survey

## Changes

- Add 4 new parser classes in 
- Update parser map via 
> youtubei.js@17.0.1 build:parser-map
> node ./dev-scripts/gen-parser-map.mjs

## Testing

The parser warnings mentioned in #1173 should no longer appear when calling .

Fixes #1173