### PR TITLE
fix(Text): Handle missing `length` in `attachmentRuns`

### DIFF
--- a/src/parser/classes/misc/Text.ts
+++ b/src/parser/classes/misc/Text.ts
@@ -130,8 +130,14 @@ export default class Text {
     if (command_runs?.length)
       this.processCommandRuns(runs, command_runs, data);
 
-    if (attachment_runs?.length)
-      this.processAttachmentRuns(runs, attachment_runs, data);
+    const normalized_attachment_runs = attachment_runs?.map((run) => ({
+      ...run,
+      startIndex: run.startIndex ?? 0,
+      length: run.length ?? 0
+    }) as AttachmentRun);
+
+    if (normalized_attachment_runs?.length)
+      this.processAttachmentRuns(runs, normalized_attachment_runs, data);
 
     return new Text({ runs });
   }


### PR DESCRIPTION
This fixes the following warnings that appear when fetching certain channels:
```
[YOUTUBEJS][Text]: Unable to find matching run for attachment run. Skipping...
```

 To reproduce:
 ```
 youtube.getChannel("UCODHrzPMGbNv67e84WDZhQQ");
```