### PR TITLE
feat(parser): Add `ThumbnailOverlayAvatarStackView` class

### DIFF
--- a/src/parser/classes/ThumbnailOverlayAvatarStackView.ts
+++ b/src/parser/classes/ThumbnailOverlayAvatarStackView.ts
@@ -1,0 +1,15 @@
+import type { RawNode } from '../index.js';
+import { Parser } from '../index.js';
+import { YTNode } from '../helpers.js';
+import AvatarStackView from './AvatarStackView.js';
+
+export default class ThumbnailOverlayAvatarStackView extends YTNode {
+  static type = 'ThumbnailOverlayAvatarStackView';
+
+  avatar_stack: AvatarStackView | null;
+
+  constructor(data: RawNode) {
+    super();
+    this.avatar_stack = Parser.parseItem(data.avatarStack, AvatarStackView);
+  }
+}

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -482,6 +482,7 @@ export { default as ThumbnailBottomOverlayView } from './classes/ThumbnailBottom
 export { default as ThumbnailHoverOverlayToggleActionsView } from './classes/ThumbnailHoverOverlayToggleActionsView.js';
 export { default as ThumbnailHoverOverlayView } from './classes/ThumbnailHoverOverlayView.js';
 export { default as ThumbnailLandscapePortrait } from './classes/ThumbnailLandscapePortrait.js';
+export { default as ThumbnailOverlayAvatarStackView } from './classes/ThumbnailOverlayAvatarStackView.js';
 export { default as ThumbnailOverlayBadgeView } from './classes/ThumbnailOverlayBadgeView.js';
 export { default as ThumbnailOverlayBottomPanel } from './classes/ThumbnailOverlayBottomPanel.js';
 export { default as ThumbnailOverlayEndorsement } from './classes/ThumbnailOverlayEndorsement.js';


### PR DESCRIPTION
Fixes 1195 [issue](https://github.com/LuanRT/YouTube.js/issues/1195).
Adds 'ThumbnailOverlayAvatarStackView' parser class.

I made tweaks pointed by LuanRT, but running tests gave some error not connected to my snippet. 
Not sure that everything is all right.
Ready to hear and make changes if there are any issues with this code.

