### PR TITLE
fix(ItemSection): ChipBarView parser warning

### DIFF
--- a/src/parser/classes/ItemSection.ts
+++ b/src/parser/classes/ItemSection.ts
@@ -5,18 +5,19 @@ import ItemSectionTabbedHeader from './ItemSectionTabbedHeader.js';
 import CommentsHeader from './comments/CommentsHeader.js';
 import SortFilterHeader from './SortFilterHeader.js';
 import FeedFilterChipBar from './FeedFilterChipBar.js';
+import ChipBarView from './ChipBarView.js';
 
 export default class ItemSection extends YTNode {
   static type = 'ItemSection';
 
-  header: CommentsHeader | ItemSectionHeader | ItemSectionTabbedHeader | SortFilterHeader | FeedFilterChipBar | null;
+  header: CommentsHeader | ItemSectionHeader | ItemSectionTabbedHeader | SortFilterHeader | FeedFilterChipBar | ChipBarView | null;
   contents: ObservedArray<YTNode>;
   target_id?: string;
   continuation?: string;
 
   constructor(data: RawNode) {
     super();
-    this.header = Parser.parseItem(data.header, [ CommentsHeader, ItemSectionHeader, ItemSectionTabbedHeader, SortFilterHeader, FeedFilterChipBar ]);
+    this.header = Parser.parseItem(data.header, [ CommentsHeader, ItemSectionHeader, ItemSectionTabbedHeader, SortFilterHeader, FeedFilterChipBar, ChipBarView ]);
     this.contents = Parser.parseArray(data.contents);
 
     if (data.targetId || data.sectionIdentifier) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This fixes:
```
[YOUTUBEJS][Parser]: gD: Type mismatch, got ChipBarView expected CommentsHeader | ItemSectionHeader | ItemSectionTabbedHeader | SortFilterHeader |
  FeedFilterChipBar.
      at ERROR_HANDLER
      at Object.parseItem
      at new ItemSection
      at parseItem
      at Object.parseArray
      at new SectionList
      at Object.parseItem
      at new Tab
      at parseItem
      at Object.parseArray
      at new TwoColumnBrowseResults
      at parseItem
      at parse
      at Object.parseResponse
      at new Feed
      at new Playlist
      at Innertube.getPlaylist
      at async
      at async Promise.all
      at async init
```