### PR TITLE
feat(LockupView): Add station as possible `content_type`

### DIFF
--- a/src/core/mixins/Feed.ts
+++ b/src/core/mixins/Feed.ts
@@ -87,7 +87,7 @@ export default class Feed<T extends IParsedResponse = IParsedResponse> {
       PlaylistVideo,
       PlaylistPanelVideo,
       WatchCardCompactVideo
-    ).filter((item) => !item.is(LockupView) || (item.content_type === 'VIDEO' || item.content_type === 'MOVIE' || item.content_type === 'SHORT')));
+    ).filter((item) => !item.is(LockupView) || (item.content_type === 'VIDEO' || item.content_type === 'MOVIE' || item.content_type === 'SHORT' || item.content_type == 'STATION')));
   }
 
   /**

--- a/src/parser/classes/LockupView.ts
+++ b/src/parser/classes/LockupView.ts
@@ -11,7 +11,7 @@ export default class LockupView extends YTNode {
   public content_image: CollectionThumbnailView | ThumbnailView | null;
   public metadata: LockupMetadataView | null;
   public content_id: string;
-  public content_type: 'UNSPECIFIED' | 'VIDEO' | 'PLAYLIST' | 'SHORT' | 'CHANNEL' | 'ALBUM' | 'PRODUCT' | 'GAME' | 'CLIP' | 'PODCAST' | 'SOURCE' | 'SHOPPING_COLLECTION' | 'MOVIE';
+  public content_type: 'UNSPECIFIED' | 'VIDEO' | 'PLAYLIST' | 'SHORT' | 'CHANNEL' | 'ALBUM' | 'PRODUCT' | 'GAME' | 'CLIP' | 'PODCAST' | 'SOURCE' | 'SHOPPING_COLLECTION' | 'MOVIE' | 'STATION';
   public renderer_context: RendererContext;
 
   constructor(data: RawNode) {


### PR DESCRIPTION
Related FreeTube PR: https://github.com/FreeTubeApp/FreeTube/pull/9620

This PR adds `station` as a lockupview type and will treat it like a video.

Example:
Michael Jackson Home page: https://www.youtube.com/channel/UC5OrDvL9DscpcAstz7JnQGA
Michael Jackson Playlist page: https://www.youtube.com/playlist?list=PLUeQUfurHN6YO6GynESHaAA4oKJYFutPh