### PR TITLE
feat(parser): Add `VideoTitleHeaderView` renderer parser

### DIFF
--- a/src/parser/classes/VideoTitleHeaderView.ts
+++ b/src/parser/classes/VideoTitleHeaderView.ts
@@ -1,16 +1,15 @@
 import { YTNode } from '../helpers.js';
 import { Parser, type RawNode } from '../index.js';
 import Text from './misc/Text.js';
-import RendererContext from './misc/RendererContext .js';
+import RendererContext from './misc/RendererContext.js';
 import ButtonView from './ButtonView.js';
-
 
 export default class VideoTitleHeaderView extends YTNode {
   static type = 'VideoTitleHeaderView';
 
-  video_title: Text;
-  header_button: ButtonView | null;
-  renderer_context?: RendererContext;
+  public video_title: Text;
+  public header_button: ButtonView | null;
+  public renderer_context?: RendererContext;
 
   constructor(data: RawNode) {
     super();

--- a/src/parser/classes/VideoTitleHeaderView.ts
+++ b/src/parser/classes/VideoTitleHeaderView.ts
@@ -9,16 +9,7 @@ export default class VideoTitleHeaderView extends YTNode {
     content: string
   };
   header_button: ButtonView | null;
-  renderer_context: {
-    logging_context: {
-      logging_directives: {
-        tracking_params: string,
-        visibility: {
-          types: string
-        }
-      }
-    }
-  };
+  renderer_context?: RendererContext;
 
   constructor(data: RawNode) {
     super();

--- a/src/parser/classes/VideoTitleHeaderView.ts
+++ b/src/parser/classes/VideoTitleHeaderView.ts
@@ -1,0 +1,40 @@
+import { YTNode } from '../helpers.js';
+import { Parser, type RawNode } from '../index.js';
+import ButtonView from './ButtonView.js';
+
+export default class VideoTitleHeaderView extends YTNode {
+  static type = 'VideoTitleHeaderView';
+
+  video_title: {
+    content: string
+  };
+  header_button: ButtonView | null;
+  renderer_context: {
+    logging_context: {
+      logging_directives: {
+        tracking_params: string,
+        visibility: {
+          types: string
+        }
+      }
+    }
+  };
+
+  constructor(data: RawNode) {
+    super();
+    this.video_title = {
+      content: data.videoTitle.content
+    };
+    this.header_button = Parser.parseItem(data.headerButton, ButtonView);
+    this.renderer_context = {
+      logging_context: {
+        logging_directives: {
+          tracking_params: data.rendererContext.loggingContext.loggingDirectives.trackingParams,
+          visibility: {
+            types: data.rendererContext.loggingContext.loggingDirectives.visibility.types
+          }
+        }
+      }
+    };
+  }
+}

--- a/src/parser/classes/VideoTitleHeaderView.ts
+++ b/src/parser/classes/VideoTitleHeaderView.ts
@@ -24,15 +24,6 @@ export default class VideoTitleHeaderView extends YTNode {
     super();
     this.video_title = Text.fromAttributed(data.videoTitle);
     this.header_button = Parser.parseItem(data.headerButton, ButtonView);
-    this.renderer_context = {
-      logging_context: {
-        logging_directives: {
-          tracking_params: data.rendererContext.loggingContext.loggingDirectives.trackingParams,
-          visibility: {
-            types: data.rendererContext.loggingContext.loggingDirectives.visibility.types
-          }
-        }
-      }
-    };
+    this.renderer_context = new RendererContext(data.rendererContext);
   }
 }

--- a/src/parser/classes/VideoTitleHeaderView.ts
+++ b/src/parser/classes/VideoTitleHeaderView.ts
@@ -13,6 +13,8 @@ export default class VideoTitleHeaderView extends YTNode {
     super();
     this.video_title = Text.fromAttributed(data.videoTitle);
     this.header_button = Parser.parseItem(data.headerButton, ButtonView);
-    this.renderer_context = new RendererContext(data.rendererContext);
+    if ('rendererContext' in data) {
+      this.renderer_context = new RendererContext(data.rendererContext);
+    }
   }
 }

--- a/src/parser/classes/VideoTitleHeaderView.ts
+++ b/src/parser/classes/VideoTitleHeaderView.ts
@@ -22,9 +22,7 @@ export default class VideoTitleHeaderView extends YTNode {
 
   constructor(data: RawNode) {
     super();
-    this.video_title = {
-      content: data.videoTitle.content
-    };
+    this.video_title = Text.fromAttributed(data.videoTitle);
     this.header_button = Parser.parseItem(data.headerButton, ButtonView);
     this.renderer_context = {
       logging_context: {

--- a/src/parser/classes/VideoTitleHeaderView.ts
+++ b/src/parser/classes/VideoTitleHeaderView.ts
@@ -1,6 +1,9 @@
 import { YTNode } from '../helpers.js';
 import { Parser, type RawNode } from '../index.js';
+import Text from './misc/Text.js';
+import RendererContext from './misc/RendererContext .js';
 import ButtonView from './ButtonView.js';
+
 
 export default class VideoTitleHeaderView extends YTNode {
   static type = 'VideoTitleHeaderView';

--- a/src/parser/classes/VideoTitleHeaderView.ts
+++ b/src/parser/classes/VideoTitleHeaderView.ts
@@ -5,9 +5,7 @@ import ButtonView from './ButtonView.js';
 export default class VideoTitleHeaderView extends YTNode {
   static type = 'VideoTitleHeaderView';
 
-  video_title: {
-    content: string
-  };
+  video_title: Text;
   header_button: ButtonView | null;
   renderer_context?: RendererContext;
 

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -544,6 +544,7 @@ export { default as VideoPrimaryInfo } from './classes/VideoPrimaryInfo.js';
 export { default as VideoSecondaryInfo } from './classes/VideoSecondaryInfo.js';
 export { default as VideoSummaryContentView } from './classes/VideoSummaryContentView.js';
 export { default as VideoSummaryParagraphView } from './classes/VideoSummaryParagraphView.js';
+export { default as VideoTitleHeaderView } from './classes/VideoTitleHeaderView.js';
 export { default as VideoViewCount } from './classes/VideoViewCount.js';
 export { default as ViewCountFactoid } from './classes/ViewCountFactoid.js';
 export { default as WatchCardCompactVideo } from './classes/WatchCardCompactVideo.js';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! Please:
* Read our contributing guidelines: https://github.com/LuanRT/YouTube.js/blob/main/CONTRIBUTING.md
* Add "Fixes #<issue_number>" to the PR description if you are fixing an issue.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
## Summary
Adds a parser class for `videoTitleHeaderRenderer`, which was previously unrecognized and triggered a console warning:

## Changes
- Added `src/parser/classes/VideoTitleHeaderView.ts`
- Registered the new class in `src/parser/nodes.ts`

## Implementation notes
Field structure was based on the JIT-generated class skeleton YouTube.js itself produces at runtime when an unrecognized renderer is encountered (as described in `docs/updating-the-parser.md`). This includes:
- `video_title.content` (string)
- `header_button` (parsed as `ButtonView`, nullable)
- `renderer_context.logging_context.logging_directives` (tracking params + visibility types)

## Testing
- Confirmed the warning no longer appears when loading videos that previously triggered it.