### PR TITLE
fix(MusicResponsiveListItem): Match a timestamp when reading a music item duration

### DIFF
--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -20,9 +20,6 @@ interface PlaylistItemData {
   playlist_set_video_id: string;
 }
 
-// A duration is a timestamp ("3:31", "1:02:03"), never a bare number. Matching
-// on digits alone also matches an artist or album named after a number, and
-// those runs come before the duration in the row, so the name won.
 const DURATION_TEXT = /^\d+(?::[0-5]\d)+$/;
 
 function findDurationText(runs?: Text['runs']): string | undefined {
@@ -32,56 +29,56 @@ function findDurationText(runs?: Text['runs']): string | undefined {
 export default class MusicResponsiveListItem extends YTNode {
   static type = 'MusicResponsiveListItem';
 
-  flex_columns: ObservedArray<MusicResponsiveListItemFlexColumn>;
-  fixed_columns: ObservedArray<MusicResponsiveListItemFixedColumn>;
+  public flex_columns: ObservedArray<MusicResponsiveListItemFlexColumn>;
+  public fixed_columns: ObservedArray<MusicResponsiveListItemFixedColumn>;
 
-  endpoint?: NavigationEndpoint;
-  item_type: 'album' | 'playlist' | 'artist' | 'library_artist' | 'non_music_track' | 'video' | 'song' | 'endpoint' | 'unknown' | 'podcast_show' | undefined;
-  index?: Text;
-  thumbnail?: MusicThumbnail | null;
-  badges?: ObservedArray<YTNode>;
-  menu?: Menu | null;
-  overlay?: MusicItemThumbnailOverlay | null;
+  public endpoint?: NavigationEndpoint;
+  public item_type: 'album' | 'playlist' | 'artist' | 'library_artist' | 'non_music_track' | 'video' | 'song' | 'endpoint' | 'unknown' | 'podcast_show' | undefined;
+  public index?: Text;
+  public thumbnail?: MusicThumbnail | null;
+  public badges?: ObservedArray<YTNode>;
+  public menu?: Menu | null;
+  public overlay?: MusicItemThumbnailOverlay | null;
 
-  id?: string;
-  title?: string;
-  duration?: {
+  public id?: string;
+  public title?: string;
+  public duration?: {
     text: string;
     seconds: number;
   };
 
-  album?: {
+  public album?: {
     id?: string,
     name: string,
     endpoint?: NavigationEndpoint
   };
 
-  artists?: {
+  public artists?: {
     name: string,
     channel_id?: string,
     endpoint?: NavigationEndpoint
   }[];
 
-  views?: string;
-  authors?: {
+  public views?: string;
+  public authors?: {
     name: string,
-    channel_id?: string
-    endpoint?: NavigationEndpoint
+    channel_id?: string;
+    endpoint?: NavigationEndpoint;
   }[];
 
-  name?: string;
-  subtitle?: Text;
-  subscribers?: string;
-  song_count?: string;
+  public name?: string;
+  public subtitle?: Text;
+  public subscribers?: string;
+  public song_count?: string;
 
   // TODO: these might be replaceable with Author class
-  author?: {
+  public author?: {
     name: string,
-    channel_id?: string
-    endpoint?: NavigationEndpoint
+    channel_id?: string;
+    endpoint?: NavigationEndpoint;
   };
-  item_count?: string;
-  year?: string;
+  public item_count?: string;
+  public year?: string;
 
   constructor(data: RawNode) {
     super();
@@ -93,7 +90,7 @@ export default class MusicResponsiveListItem extends YTNode {
       playlist_set_video_id: data?.playlistItemData?.playlistSetVideoId || null
     };
 
-    if (Reflect.has(data, 'navigationEndpoint')) {
+    if ('navigationEndpoint' in data) {
       this.endpoint = new NavigationEndpoint(data.navigationEndpoint);
     }
 
@@ -143,23 +140,23 @@ export default class MusicResponsiveListItem extends YTNode {
         }
     }
 
-    if (Reflect.has(data, 'index')) {
+    if ('index' in data) {
       this.index = new Text(data.index);
     }
 
-    if (Reflect.has(data, 'thumbnail')) {
+    if ('thumbnail' in data) {
       this.thumbnail = Parser.parseItem(data.thumbnail, MusicThumbnail);
     }
 
-    if (Reflect.has(data, 'badges')) {
+    if ('badges' in data) {
       this.badges = Parser.parseArray(data.badges);
     }
 
-    if (Reflect.has(data, 'menu')) {
+    if ('menu' in data) {
       this.menu = Parser.parseItem(data.menu, Menu);
     }
 
-    if (Reflect.has(data, 'overlay')) {
+    if ('overlay' in data) {
       this.overlay = Parser.parseItem(data.overlay, MusicItemThumbnailOverlay);
     }
   }

--- a/src/parser/classes/MusicResponsiveListItem.ts
+++ b/src/parser/classes/MusicResponsiveListItem.ts
@@ -20,6 +20,15 @@ interface PlaylistItemData {
   playlist_set_video_id: string;
 }
 
+// A duration is a timestamp ("3:31", "1:02:03"), never a bare number. Matching
+// on digits alone also matches an artist or album named after a number, and
+// those runs come before the duration in the row, so the name won.
+const DURATION_TEXT = /^\d+(?::[0-5]\d)+$/;
+
+function findDurationText(runs?: Text['runs']): string | undefined {
+  return runs?.findLast((run) => DURATION_TEXT.test(run.text))?.text;
+}
+
 export default class MusicResponsiveListItem extends YTNode {
   static type = 'MusicResponsiveListItem';
 
@@ -186,8 +195,7 @@ export default class MusicResponsiveListItem extends YTNode {
     this.id = playlist_item_data.video_id || this.endpoint?.payload?.videoId;
     this.title = this.flex_columns[0].title.toString();
 
-    const duration_text = this.flex_columns.at(1)?.title.runs?.find(
-      (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns[0]?.title?.toString();
+    const duration_text = findDurationText(this.flex_columns.at(1)?.title.runs) || this.fixed_columns[0]?.title?.toString();
 
     if (duration_text) {
       this.duration = {
@@ -250,8 +258,7 @@ export default class MusicResponsiveListItem extends YTNode {
       });
     }
 
-    const duration_text = this.flex_columns[1].title.runs?.find(
-      (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns[0]?.title.runs?.find((run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text;
+    const duration_text = findDurationText(this.flex_columns[1].title.runs) || findDurationText(this.fixed_columns[0]?.title.runs);
 
     if (duration_text) {
       this.duration = {


### PR DESCRIPTION
## Description

`MusicResponsiveListItem` picks the duration by scanning the subtitle runs for the first token that is all digits once colons are stripped:

```ts
const duration_text = this.flex_columns.at(1)?.title.runs?.find(
  (run) => (/^\d+$/).test(run.text.replace(/:/g, '')))?.text || this.fixed_columns[0]?.title?.toString();
```

A song's subtitle is `["<artist>", " • ", "<album>", " • ", "3:31"]`. Both `"3:31"` (`"331"` after the strip) and a bare number satisfy that predicate, so document order decides the winner — and the artist and album runs come first.

So an artist named after a number becomes the duration. `999999999` and `300000003` are real acts, and for their tracks `duration.text` is the artist name, which `timeToSeconds` returns verbatim through its single-part branch. A 3:31 song reports **999999999 seconds**.

The `fixed_columns[0]` fallback holds the real value, but it is only reached when *no* subtitle run is all digits, so it never fires for these rows.

This matches a real timestamp instead, and takes the **last** match rather than the first — an album named like a clock (JAY-Z's *4:44*) sits before the duration, never after it. Both call sites shared the predicate, so both are fixed.

## Reproduction

Same `musicResponsiveListItemRenderer` fixture through the published `17.2.0` and this branch:

```
published | numeric artist name | duration.text="999999999"  seconds=999999999  expected=211  WRONG
published | clock-named album   | duration.text="4:44"       seconds=284        expected=192  WRONG

patched   | numeric artist name | duration.text="3:31"       seconds=211        expected=211  OK
patched   | clock-named album   | duration.text="3:12"       seconds=192        expected=192  OK
```

First case: *Acid Blood* by **999999999**, a 3:31 track. Second: *Kill Jay Z* from JAY-Z's **4:44**, a 3:12 track.

## Impact

Downstream this is easy to miss, because the value looks like a plausible integer rather than an error. In our case four such tracks entered one playlist and the aggregate `SUM(duration)` overflowed an `int4` column, which took down every read path sharing that query until we tracked it back here.

The clock-named-album variant is the nastier one: the value is not just wrong but plausible, so nothing downstream can detect it.

## Notes

- Requiring at least one colon is safe for these rows: YouTube Music always renders a duration as `m:ss` or `h:mm:ss`, never as a bare count of seconds. The existing `replace(/:/g, '')` shows colons were expected here.
- No behaviour change for rows without a numeric name — the last (and only) timestamp-shaped run is the same one the old predicate found.
- `npx tspc --noEmit` and `npm run lint` are clean.
- I did not add a test: the suite here runs against the live API, and a parser fixture test would introduce a pattern the project does not currently use. Happy to add one if you would like that pattern.
