### PR TITLE
feat: add podcast and episode music search filters

### DIFF
--- a/protos/generated/misc/params.ts
+++ b/protos/generated/misc/params.ts
@@ -17,6 +17,8 @@ export interface VisitorData {
 export interface SearchFilter {
   prioritize?: SearchFilter_Prioritize | undefined;
   filters?: SearchFilter_Filters | undefined;
+  /** Opaque search options supplied by YouTube Music filter endpoints. */
+  options?: Uint8Array | undefined;
 }
 
 export enum SearchFilter_Prioritize {
@@ -76,6 +78,8 @@ export interface SearchFilter_Filters_MusicSearchType {
   album?: boolean | undefined;
   artist?: boolean | undefined;
   playlist?: boolean | undefined;
+  episode?: boolean | undefined;
+  podcast?: boolean | undefined;
 }
 
 export interface ChannelAnalytics {
@@ -322,7 +326,7 @@ export const VisitorData: MessageFns<VisitorData> = {
 };
 
 function createBaseSearchFilter(): SearchFilter {
-  return { prioritize: undefined, filters: undefined };
+  return { prioritize: undefined, filters: undefined, options: undefined };
 }
 
 export const SearchFilter: MessageFns<SearchFilter> = {
@@ -332,6 +336,9 @@ export const SearchFilter: MessageFns<SearchFilter> = {
     }
     if (message.filters !== undefined) {
       SearchFilter_Filters.encode(message.filters, writer.uint32(18).fork()).join();
+    }
+    if (message.options !== undefined) {
+      writer.uint32(106).bytes(message.options);
     }
     return writer;
   },
@@ -357,6 +364,14 @@ export const SearchFilter: MessageFns<SearchFilter> = {
           }
 
           message.filters = SearchFilter_Filters.decode(reader, reader.uint32());
+          continue;
+        }
+        case 13: {
+          if (tag !== 106) {
+            break;
+          }
+
+          message.options = reader.bytes();
           continue;
         }
       }
@@ -577,7 +592,15 @@ export const SearchFilter_Filters: MessageFns<SearchFilter_Filters> = {
 };
 
 function createBaseSearchFilter_Filters_MusicSearchType(): SearchFilter_Filters_MusicSearchType {
-  return { song: undefined, video: undefined, album: undefined, artist: undefined, playlist: undefined };
+  return {
+    song: undefined,
+    video: undefined,
+    album: undefined,
+    artist: undefined,
+    playlist: undefined,
+    episode: undefined,
+    podcast: undefined,
+  };
 }
 
 export const SearchFilter_Filters_MusicSearchType: MessageFns<SearchFilter_Filters_MusicSearchType> = {
@@ -596,6 +619,12 @@ export const SearchFilter_Filters_MusicSearchType: MessageFns<SearchFilter_Filte
     }
     if (message.playlist !== undefined) {
       writer.uint32(40).bool(message.playlist);
+    }
+    if (message.episode !== undefined) {
+      writer.uint32(72).bool(message.episode);
+    }
+    if (message.podcast !== undefined) {
+      writer.uint32(80).bool(message.podcast);
     }
     return writer;
   },
@@ -645,6 +674,22 @@ export const SearchFilter_Filters_MusicSearchType: MessageFns<SearchFilter_Filte
           }
 
           message.playlist = reader.bool();
+          continue;
+        }
+        case 9: {
+          if (tag !== 72) {
+            break;
+          }
+
+          message.episode = reader.bool();
+          continue;
+        }
+        case 10: {
+          if (tag !== 80) {
+            break;
+          }
+
+          message.podcast = reader.bool();
           continue;
         }
       }

--- a/protos/misc/params.proto
+++ b/protos/misc/params.proto
@@ -62,10 +62,14 @@ message SearchFilter {
       optional bool album = 3;
       optional bool artist = 4;
       optional bool playlist = 5;
+      optional bool episode = 9;
+      optional bool podcast = 10;
     }
   }
   
   optional Filters filters = 2;
+  // Opaque search options supplied by YouTube Music filter endpoints.
+  optional bytes options = 13;
 }
 
 message ChannelAnalytics {

--- a/src/core/clients/Music.ts
+++ b/src/core/clients/Music.ts
@@ -1,4 +1,4 @@
-import { generateRandomString, InnertubeError, throwIfMissing, u8ToBase64 } from '../../utils/Utils.js';
+import { base64ToU8, generateRandomString, InnertubeError, throwIfMissing, u8ToBase64 } from '../../utils/Utils.js';
 
 import {
   Album,
@@ -29,6 +29,9 @@ import { SearchFilter } from '../../../protos/generated/misc/params.js';
 import type { ObservedArray } from '../../parser/helpers.js';
 import type { GetVideoInfoOptions, MusicSearchFilters } from '../../types/index.js';
 import type { Actions, Session } from '../index.js';
+
+// Podcast and episode searches require YouTube Music's default filter options payload.
+const DEFAULT_MUSIC_SEARCH_OPTIONS = base64ToU8('EA4QChADEAQQCRAF');
 
 export default class Music {
   #session: Session;
@@ -136,14 +139,17 @@ export default class Music {
     throwIfMissing({ query });
 
     let params: string | undefined;
+    const filter_type = filters.type;
+    const requires_options = filter_type === 'episode' || filter_type === 'podcast';
 
-    if (filters.type && filters.type !== 'all') {
+    if (filter_type && filter_type !== 'all') {
       const writer = SearchFilter.encode({
         filters: {
           musicSearchType: {
-            [filters.type]: true
+            [filter_type]: true
           }
-        }
+        },
+        options: requires_options ? DEFAULT_MUSIC_SEARCH_OPTIONS : undefined
       });
       params = encodeURIComponent(u8ToBase64(writer.finish()));
     }

--- a/src/types/Misc.ts
+++ b/src/types/Misc.ts
@@ -37,7 +37,7 @@ export type UploadedVideoMetadataOptions = Partial<{
   is_draft: boolean;
 }>;
 
-export type MusicSearchType = 'all' | 'song' | 'video' | 'album' | 'playlist' | 'artist';
+export type MusicSearchType = 'all' | 'song' | 'video' | 'album' | 'playlist' | 'artist' | 'episode' | 'podcast';
 
 export type MusicSearchFilters = {
   type?: MusicSearchType;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, beforeAll, test } from 'vitest';
+import { describe, expect, beforeAll, test, vi } from 'vitest';
 
 import { Innertube, YT, YTMusic, YTNodes } from '../dist/src/platform/node.js';
 
@@ -368,6 +368,23 @@ describe('YouTube.js Tests', () => {
         expect(incremental_continuation.contents).toBeDefined();
         expect(incremental_continuation.contents?.contents).toBeDefined();
         expect(incremental_continuation.contents?.contents?.length).toBeGreaterThan(0);
+      });
+
+      test.each([
+        [ 'episode', 'EgWKAQJIAWoMEA4QChADEAQQCRAF' ],
+        [ 'podcast', 'EgWKAQJQAWoMEA4QChADEAQQCRAF' ]
+      ] as const)('encodes the %s filter params', async (type, expected_params) => {
+        const endpoint_call = vi.spyOn(YTNodes.NavigationEndpoint.prototype, 'call')
+          .mockRejectedValue(new Error('Request intercepted.'));
+
+        try {
+          await expect(innertube.music.search('technology podcast', { type }))
+            .rejects.toThrow('Request intercepted.');
+          expect(endpoint_call).toHaveBeenCalledOnce();
+          expect(decodeURIComponent(endpoint_call.mock.instances[0].payload.params)).toBe(expected_params);
+        } finally {
+          endpoint_call.mockRestore();
+        }
       });
     });
 


### PR DESCRIPTION
## Summary

- add `episode` and `podcast` to `MusicSearchType`
- model their protobuf filter fields and the opaque search-options payload
- include the YouTube Music options required by these two filtered searches
- add deterministic regression coverage for the generated endpoint parameters

Type-only parameters are insufficient for episode searches. The resulting payload now includes the same default search-options suffix used by YouTube Music's filtered endpoints, while existing filter types keep their current encoding.

Fixes #1159

## Testing

- `npx vitest run tests/main.test.ts -t "encodes the" --reporter verbose`
- `npm run build`
- `npm run lint`

The targeted tests and full build pass. The full live-API suite completed with 39/40 tests passing; the unrelated existing `Innertube#getCourses` live test failed against the current upstream response. Manual API checks confirmed both payloads can return 20-result `Episodes` and `Podcasts` shelves.
