### PR TITLE
fix(Innertube#getHashtag): Use URL-safe Base64 for hashtag params

### DIFF
--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -437,7 +437,7 @@ export default class Innertube {
       }
     });
 
-    const params = encodeURIComponent(u8ToBase64(writer.finish()).replace(/\+/g, '-').replace(/\//g, '_'));
+    const params = encodeURIComponent(u8ToBase64(writer.finish(), true));
 
     const browse_endpoint = new NavigationEndpoint({ browseEndpoint: { browseId: 'FEhashtag', params } });
     const response = await browse_endpoint.call(this.#session.actions);

--- a/src/Innertube.ts
+++ b/src/Innertube.ts
@@ -437,7 +437,7 @@ export default class Innertube {
       }
     });
 
-    const params = encodeURIComponent(u8ToBase64(writer.finish()));
+    const params = encodeURIComponent(u8ToBase64(writer.finish()).replace(/\+/g, '-').replace(/\//g, '_'));
 
     const browse_endpoint = new NavigationEndpoint({ browseEndpoint: { browseId: 'FEhashtag', params } });
     const response = await browse_endpoint.call(this.#session.actions);

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -243,8 +243,16 @@ export const debugFetch: FetchFunction = (input, init) => {
   return Platform.shim.fetch(input, init);
 };
 
-export function u8ToBase64(u8: Uint8Array): string {
-  return btoa(String.fromCharCode.apply(null, Array.from(u8)));
+export function u8ToBase64(u8: Uint8Array, base64url = false): string {
+  const result = btoa(String.fromCharCode(...u8));
+
+  if (base64url) {
+    return result
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+  }
+
+  return result;
 }
 
 export function base64ToU8(base64: string): Uint8Array {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -273,6 +273,12 @@ describe('YouTube.js Tests', () => {
         expect(incremental_continuation).toBeDefined();
         expect(incremental_continuation.videos.length).toBeGreaterThan(0);
       });
+
+      test('supports hashtags whose params require URL-safe Base64', async () => {
+        const cyrillic_hashtag = await innertube.getHashtag('биткоин');
+        expect(cyrillic_hashtag).toBeDefined();
+        expect(cyrillic_hashtag.videos.length).toBeGreaterThan(0);
+      });
     });
 
     test('Innertube#resolveURL', async () => {


### PR DESCRIPTION
## Summary

- encode hashtag protobuf parameters with the URL-safe Base64 alphabet
- add a regression test for the Cyrillic hashtag `биткоин`

The protobuf payload for some non-ASCII hashtags contains `+` or `/`. Percent-encoding standard Base64 produces values that the hashtag browse endpoint rejects with HTTP 400. Converting those characters to `-` and `_` matches the Base64URL format already used by other protobuf-backed endpoints in this client.

Fixes #892

## Testing

- `npx vitest run tests/main.test.ts -t "Innertube#getHashtag" --reporter verbose`
- `npm run build:esm`
- `npm run lint`

The targeted tests pass. The full live-API suite was also run; the new regression test passes, while unrelated existing `getCourses` and YouTube Music live tests currently fail against upstream responses.
