### PR TITLE
refactor(VideoInfo): return a WatchNextContinuation instead of mutating state

### DIFF
--- a/src/parser/classes/misc/WatchNextContinuation.ts
+++ b/src/parser/classes/misc/WatchNextContinuation.ts
@@ -1,0 +1,54 @@
+import { InnertubeError } from '../../../utils/Utils.js';
+import { type ObservedArray, observe, type YTNode } from '../../helpers.js';
+import AppendContinuationItemsAction from '../actions/AppendContinuationItemsAction.js';
+import ContinuationItem from '../ContinuationItem.js';
+
+import type { Actions } from '../../../core/index.js';
+import type { INextResponse } from '../../types/index.js';
+
+export default class WatchNextContinuation {
+  public contents: ObservedArray<YTNode>;
+
+  readonly #actions: Actions;
+  readonly #continuation?: ContinuationItem;
+
+  constructor(actions: Actions, data: INextResponse) {
+    this.#actions = actions;
+
+    const append_continuation_items_action = data.on_response_received_endpoints?.firstOfType(AppendContinuationItemsAction);
+
+    if (!append_continuation_items_action)
+      throw new InnertubeError('AppendContinuationItemsAction not found', data);
+
+    const items: YTNode[] = [];
+
+    for (const item of append_continuation_items_action.contents) {
+      if (item.is(ContinuationItem)) {
+        this.#continuation = item;
+      } else {
+        items.push(item);
+      }
+    }
+
+    this.contents = observe(items);
+  }
+
+  /**
+   * Indicates whether there are more items that can be fetched.
+   */
+  get has_continuation(): boolean {
+    return !!this.#continuation;
+  }
+
+  /**
+   * Retrieves the next batch of items.
+   */
+  public async getContinuation(): Promise<WatchNextContinuation> {
+    if (!this.#continuation)
+      throw new InnertubeError('No continuation item found');
+
+    const response = await this.#continuation.endpoint.call(this.#actions, { parse: true });
+
+    return new WatchNextContinuation(this.#actions, response);
+  }
+}

--- a/src/parser/misc.ts
+++ b/src/parser/misc.ts
@@ -17,3 +17,4 @@ export { default as Text } from './classes/misc/Text.js';
 export { default as TextRun } from './classes/misc/TextRun.js';
 export { default as Thumbnail } from './classes/misc/Thumbnail.js';
 export { default as VideoDetails } from './classes/misc/VideoDetails.js';
+export { default as WatchNextContinuation } from './classes/misc/WatchNextContinuation.js';

--- a/src/parser/youtube/VideoInfo.ts
+++ b/src/parser/youtube/VideoInfo.ts
@@ -26,10 +26,10 @@ import StructuredDescriptionContent from '../classes/StructuredDescriptionConten
 import VideoDescriptionMusicSection from '../classes/VideoDescriptionMusicSection.js';
 import LiveChatWrap from './LiveChat.js';
 import MacroMarkersListEntity from '../classes/MacroMarkersListEntity.js';
+import WatchNextContinuation from '../classes/misc/WatchNextContinuation.js';
 
 import type { RawNode } from '../index.js';
 import { ReloadContinuationItemsCommand } from '../index.js';
-import AppendContinuationItemsAction from '../classes/actions/AppendContinuationItemsAction.js';
 
 import type { Actions, ApiResponse } from '../../core/index.js';
 import type { ObservedArray, YTNode } from '../helpers.js';
@@ -206,24 +206,13 @@ export default class VideoInfo extends MediaInfo {
   /**
    * Retrieves watch next feed continuation.
    */
-  async getWatchNextContinuation(): Promise<VideoInfo> {
+  async getWatchNextContinuation(): Promise<WatchNextContinuation> {
     if (!this.#watch_next_continuation)
       throw new InnertubeError('Watch next feed continuation not found');
 
-    const response = await this.#watch_next_continuation?.endpoint.call(this.actions, { parse: true });
-    const data = response?.on_response_received_endpoints?.firstOfType(AppendContinuationItemsAction);
+    const response = await this.#watch_next_continuation.endpoint.call(this.actions, { parse: true });
 
-    if (!data)
-      throw new InnertubeError('AppendContinuationItemsAction not found');
-
-    this.watch_next_feed = data?.contents;
-    if (this.watch_next_feed?.at(-1)?.is(ContinuationItem)) {
-      this.#watch_next_continuation = this.watch_next_feed.pop()?.as(ContinuationItem);
-    } else {
-      this.#watch_next_continuation = undefined;
-    }
-
-    return this;
+    return new WatchNextContinuation(this.actions, response);
   }
 
   /**


### PR DESCRIPTION
Fixes #1237

## What

`VideoInfo#getWatchNextContinuation()` mutated the instance in place: it overwrote `watch_next_feed`, reassigned the private `#watch_next_continuation`, and returned `this`. As noted in the issue, that pattern doesn't play well with reactive frameworks (Vue and friends) because the object identity stays the same while its contents change underneath.

This adds a `WatchNextContinuation` class modelled directly on the existing `CommentsContinuation` / `CommentThread#getContinuation()` pattern referenced in the issue:

```ts
export default class WatchNextContinuation {
  public contents: ObservedArray<YTNode>;

  get has_continuation(): boolean;
  public async getContinuation(): Promise<WatchNextContinuation>;
}
```

`VideoInfo#getWatchNextContinuation()` now just builds one from the response and returns it; `VideoInfo` itself is left untouched.

Two small behavioural notes:

* The `ContinuationItem` is **filtered out** of `contents` rather than `pop()`ed off after the fact, so feed items are never mixed with the continuation marker (the old code also relied on it being the last element).
* An `InnertubeError` is thrown when `AppendContinuationItemsAction` is missing, same as before.

I deliberately left `VideoInfo`'s constructor, `watch_next_feed`, and `wn_has_continuation` alone — the initial feed still comes from the watch page as it always did, so nothing changes for the first page.

## Breaking change

`getWatchNextContinuation()` used to resolve to the (mutated) `VideoInfo`. It now resolves to a `WatchNextContinuation`:

```ts
// before
const info = await yt.getInfo(id);
let feed = info.watch_next_feed;
while (info.wn_has_continuation) {
  await info.getWatchNextContinuation();
  feed = info.watch_next_feed; // same object, mutated
}

// after
const info = await yt.getInfo(id);
let page = await info.getWatchNextContinuation();
console.log(page.contents);
while (page.has_continuation) {
  page = await page.getContinuation();
  console.log(page.contents);
}
```

Note that `YTShorts.ShortFormVideoInfo#getWatchNextContinuation()` has the same mutation pattern but a different response shape (`reel_watch_sequence` / `ContinuationCommand`), so I left it out of this PR to keep the change focused. Happy to follow up on it if you'd like it aligned too.

## Testing

* `npx tsc --noEmit -p tsconfig.json` — clean
* `npx eslint src/` — clean
* `npm run build:esm` and `npm run build:parser-map` — clean (the new class is exported from `src/parser/misc.ts` by the generator, as with `CommentsContinuation`)
* Ran the built class against a hand-crafted `appendContinuationItemsAction` payload to verify behaviour end to end:

```
contents length: 2
types: CompactVideo, CompactVideo
has_continuation: true
no ContinuationItem leaked: true
last page has_continuation: false len: 2
throws on missing action: InnertubeError
```

The `tests/main.test.ts` suite hits the live API and the only `getWatchNextContinuation` case there is the Shorts one, which is unaffected.
